### PR TITLE
thread through branch id for OnlineQuery and OnlineQueryBulk

### DIFF
--- a/client_impl.go
+++ b/client_impl.go
@@ -53,7 +53,7 @@ func (c *clientImpl) OfflineQuery(params OfflineQueryParamsComplete) (Dataset, e
 			Body:                request,
 			Response:            &response,
 			EnvironmentOverride: request.EnvironmentId,
-			Branch:              request.Branch,
+			Branch:              &request.Branch,
 		},
 	)
 	if err != nil {
@@ -108,6 +108,7 @@ func (c *clientImpl) OnlineQueryBulk(params OnlineQueryParamsComplete) (OnlineQu
 			Response:            &response,
 			EnvironmentOverride: params.underlying.EnvironmentId,
 			PreviewDeploymentId: params.underlying.PreviewDeploymentId,
+			Branch:              params.underlying.BranchId,
 		},
 	)
 
@@ -235,6 +236,7 @@ func (c *clientImpl) OnlineQuery(params OnlineQueryParamsComplete, resultHolder 
 			Response:            &serializedResponse,
 			EnvironmentOverride: request.EnvironmentId,
 			PreviewDeploymentId: request.PreviewDeploymentId,
+			Branch:              params.underlying.BranchId,
 		},
 	)
 	if err != nil {
@@ -546,7 +548,7 @@ func (c *clientImpl) retryRequest(
 	return res, nil
 }
 
-func (c *clientImpl) getHeaders(environmentOverride string, previewDeploymentId string, branchOverride string) http.Header {
+func (c *clientImpl) getHeaders(environmentOverride string, previewDeploymentId string, branchOverride *string) http.Header {
 	headers := http.Header{}
 
 	headers.Set("Accept", "application/json")
@@ -554,8 +556,8 @@ func (c *clientImpl) getHeaders(environmentOverride string, previewDeploymentId 
 	headers.Set("User-Agent", "chalk-go-0.0")
 	headers.Set("X-Chalk-Client-Id", c.ClientId.Value)
 
-	if branchOverride != "" {
-		headers.Set("X-Chalk-Branch-Id", branchOverride)
+	if branchOverride != nil && *branchOverride != "" {
+		headers.Set("X-Chalk-Branch-Id", *branchOverride)
 	} else if c.Branch != "" {
 		headers.Set("X-Chalk-Branch-Id", c.Branch)
 	}

--- a/internal/tests/integration/branch_test.go
+++ b/internal/tests/integration/branch_test.go
@@ -34,16 +34,15 @@ func (c *InterceptorHTTPClient) Get(url string) (*http.Response, error) {
 	return actualClient.Get(url)
 }
 
-// TestOnlineQueryAndQueryBulkBranch tests that when we
+// TestOnlineQueryAndQueryBulkBranchInRequest tests that when we
 // specify a branch ID in online query params, the request
 // includes the branch ID header.
-func TestOnlineQueryAndQueryBulkBranch(t *testing.T) {
+func TestOnlineQueryAndQueryBulkBranchInRequest(t *testing.T) {
 	SkipIfNotIntegrationTester(t)
 	httpClient := NewCovertHTTPClient()
 	branchId := "test-branch-id"
 	client, err := chalk.NewClient(&chalk.ClientConfig{
 		HTTPClient: httpClient,
-		Branch:     branchId,
 	})
 	if err != nil {
 		t.Fatal("Failed creating a Chalk Client", err)
@@ -53,7 +52,10 @@ func TestOnlineQueryAndQueryBulkBranch(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed initializing features", err)
 	}
-	req := chalk.OnlineQueryParams{}.WithInput(testFeatures.User.Id, userIds[0]).WithOutputs(testFeatures.User.SocureScore)
+	req := chalk.OnlineQueryParams{}.
+		WithInput(testFeatures.User.Id, userIds[0]).
+		WithOutputs(testFeatures.User.SocureScore).
+		WithBranchId(branchId)
 	_, _ = client.OnlineQuery(req, nil)
 	assert.Equal(t, httpClient.Intercepted.Header.Get("X-Chalk-Branch-Id"), branchId)
 

--- a/internal/tests/integration/branch_test.go
+++ b/internal/tests/integration/branch_test.go
@@ -1,0 +1,59 @@
+package integration
+
+import (
+	"bytes"
+	"github.com/chalk-ai/chalk-go"
+	assert "github.com/stretchr/testify/require"
+	"io"
+	"net/http"
+	"testing"
+)
+
+type Intercepted struct {
+	Header http.Header
+}
+
+type InterceptorHTTPClient struct {
+	Intercepted Intercepted
+}
+
+func NewCovertHTTPClient() *InterceptorHTTPClient {
+	return &InterceptorHTTPClient{}
+}
+
+func (c *InterceptorHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	c.Intercepted = Intercepted{
+		Header: req.Header,
+	}
+	body := io.NopCloser(bytes.NewBufferString(`{"data": {"something": "exciting"}}`))
+	return &http.Response{StatusCode: 200, Body: body}, nil
+}
+
+func (c *InterceptorHTTPClient) Get(url string) (*http.Response, error) {
+	actualClient := &http.Client{}
+	return actualClient.Get(url)
+}
+
+// TestQueryBranch tests that when we specify a branch ID in
+// online query params, the request includes the branch ID
+// header.
+func TestOnlineQueryBranch(t *testing.T) {
+	SkipIfNotIntegrationTester(t)
+	httpClient := NewCovertHTTPClient()
+	branchId := "test-branch-id"
+	client, err := chalk.NewClient(&chalk.ClientConfig{
+		HTTPClient: httpClient,
+		Branch:     branchId,
+	})
+	if err != nil {
+		t.Fatal("Failed creating a Chalk Client", err)
+	}
+	userIds := []int{1}
+	err = chalk.InitFeatures(&testFeatures)
+	if err != nil {
+		t.Fatal("Failed initializing features", err)
+	}
+	res := chalk.OnlineQueryParams{}.WithInput(testFeatures.User.Id, userIds[0]).WithOutputs(testFeatures.User.SocureScore)
+	_, _ = client.OnlineQuery(res, nil)
+	assert.Equal(t, httpClient.Intercepted.Header.Get("X-Chalk-Branch-Id"), branchId)
+}

--- a/internal/tests/integration/branch_test.go
+++ b/internal/tests/integration/branch_test.go
@@ -53,7 +53,15 @@ func TestOnlineQueryBranch(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed initializing features", err)
 	}
-	res := chalk.OnlineQueryParams{}.WithInput(testFeatures.User.Id, userIds[0]).WithOutputs(testFeatures.User.SocureScore)
-	_, _ = client.OnlineQuery(res, nil)
+	req := chalk.OnlineQueryParams{}.WithInput(testFeatures.User.Id, userIds[0]).WithOutputs(testFeatures.User.SocureScore)
+	_, _ = client.OnlineQuery(req, nil)
 	assert.Equal(t, httpClient.Intercepted.Header.Get("X-Chalk-Branch-Id"), branchId)
+
+	bulkBranchId := "bulk-branch-id"
+	bulkReq := chalk.OnlineQueryParams{}.
+		WithInput(testFeatures.User.Id, userIds).
+		WithOutputs(testFeatures.User.SocureScore).
+		WithBranchId(bulkBranchId)
+	_, _ = client.OnlineQueryBulk(bulkReq)
+	assert.Equal(t, httpClient.Intercepted.Header.Get("X-Chalk-Branch-Id"), bulkBranchId)
 }

--- a/internal/tests/integration/branch_test.go
+++ b/internal/tests/integration/branch_test.go
@@ -34,10 +34,10 @@ func (c *InterceptorHTTPClient) Get(url string) (*http.Response, error) {
 	return actualClient.Get(url)
 }
 
-// TestQueryBranch tests that when we specify a branch ID in
-// online query params, the request includes the branch ID
-// header.
-func TestOnlineQueryBranch(t *testing.T) {
+// TestOnlineQueryAndQueryBulkBranch tests that when we
+// specify a branch ID in online query params, the request
+// includes the branch ID header.
+func TestOnlineQueryAndQueryBulkBranch(t *testing.T) {
 	SkipIfNotIntegrationTester(t)
 	httpClient := NewCovertHTTPClient()
 	branchId := "test-branch-id"

--- a/internal/tests/integration/branch_test.go
+++ b/internal/tests/integration/branch_test.go
@@ -38,6 +38,9 @@ func (c *InterceptorHTTPClient) Get(url string) (*http.Response, error) {
 // specify a branch ID in online query params, the request
 // includes the branch ID header.
 func TestOnlineQueryAndQueryBulkBranchInRequest(t *testing.T) {
+	// TODO: This can be a non-integration test if we can make
+	//       the mock client return a fake JWT when auth is
+	//       being performed.
 	SkipIfNotIntegrationTester(t)
 	httpClient := NewCovertHTTPClient()
 	branchId := "test-branch-id"
@@ -66,4 +69,62 @@ func TestOnlineQueryAndQueryBulkBranchInRequest(t *testing.T) {
 		WithBranchId(bulkBranchId)
 	_, _ = client.OnlineQueryBulk(bulkReq)
 	assert.Equal(t, httpClient.Intercepted.Header.Get("X-Chalk-Branch-Id"), bulkBranchId)
+}
+
+// TestOnlineQueryBranchInClient tests that when we
+// specify a branch ID in the client, the online query
+// request includes the branch ID header.
+func TestOnlineQueryBranchInClient(t *testing.T) {
+	// TODO: This can be a non-integration test if we can make
+	//       the mock client return a fake JWT when auth is
+	//       being performed.
+	SkipIfNotIntegrationTester(t)
+	httpClient := NewCovertHTTPClient()
+	branchId := "test-branch-id"
+	client, err := chalk.NewClient(&chalk.ClientConfig{
+		HTTPClient: httpClient,
+		Branch:     branchId,
+	})
+	if err != nil {
+		t.Fatal("Failed creating a Chalk Client", err)
+	}
+	userIds := []int{1}
+	err = chalk.InitFeatures(&testFeatures)
+	if err != nil {
+		t.Fatal("Failed initializing features", err)
+	}
+	req := chalk.OnlineQueryParams{}.
+		WithInput(testFeatures.User.Id, userIds[0]).
+		WithOutputs(testFeatures.User.SocureScore)
+	_, _ = client.OnlineQuery(req, nil)
+	assert.Equal(t, httpClient.Intercepted.Header.Get("X-Chalk-Branch-Id"), branchId)
+}
+
+// TestOnlineQueryBulkBranchInClient tests that when we
+// specify a branch ID in the client, the bulk online query
+// request includes the branch ID header.
+func TestOnlineQueryBulkBranchInClient(t *testing.T) {
+	// TODO: This can be a non-integration test if we can make
+	//       the mock client return a fake JWT when auth is
+	//       being performed.
+	SkipIfNotIntegrationTester(t)
+	httpClient := NewCovertHTTPClient()
+	branchId := "test-branch-id"
+	client, err := chalk.NewClient(&chalk.ClientConfig{
+		HTTPClient: httpClient,
+		Branch:     branchId,
+	})
+	if err != nil {
+		t.Fatal("Failed creating a Chalk Client", err)
+	}
+	userIds := []int{1}
+	err = chalk.InitFeatures(&testFeatures)
+	if err != nil {
+		t.Fatal("Failed initializing features", err)
+	}
+	req := chalk.OnlineQueryParams{}.
+		WithInput(testFeatures.User.Id, userIds[0]).
+		WithOutputs(testFeatures.User.SocureScore)
+	_, _ = client.OnlineQueryBulk(req)
+	assert.Equal(t, httpClient.Intercepted.Header.Get("X-Chalk-Branch-Id"), branchId)
 }

--- a/models_private.go
+++ b/models_private.go
@@ -98,7 +98,7 @@ type sendRequestParams struct {
 
 	EnvironmentOverride string
 	PreviewDeploymentId string
-	Branch              string
+	Branch              *string
 }
 
 type getTokenRequest struct {


### PR DESCRIPTION
Fixes when params are specified with WithBranchId, the client makes a request that does not include the branch ID header 