### PR TITLE
Fix branch ID not displayed

### DIFF
--- a/client_impl.go
+++ b/client_impl.go
@@ -95,7 +95,7 @@ func (c *clientImpl) OnlineQueryBulk(params OnlineQueryParamsComplete) (OnlineQu
 			}
 		}
 	}
-	data, err := params.ToBytes()
+	data, err := params.ToBytes(&SerializationOptions{ClientConfigBranchId: c.Branch})
 	if err != nil {
 		return emptyResult, &ErrorResponse{ClientError: &ClientError{fmt.Errorf("error serializing online query params: %w", err).Error()}}
 	}

--- a/feather.go
+++ b/feather.go
@@ -14,11 +14,24 @@ func (r OnlineQueryBulkResult) Release() {
 	}
 }
 
-func (p OnlineQueryParamsComplete) ToBytes() ([]byte, error) {
+type SerializationOptions struct {
+	ClientConfigBranchId string
+}
+
+func (p OnlineQueryParamsComplete) ToBytes(options ...*SerializationOptions) ([]byte, error) {
+	branchId := p.underlying.BranchId
+	if len(options) > 1 {
+		return nil, fmt.Errorf("expected 1 SerializationOptions, got %d", len(options))
+	} else if len(options) == 1 {
+		if branchId == nil || *branchId == "" && options[0].ClientConfigBranchId != "" {
+			branchId = &options[0].ClientConfigBranchId
+		}
+	}
+
 	return internal.CreateOnlineQueryBulkBody(p.underlying.inputs, internal.FeatherRequestHeader{
 		Outputs:  p.underlying.outputs,
 		Explain:  false,
-		BranchId: p.underlying.BranchId,
+		BranchId: branchId,
 	})
 }
 

--- a/internal/feather.go
+++ b/internal/feather.go
@@ -126,8 +126,8 @@ func consume8ByteLen(startIdx int, bytes []byte) (int, error, uint64) {
 	return startIdx + numBytesThatRepresentsLength, nil, length
 }
 
-func consumeMagicStr(startIdx int, bytes []byte) (int, error) {
-	magicBytes := []byte("CHALK_BYTE_TRANSMISSION")
+func consumeMagicStr(magicStr string, startIdx int, bytes []byte) (int, error) {
+	magicBytes := []byte(magicStr)
 	err := checkLen(startIdx, bytes, len(magicBytes))
 	if err != nil {
 		return startIdx, fmt.Errorf("failed to find enough bytes to consume magic string")
@@ -423,8 +423,25 @@ func CreateOnlineQueryBulkBody(inputs map[string]any, header FeatherRequestHeade
 	return resultBytes, nil
 }
 
+func GetHeaderFromSerializedOnlineQueryBulkBody(body []byte) (map[string]any, error) {
+	idx, err := consumeMagicStr("chal1", 0, body)
+	if err != nil {
+		return nil, err
+	}
+
+	idx, err, header := consumeJsonAttrs(idx, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to consume header: %w", err)
+	}
+	headerMap, ok := header.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("failed to cast header to map")
+	}
+	return headerMap, nil
+}
+
 func ChalkUnmarshal(body []byte) (map[string]any, error) {
-	idx, err := consumeMagicStr(0, body)
+	idx, err := consumeMagicStr("CHALK_BYTE_TRANSMISSION", 0, body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tests/integration/branch_test.go
+++ b/internal/tests/integration/branch_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"bytes"
 	"github.com/chalk-ai/chalk-go"
+	"github.com/chalk-ai/chalk-go/internal"
 	assert "github.com/stretchr/testify/require"
 	"io"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 
 type Intercepted struct {
 	Header http.Header
+	Body   []byte
 }
 
 type InterceptorHTTPClient struct {
@@ -22,8 +24,14 @@ func NewCovertHTTPClient() *InterceptorHTTPClient {
 }
 
 func (c *InterceptorHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	bodyBytes, bodyBytesErr := io.ReadAll(req.Body)
+	if bodyBytesErr != nil {
+		return nil, bodyBytesErr
+	}
+	req.Body.Close()
 	c.Intercepted = Intercepted{
 		Header: req.Header,
+		Body:   bodyBytes,
 	}
 	body := io.NopCloser(bytes.NewBufferString(`{"data": {"something": "exciting"}}`))
 	return &http.Response{StatusCode: 200, Body: body}, nil
@@ -123,8 +131,68 @@ func TestOnlineQueryBulkBranchInClient(t *testing.T) {
 		t.Fatal("Failed initializing features", err)
 	}
 	req := chalk.OnlineQueryParams{}.
-		WithInput(testFeatures.User.Id, userIds[0]).
+		WithInput(testFeatures.User.Id, userIds).
 		WithOutputs(testFeatures.User.SocureScore)
 	_, _ = client.OnlineQueryBulk(req)
 	assert.Equal(t, httpClient.Intercepted.Header.Get("X-Chalk-Branch-Id"), branchId)
+}
+
+// TestClientBranchSetInFeatherHeader tests that when we
+// specify a branch ID in the client, the feather request
+// header that we serialize includes the branch ID header.
+func TestClientBranchSetInFeatherHeader(t *testing.T) {
+	SkipIfNotIntegrationTester(t)
+	httpClient := NewCovertHTTPClient()
+	expectedBranchId := "test-branch-id"
+	client, err := chalk.NewClient(&chalk.ClientConfig{
+		HTTPClient: httpClient,
+		Branch:     expectedBranchId,
+	})
+	if err != nil {
+		t.Fatal("Failed creating a Chalk Client", err)
+	}
+	userIds := []int{1}
+	err = chalk.InitFeatures(&testFeatures)
+	if err != nil {
+		t.Fatal("Failed initializing features", err)
+	}
+	req := chalk.OnlineQueryParams{}.
+		WithInput(testFeatures.User.Id, userIds).
+		WithOutputs(testFeatures.User.SocureScore)
+	_, _ = client.OnlineQueryBulk(req)
+	header, headerErr := internal.GetHeaderFromSerializedOnlineQueryBulkBody(httpClient.Intercepted.Body)
+	assert.Nil(t, headerErr)
+	actualBranchId, ok := header["branch_id"]
+	assert.True(t, ok)
+	assert.Equal(t, expectedBranchId, actualBranchId)
+}
+
+// TestParamsBranchSetInFeatherHeader tests that when we
+// specify a branch ID in the params, the feather request
+// header that we serialize includes the branch ID header.
+func TestParamsBranchSetInFeatherHeader(t *testing.T) {
+	SkipIfNotIntegrationTester(t)
+	httpClient := NewCovertHTTPClient()
+	expectedBranchId := "test-branch-id"
+	client, err := chalk.NewClient(&chalk.ClientConfig{
+		HTTPClient: httpClient,
+	})
+	if err != nil {
+		t.Fatal("Failed creating a Chalk Client", err)
+	}
+	userIds := []int{1}
+	err = chalk.InitFeatures(&testFeatures)
+	if err != nil {
+		t.Fatal("Failed initializing features", err)
+	}
+	req := chalk.OnlineQueryParams{}.
+		WithInput(testFeatures.User.Id, userIds).
+		WithOutputs(testFeatures.User.SocureScore).
+		WithBranchId(expectedBranchId)
+	_, _ = client.OnlineQueryBulk(req)
+	header, headerErr := internal.GetHeaderFromSerializedOnlineQueryBulkBody(httpClient.Intercepted.Body)
+	assert.Nil(t, headerErr)
+	actualBranchId, ok := header["branch_id"]
+	assert.True(t, ok)
+	assert.Equal(t, expectedBranchId, actualBranchId)
 }


### PR DESCRIPTION
We were not setting branch_id in our FeatherRequestHeader object when branch was specified at the client level. This PR fixes that. This issue does not exist for when branch was specified at the request level. 

This effectively fixes only the display of the branch ID when a branch query is made with the branch specified at the client level. The query currently already hits the branch server appropriately. 