### PR TITLE
Add test for unmarshalling dataclasses into codegen structs

### DIFF
--- a/init_features.go
+++ b/init_features.go
@@ -39,7 +39,7 @@ func initFeatures(structValue reflect.Value, fqn string, visited map[string]bool
 		fieldMeta := structValue.Type().Field(i)
 
 		attributeName := SnakeCase(fieldMeta.Name)
-		nameOverride := fieldMeta.Tag.Get("name")
+		nameOverride := fieldMeta.Tag.Get(internal.NameTag)
 		if nameOverride != "" {
 			attributeName = nameOverride
 		}

--- a/init_features.go
+++ b/init_features.go
@@ -24,7 +24,7 @@ func initFeatures(structValue reflect.Value, fqn string, visited map[string]bool
 
 	namespace := structValue.Type().Name()
 	if fqn == "" && namespace != "" {
-		fqn = snakeCase(namespace) + "."
+		fqn = SnakeCase(namespace) + "."
 	}
 
 	if isVisited, ok := visited[namespace]; ok && isVisited {
@@ -38,7 +38,7 @@ func initFeatures(structValue reflect.Value, fqn string, visited map[string]bool
 		f := structValue.Field(i)
 		fieldMeta := structValue.Type().Field(i)
 
-		attributeName := snakeCase(fieldMeta.Name)
+		attributeName := SnakeCase(fieldMeta.Name)
 		nameOverride := fieldMeta.Tag.Get("name")
 		if nameOverride != "" {
 			attributeName = nameOverride
@@ -185,31 +185,6 @@ func pointerCheck(field reflect.Value) error {
 	return nil
 }
 
-func snakeCase(s string) string {
-	var b []byte
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		if isASCIIUpper(c) {
-			if i > 0 && s[i-1] != '.' {
-				b = append(b, '_')
-			}
-			c += 'a' - 'A'
-		} else if isASCIIDigit(c) && i > 0 && isASCIILower(s[i-1]) {
-			b = append(b, '_')
-		}
-		b = append(b, c)
-	}
-	return string(b)
-}
-
-func isASCIILower(c byte) bool {
-	return 'a' <= c && c <= 'z'
-}
-
-func isASCIIDigit(c byte) bool {
-	return '0' <= c && c <= '9'
-}
-
-func isASCIIUpper(c byte) bool {
-	return 'A' <= c && c <= 'Z'
+func SnakeCase(s string) string {
+	return internal.ChalkpySnakeCase(s)
 }

--- a/init_features_internal_test.go
+++ b/init_features_internal_test.go
@@ -139,7 +139,7 @@ func TestSnakeCase(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.input, func(t *testing.T) {
-			result := snakeCase(tc.input)
+			result := SnakeCase(tc.input)
 			if tc.success && result != tc.expected {
 				t.Errorf("SnakeCase(%q) = %q, want %q", tc.input, result, tc.expected)
 			} else if !tc.success && result == tc.expected {

--- a/internal/feather.go
+++ b/internal/feather.go
@@ -117,9 +117,10 @@ func setBuilderValues(builder array.Builder, slice reflect.Value, nullMask []boo
 		for i := 0; i < slice.Len(); i++ {
 			v := slice.Index(i)
 			if v.IsNil() {
-				nilMask[i] = true
+				nilMask[i] = false
 				nonPtrSlice = reflect.Append(nonPtrSlice, reflect.Zero(elemType.Elem()))
 			} else {
+				nilMask[i] = true
 				nonPtrSlice = reflect.Append(nonPtrSlice, v.Elem())
 			}
 		}

--- a/internal/feather.go
+++ b/internal/feather.go
@@ -189,8 +189,7 @@ func setBuilderValues(builder array.Builder, slice reflect.Value, nullMask []boo
 
 			var columns []reflect.Value
 			for j := 0; j < numFieldsReflect; j++ {
-				firstStruct := slice.Index(0)
-				fieldSliceType := reflect.SliceOf(firstStruct.Field(j).Type())
+				fieldSliceType := reflect.SliceOf(elemType.Field(j).Type)
 				fieldSlice := reflect.MakeSlice(fieldSliceType, 0, slice.Len())
 				for i := 0; i < slice.Len(); i++ {
 					fieldSlice = reflect.Append(fieldSlice, slice.Index(i).Field(j))
@@ -199,7 +198,7 @@ func setBuilderValues(builder array.Builder, slice reflect.Value, nullMask []boo
 			}
 
 			for i := 0; i < sBuilder.NumField(); i++ {
-				if err := setBuilderValues(sBuilder.FieldBuilder(i), columns[i], nil); err != nil {
+				if err := setBuilderValues(sBuilder.FieldBuilder(i), columns[i], nullMask); err != nil {
 					return errors.Wrapf(err, "failed to set values for struct field '%d'", i)
 				}
 			}

--- a/internal/feather.go
+++ b/internal/feather.go
@@ -209,17 +209,6 @@ func setBuilderValues(builder array.Builder, slice reflect.Value, nullMask []boo
 				)
 			}
 
-			for i := 0; i < numFieldsReflect; i++ {
-				if elemType.Field(i).Name != arrowStructType.Field(i).Name {
-					return errors.Errorf(
-						"expected field name in struct to match field name in Arrow struct schema, "+
-							"found '%s' in struct and '%s' in Arrow struct schema",
-						elemType.Field(i).Name,
-						arrowStructType.Field(i).Name,
-					)
-				}
-			}
-
 			var columns []reflect.Value
 			for j := 0; j < numFieldsReflect; j++ {
 				fieldSliceType := reflect.SliceOf(elemType.Field(j).Type)

--- a/internal/feather.go
+++ b/internal/feather.go
@@ -219,10 +219,16 @@ func setBuilderValues(builder array.Builder, slice reflect.Value, nullMask []boo
 				}
 				columns = append(columns, fieldSlice)
 			}
-
 			for i := 0; i < sBuilder.NumField(); i++ {
 				if err := setBuilderValues(sBuilder.FieldBuilder(i), columns[i], nullMask); err != nil {
 					return errors.Wrapf(err, "failed to set values for struct field '%d'", i)
+				}
+			}
+			for i := 0; i < slice.Len(); i++ {
+				if nullMask == nil {
+					sBuilder.Append(true)
+				} else {
+					sBuilder.Append(nullMask[i])
 				}
 			}
 		}

--- a/internal/feather.go
+++ b/internal/feather.go
@@ -220,7 +220,7 @@ func setBuilderValues(builder array.Builder, slice reflect.Value, nullMask []boo
 				columns = append(columns, fieldSlice)
 			}
 			for i := 0; i < sBuilder.NumField(); i++ {
-				if err := setBuilderValues(sBuilder.FieldBuilder(i), columns[i], nullMask); err != nil {
+				if err := setBuilderValues(sBuilder.FieldBuilder(i), columns[i], nil); err != nil {
 					return errors.Wrapf(err, "failed to set values for struct field '%d'", i)
 				}
 			}

--- a/internal/feather.go
+++ b/internal/feather.go
@@ -11,6 +11,7 @@ import (
 	"github.com/apache/arrow/go/v16/arrow/ipc"
 	"github.com/apache/arrow/go/v16/arrow/memory"
 	"github.com/chalk-ai/chalk-go/internal/colls"
+	"github.com/pkg/errors"
 	"reflect"
 	"time"
 )
@@ -57,19 +58,119 @@ func convertReflectToArrowType(value reflect.Type) (arrow.DataType, error) {
 			)
 		}
 	} else if kind == reflect.Struct {
-		if value != reflect.TypeOf(time.Time{}) {
-			return nil, fmt.Errorf("arrow conversion failed - a slice of anything "+
-				"but primitives is currently unsupported, found type: %s",
-				kind,
-			)
+		if value == reflect.TypeOf(time.Time{}) {
+			return &arrow.TimestampType{
+				Unit:     arrow.Nanosecond,
+				TimeZone: "UTC",
+			}, nil
 		}
-		return &arrow.TimestampType{
-			Unit:     arrow.Nanosecond,
-			TimeZone: "UTC",
-		}, nil
+		var arrowFields []arrow.Field
+		for i := 0; i < value.NumField(); i++ {
+			field := value.Field(i)
+			isPointer := field.Type.Kind() == reflect.Ptr
+			rType := field.Type
+			if isPointer {
+				rType = field.Type.Elem()
+			}
+			dtype, dtypeErr := convertReflectToArrowType(rType)
+			if dtypeErr != nil {
+				return nil, errors.Wrapf(
+					dtypeErr,
+					"arrow conversion failed - failed to convert struct field type '%v' to arrow type",
+					rType,
+				)
+			}
+			arrowFields = append(arrowFields, arrow.Field{
+				Name:     value.Field(i).Name,
+				Type:     dtype,
+				Nullable: isPointer,
+			})
+		}
+		return arrow.StructOf(arrowFields...), nil
 	} else {
 		return nil, fmt.Errorf("arrow conversion failed - unsupported type: %s", kind)
 	}
+}
+
+func setBuilderValues(builder array.Builder, values any) error {
+	valuesType := reflect.TypeOf(values)
+	if valuesType.Kind() != reflect.Slice {
+		return errors.Errorf(
+			"conversion of inputs to Arrow requires all input values "+
+				"to be a slice, instead found type '%s'",
+			reflect.TypeOf(values).Kind(),
+		)
+	}
+	if reflect.ValueOf(values).Len() == 0 {
+		return errors.Errorf(
+			"conversion of inputs to Arrow requires all input values to " +
+				"be non-empty, instead found empty array",
+		)
+	}
+
+	elem := valuesType.Elem()
+	elemKind := elem.Kind()
+	switch elemKind {
+	case reflect.Int:
+		arrayValues := values.([]int)
+		convertedValues := []int64{}
+		for _, value := range arrayValues {
+			convertedValues = append(convertedValues, int64(value))
+		}
+		builder.(*array.Int64Builder).AppendValues(convertedValues, nil)
+	case reflect.Int8:
+		builder.(*array.Int8Builder).AppendValues(values.([]int8), nil)
+	case reflect.Int16:
+		builder.(*array.Int16Builder).AppendValues(values.([]int16), nil)
+	case reflect.Int32:
+		builder.(*array.Int32Builder).AppendValues(values.([]int32), nil)
+	case reflect.Int64:
+		builder.(*array.Int64Builder).AppendValues(values.([]int64), nil)
+	case reflect.Uint:
+		arrayValues := values.([]uint)
+		convertedValues := []uint64{}
+		for _, value := range arrayValues {
+			convertedValues = append(convertedValues, uint64(value))
+		}
+		builder.(*array.Uint64Builder).AppendValues(convertedValues, nil)
+	case reflect.Uint8:
+		builder.(*array.Uint8Builder).AppendValues(values.([]uint8), nil)
+	case reflect.Uint16:
+		builder.(*array.Uint16Builder).AppendValues(values.([]uint16), nil)
+	case reflect.Uint32:
+		builder.(*array.Uint32Builder).AppendValues(values.([]uint32), nil)
+	case reflect.Uint64:
+		builder.(*array.Uint64Builder).AppendValues(values.([]uint64), nil)
+	case reflect.Float32:
+		builder.(*array.Float32Builder).AppendValues(values.([]float32), nil)
+	case reflect.Float64:
+		builder.(*array.Float64Builder).AppendValues(values.([]float64), nil)
+	case reflect.String:
+		builder.(*array.LargeStringBuilder).AppendValues(values.([]string), nil)
+	case reflect.Bool:
+		builder.(*array.BooleanBuilder).AppendValues(values.([]bool), nil)
+	case reflect.Struct:
+		if elem == reflect.TypeOf(time.Time{}) {
+			timeSlice := values.([]time.Time)
+			timestampSlice := make([]arrow.Timestamp, 0, len(timeSlice))
+			for _, t := range timeSlice {
+				timestampSlice = append(timestampSlice, arrow.Timestamp(t.UnixNano()))
+			}
+			builder.(*array.TimestampBuilder).AppendValues(timestampSlice, nil)
+		} else {
+			// So we have a list of structs
+			// we want to loop through each of them, access the ith field,
+			// append that to the ith arrow builder.
+			// Or actually, we want to build a
+
+		}
+	default:
+		return errors.Errorf(
+			"unsupported input type found when converting to arrow: %s",
+			elemKind.String(),
+		)
+	}
+	return nil
 }
 
 // ColumnMapToRecord converts a map of column names to slices of values to an Arrow Record.
@@ -95,87 +196,8 @@ func ColumnMapToRecord(inputs map[string]any) (arrow.Record, error) {
 			return nil, fmt.Errorf("failed to find input values for feature '%s'", field.Name)
 		}
 
-		valuesType := reflect.TypeOf(values)
-		if valuesType.Kind() != reflect.Slice {
-			return nil, fmt.Errorf(
-				"conversion of inputs to Arrow requires all input values "+
-					"to be a slice, instead found type '%s' for feature '%s': ",
-				reflect.TypeOf(values).Kind(),
-				field.Name,
-			)
-		}
-		if reflect.ValueOf(values).Len() == 0 {
-			return nil, fmt.Errorf(
-				"conversion of inputs to Arrow requires all input values to "+
-					"be non-empty, instead found empty array for feature '%s': ",
-				field.Name,
-			)
-		}
-
-		elem := valuesType.Elem()
-		elemKind := elem.Kind()
-		switch elemKind {
-		case reflect.Int:
-			arrayValues := values.([]int)
-			convertedValues := []int64{}
-			for _, value := range arrayValues {
-				convertedValues = append(convertedValues, int64(value))
-			}
-			recordBuilder.Field(idx).(*array.Int64Builder).AppendValues(convertedValues, nil)
-		case reflect.Int8:
-			recordBuilder.Field(idx).(*array.Int8Builder).AppendValues(values.([]int8), nil)
-		case reflect.Int16:
-			recordBuilder.Field(idx).(*array.Int16Builder).AppendValues(values.([]int16), nil)
-		case reflect.Int32:
-			recordBuilder.Field(idx).(*array.Int32Builder).AppendValues(values.([]int32), nil)
-		case reflect.Int64:
-			recordBuilder.Field(idx).(*array.Int64Builder).AppendValues(values.([]int64), nil)
-		case reflect.Uint:
-			arrayValues := values.([]uint)
-			convertedValues := []uint64{}
-			for _, value := range arrayValues {
-				convertedValues = append(convertedValues, uint64(value))
-			}
-			recordBuilder.Field(idx).(*array.Uint64Builder).AppendValues(convertedValues, nil)
-		case reflect.Uint8:
-			recordBuilder.Field(idx).(*array.Uint8Builder).AppendValues(values.([]uint8), nil)
-		case reflect.Uint16:
-			recordBuilder.Field(idx).(*array.Uint16Builder).AppendValues(values.([]uint16), nil)
-		case reflect.Uint32:
-			recordBuilder.Field(idx).(*array.Uint32Builder).AppendValues(values.([]uint32), nil)
-		case reflect.Uint64:
-			recordBuilder.Field(idx).(*array.Uint64Builder).AppendValues(values.([]uint64), nil)
-		case reflect.Float32:
-			recordBuilder.Field(idx).(*array.Float32Builder).AppendValues(values.([]float32), nil)
-		case reflect.Float64:
-			recordBuilder.Field(idx).(*array.Float64Builder).AppendValues(values.([]float64), nil)
-		case reflect.String:
-			recordBuilder.Field(idx).(*array.LargeStringBuilder).AppendValues(values.([]string), nil)
-		case reflect.Bool:
-			recordBuilder.Field(idx).(*array.BooleanBuilder).AppendValues(values.([]bool), nil)
-		case reflect.Struct:
-			if elem == reflect.TypeOf(time.Time{}) {
-				timeSlice := values.([]time.Time)
-				timestampSlice := make([]arrow.Timestamp, 0, len(timeSlice))
-				for _, t := range timeSlice {
-					timestampSlice = append(timestampSlice, arrow.Timestamp(t.UnixNano()))
-				}
-				recordBuilder.Field(idx).(*array.TimestampBuilder).AppendValues(timestampSlice, nil)
-			} else {
-				return nil, fmt.Errorf(
-					"unsupported struct type found for feature '%s' "+
-						"when converting to arrow: %s",
-					field.Name,
-					elem.String(),
-				)
-			}
-		default:
-			return nil, fmt.Errorf(
-				"unsupported input type found for feature '%s' "+
-					"when converting to arrow: %s",
-				field.Name,
-				elemKind.String(),
-			)
+		if err := setBuilderValues(recordBuilder.Field(idx), values); err != nil {
+			return nil, errors.Wrapf(err, "failed to set values for feature '%s'", field.Name)
 		}
 	}
 	return recordBuilder.NewRecord(), nil

--- a/internal/feather.go
+++ b/internal/feather.go
@@ -81,7 +81,7 @@ func convertReflectToArrowType(value reflect.Type) (arrow.DataType, error) {
 				)
 			}
 			arrowFields = append(arrowFields, arrow.Field{
-				Name:     value.Field(i).Name,
+				Name:     resolveFeatureName(field),
 				Type:     dtype,
 				Nullable: isPointer,
 			})
@@ -189,7 +189,7 @@ func setBuilderValues(builder array.Builder, slice reflect.Value, nullMask []boo
 
 			var namesReflect []string
 			var namesArrow []string
-			structType, typeOk := sBuilder.Type().(*arrow.StructType)
+			arrowStructType, typeOk := sBuilder.Type().(*arrow.StructType)
 			if !typeOk {
 				return errors.Errorf(
 					"internal error: expected struct type as StructBuilder type, found %T",
@@ -197,8 +197,8 @@ func setBuilderValues(builder array.Builder, slice reflect.Value, nullMask []boo
 				)
 			}
 			for i := 0; i < numFieldsReflect; i++ {
-				namesReflect = append(namesReflect, elemType.Field(i).Name)
-				namesArrow = append(namesArrow, structType.Field(i).Name)
+				namesReflect = append(namesReflect, resolveFeatureName(elemType.Field(i)))
+				namesArrow = append(namesArrow, arrowStructType.Field(i).Name)
 			}
 			if !reflect.DeepEqual(namesReflect, namesArrow) {
 				return errors.Errorf(
@@ -210,12 +210,12 @@ func setBuilderValues(builder array.Builder, slice reflect.Value, nullMask []boo
 			}
 
 			for i := 0; i < numFieldsReflect; i++ {
-				if elemType.Field(i).Name != structType.Field(i).Name {
+				if elemType.Field(i).Name != arrowStructType.Field(i).Name {
 					return errors.Errorf(
 						"expected field name in struct to match field name in Arrow struct schema, "+
 							"found '%s' in struct and '%s' in Arrow struct schema",
 						elemType.Field(i).Name,
-						structType.Field(i).Name,
+						arrowStructType.Field(i).Name,
 					)
 				}
 			}

--- a/internal/feather_test.go
+++ b/internal/feather_test.go
@@ -1,0 +1,33 @@
+package internal
+
+import (
+	assert "github.com/stretchr/testify/require"
+	"reflect"
+	"testing"
+)
+
+func TestColumnMapToRecordOptionalPrimitives(t *testing.T) {
+	// Tests that we can convert a slice of pointers to primitive
+	// types to an Arrow column with nulls correctly set.
+	num := int64(1)
+	numFloat := 1.0
+	in := map[string]any{
+		"int":   []*int64{&num, nil, &num},
+		"float": []*float64{&numFloat, &numFloat, nil},
+	}
+	record, convertErr := ColumnMapToRecord(in)
+	assert.Nil(t, convertErr)
+	for i := 0; i < int(record.NumRows()); i++ {
+		for j, col := range record.Columns() {
+			name := record.ColumnName(j)
+			slice := in[name]
+			if col.IsNull(i) {
+				assert.True(t, reflect.ValueOf(slice).Index(i).IsNil())
+			} else {
+				val, valErr := GetValueFromArrowArray(col, i)
+				assert.Nil(t, valErr)
+				assert.Equal(t, reflect.ValueOf(slice).Index(i).Elem().Interface(), val)
+			}
+		}
+	}
+}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 )
 
+var NameTag = "name"
+
 func FileExists(path string) bool {
 	if _, err := os.Stat(path); err != nil {
 		return false
@@ -123,7 +125,7 @@ func isASCIIUpper(c byte) bool {
 }
 
 func resolveFeatureName(field reflect.StructField) string {
-	if tag := field.Tag.Get("name"); tag != "" {
+	if tag := field.Tag.Get(NameTag); tag != "" {
 		return tag
 	}
 	return ChalkpySnakeCase(field.Name)

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -93,8 +93,7 @@ func getFeatureNameFromFqn(fqn string) string {
 }
 
 // ChalkpySnakeCase aims to be in parity with
-//
-//	our Python implementation of snake_case
+// our Python implementation of snake_case
 func ChalkpySnakeCase(s string) string {
 	var b []byte
 	for i := 0; i < len(s); i++ {

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"fmt"
 	"os"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -87,4 +88,43 @@ func ExpandTilde(path string) (string, error) {
 func getFeatureNameFromFqn(fqn string) string {
 	lastPart := strings.Split(fqn, ".")
 	return lastPart[len(lastPart)-1]
+}
+
+// ChalkpySnakeCase aims to be in parity with
+//
+//	our Python implementation of snake_case
+func ChalkpySnakeCase(s string) string {
+	var b []byte
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if isASCIIUpper(c) {
+			if i > 0 && s[i-1] != '.' {
+				b = append(b, '_')
+			}
+			c += 'a' - 'A'
+		} else if isASCIIDigit(c) && i > 0 && isASCIILower(s[i-1]) {
+			b = append(b, '_')
+		}
+		b = append(b, c)
+	}
+	return string(b)
+}
+
+func isASCIILower(c byte) bool {
+	return 'a' <= c && c <= 'z'
+}
+
+func isASCIIDigit(c byte) bool {
+	return '0' <= c && c <= '9'
+}
+
+func isASCIIUpper(c byte) bool {
+	return 'A' <= c && c <= 'Z'
+}
+
+func resolveFeatureName(field reflect.StructField) string {
+	if tag := field.Tag.Get("name"); tag != "" {
+		return tag
+	}
+	return ChalkpySnakeCase(field.Name)
 }

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -34,7 +34,7 @@ func setFeatureSingle(field reflect.Value, fqn string, value any) error {
 		for idx, memberValue := range dataclassValues {
 			memberFieldMeta := structValue.Type().Field(idx)
 			memberField := structValue.Field(idx)
-			pythonName := snakeCase(memberFieldMeta.Name)
+			pythonName := SnakeCase(memberFieldMeta.Name)
 			if memberField == (reflect.Value{}) {
 				return fmt.Errorf("error unmarshalling value for dataclass feature %s: field %s not found in struct %s", fqn, pythonName, structValue.Type().Name())
 			}

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -24,24 +24,63 @@ func (f fqnToFields) addField(fqn string, field reflect.Value) {
 func setFeatureSingle(field reflect.Value, fqn string, value any) error {
 	if internal.IsDataclassPointer(field) {
 		structValue := field.Elem()
-		dataclassValues, ok := value.([]any)
-		if !ok {
-			return fmt.Errorf("error unmarshalling value for dataclass feature %s: value is not an `any` slice", fqn)
-		}
-		if len(dataclassValues) != structValue.NumField() {
-			return fmt.Errorf("error unmarshalling value for dataclass feature %s: expected %d fields, got %s", fqn, structValue.NumField(), dataclassValues)
-		}
-		for idx, memberValue := range dataclassValues {
-			memberFieldMeta := structValue.Type().Field(idx)
-			memberField := structValue.Field(idx)
-			pythonName := SnakeCase(memberFieldMeta.Name)
-			if memberField == (reflect.Value{}) {
-				return fmt.Errorf("error unmarshalling value for dataclass feature %s: field %s not found in struct %s", fqn, pythonName, structValue.Type().Name())
+		if slice, isSlice := value.([]any); isSlice {
+			if len(slice) != structValue.NumField() {
+				return fmt.Errorf(
+					"error unmarshalling value for dataclass "+
+						"feature %s: expected %d fields, got %s",
+					fqn,
+					structValue.NumField(),
+					slice,
+				)
 			}
-			memberFqn := fqn + "." + pythonName
-			if err := setFeatureSingle(memberField, memberFqn, memberValue); err != nil {
-				return fmt.Errorf("error unmarshalling value '%s' for dataclass feature '%s': %w", pythonName, fqn, err)
+			for idx, memberValue := range slice {
+				memberFieldMeta := structValue.Type().Field(idx)
+				memberField := structValue.Field(idx)
+				pythonName := SnakeCase(memberFieldMeta.Name)
+				if memberField == (reflect.Value{}) {
+					return fmt.Errorf(
+						"error unmarshalling value for dataclass feature %s: "+
+							"field %s not found in struct %s",
+						fqn, pythonName, structValue.Type().Name(),
+					)
+				}
+				memberFqn := fqn + "." + pythonName
+				if err := setFeatureSingle(memberField, memberFqn, memberValue); err != nil {
+					return fmt.Errorf(
+						"error unmarshalling value '%s' "+
+							"for dataclass feature '%s': %w",
+						pythonName, fqn, err,
+					)
+				}
 			}
+		} else if mapz, isMap := value.(map[string]any); isMap {
+			nameToField := make(map[string]reflect.Value)
+			for i := 0; i < structValue.NumField(); i++ {
+				nameToField[SnakeCase(structValue.Type().Field(i).Name)] = structValue.Field(i)
+			}
+			for k, v := range mapz {
+				memberField, fieldOk := nameToField[k]
+				if !fieldOk {
+					return fmt.Errorf(
+						"error unmarshalling value for dataclass feature %s: "+
+							"field %s not found in struct %s",
+						fqn, k, structValue.Type().Name(),
+					)
+				}
+				if err := setFeatureSingle(memberField, fqn+"."+k, v); err != nil {
+					return fmt.Errorf(
+						"error unmarshalling value '%s' for dataclass feature '%s': %w",
+						k, fqn, err,
+					)
+				}
+			}
+		} else {
+			return fmt.Errorf(
+				"error unmarshalling value for dataclass "+
+					"feature %s: value is not an `any` slice",
+				fqn,
+			)
 		}
 	} else if field.Kind() == reflect.Map {
 		sections := strings.Split(fqn, ".")

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -220,7 +220,10 @@ func TestUnmarshalOnlineQueryBulkResultPrimitives(t *testing.T) {
 	assert.Equal(t, time.Date(2024, 5, 9, 22, 30, 0, 0, time.UTC), *resultHolders[1].Timestamp)
 }
 
-// TestUnmarshalOnlineQueryBulkResultDataclasses does what it says it does.
+// TestUnmarshalOnlineQueryBulkResultDataclasses tests unmarshalling
+// a bulk query result with dataclass features. This test first
+// builds an Arrow table that contains a column of dataclass features,
+// then unmarshals the table into appropriate structs.
 func TestUnmarshalOnlineQueryBulkResultDataclasses(t *testing.T) {
 	initErr := InitFeatures(&testRootFeatures)
 	assert.Nil(t, initErr)
@@ -233,22 +236,22 @@ func TestUnmarshalOnlineQueryBulkResultDataclasses(t *testing.T) {
 			},
 		},
 	}
-	scalarsTable, scalarsErr := buildTableFromFeatureToValuesMap(scalarsMap)
+	_, scalarsErr := buildTableFromFeatureToValuesMap(scalarsMap)
 	assert.Nil(t, scalarsErr)
 
-	bulkRes := OnlineQueryBulkResult{
-		ScalarsTable: scalarsTable,
-	}
-	defer bulkRes.Release()
-
-	resultHolders := make([]allTypes, 0)
-
-	if err := bulkRes.UnmarshalInto(&resultHolders); err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(t, 1, len(resultHolders))
-	assert.Equal(t, testLatLng{&coord, &coord}, *resultHolders[0].Dataclass)
+	//bulkRes := OnlineQueryBulkResult{
+	//	ScalarsTable: scalarsTable,
+	//}
+	//defer bulkRes.Release()
+	//
+	//resultHolders := make([]allTypes, 0)
+	//
+	//if err := bulkRes.UnmarshalInto(&resultHolders); err != nil {
+	//	t.Fatal(err)
+	//}
+	//
+	//assert.Equal(t, 1, len(resultHolders))
+	//assert.Equal(t, testLatLng{&coord, &coord}, *resultHolders[0].Dataclass)
 }
 
 // TestUnmarshalBulkQueryOptionalValues tests that when a

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -227,18 +227,20 @@ func TestUnmarshalOnlineQueryBulkResultPrimitives(t *testing.T) {
 func TestUnmarshalOnlineQueryBulkResultDataclasses(t *testing.T) {
 	initErr := InitFeatures(&testRootFeatures)
 	assert.Nil(t, initErr)
-	coord := 1.09
+	lat := 37.7749
+	lng := 122.4194
 	scalarsMap := map[any]any{
 		testRootFeatures.AllTypes.Dataclass: []testLatLng{
 			{
-				Lat: &coord,
-				Lng: &coord,
+				Lat: &lat,
+				Lng: &lng,
 			},
 		},
 	}
 	_, scalarsErr := buildTableFromFeatureToValuesMap(scalarsMap)
 	assert.Nil(t, scalarsErr)
 
+	// TODO: Uncomment once we support deserializing dataclass features.
 	//bulkRes := OnlineQueryBulkResult{
 	//	ScalarsTable: scalarsTable,
 	//}

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -220,6 +220,37 @@ func TestUnmarshalOnlineQueryBulkResultPrimitives(t *testing.T) {
 	assert.Equal(t, time.Date(2024, 5, 9, 22, 30, 0, 0, time.UTC), *resultHolders[1].Timestamp)
 }
 
+// TestUnmarshalOnlineQueryBulkResultDataclasses does what it says it does.
+func TestUnmarshalOnlineQueryBulkResultDataclasses(t *testing.T) {
+	initErr := InitFeatures(&testRootFeatures)
+	assert.Nil(t, initErr)
+	coord := 1.09
+	scalarsMap := map[any]any{
+		testRootFeatures.AllTypes.Dataclass: []testLatLng{
+			{
+				Lat: &coord,
+				Lng: &coord,
+			},
+		},
+	}
+	scalarsTable, scalarsErr := buildTableFromFeatureToValuesMap(scalarsMap)
+	assert.Nil(t, scalarsErr)
+
+	bulkRes := OnlineQueryBulkResult{
+		ScalarsTable: scalarsTable,
+	}
+	defer bulkRes.Release()
+
+	resultHolders := make([]allTypes, 0)
+
+	if err := bulkRes.UnmarshalInto(&resultHolders); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 1, len(resultHolders))
+	assert.Equal(t, testLatLng{&coord, &coord}, *resultHolders[0].Dataclass)
+}
+
 // TestUnmarshalBulkQueryOptionalValues tests that when a
 // feature is optional, we can still unmarshal a bulk query
 // result successfully.

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -229,31 +229,41 @@ func TestUnmarshalOnlineQueryBulkResultDataclasses(t *testing.T) {
 	assert.Nil(t, initErr)
 	lat := 37.7749
 	lng := 122.4194
+	lat2 := 47.6062
+	lng2 := 122.3321
 	scalarsMap := map[any]any{
-		testRootFeatures.AllTypes.Dataclass: []testLatLng{
+		testRootFeatures.AllTypes.Dataclass: []*testLatLng{
 			{
 				Lat: &lat,
 				Lng: &lng,
 			},
+			nil,
+			{
+				Lat: &lat2,
+				Lng: &lng2,
+			},
 		},
 	}
-	_, scalarsErr := buildTableFromFeatureToValuesMap(scalarsMap)
+	scalarsTable, scalarsErr := buildTableFromFeatureToValuesMap(scalarsMap)
 	assert.Nil(t, scalarsErr)
 
-	// TODO: Uncomment once we support deserializing dataclass features.
-	//bulkRes := OnlineQueryBulkResult{
-	//	ScalarsTable: scalarsTable,
-	//}
-	//defer bulkRes.Release()
-	//
-	//resultHolders := make([]allTypes, 0)
-	//
-	//if err := bulkRes.UnmarshalInto(&resultHolders); err != nil {
-	//	t.Fatal(err)
-	//}
-	//
-	//assert.Equal(t, 1, len(resultHolders))
-	//assert.Equal(t, testLatLng{&coord, &coord}, *resultHolders[0].Dataclass)
+	bulkRes := OnlineQueryBulkResult{
+		ScalarsTable: scalarsTable,
+	}
+	defer bulkRes.Release()
+
+	resultHolders := make([]allTypes, 0)
+
+	if err := bulkRes.UnmarshalInto(&resultHolders); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 3, len(resultHolders))
+	assert.Equal(t, testLatLng{&lat, &lng}, *resultHolders[0].Dataclass)
+	assert.Equal(t, testLatLng{&lat2, &lng2}, *resultHolders[2].Dataclass)
+
+	// TODO: Handle optional dataclasses in CHA-3655
+	//assert.Nil(t, resultHolders[1].Dataclass)
 }
 
 // TestUnmarshalBulkQueryOptionalValues tests that when a


### PR DESCRIPTION
This PR primarily adds a test for unmarshalling dataclasses into codegen structs. With some supporting refactors:
- [x] Extract recursive logic for setting Arrow builders
- [x] Add logic for StructBuilder
- [x] Handle building an Arrow table for a slice of pointers (a dataclass with 4 pointer fields would have 4 underlying slices of pointers)