### PR TITLE
Lazy initialize struct features upon deser

### DIFF
--- a/init_features.go
+++ b/init_features.go
@@ -99,7 +99,7 @@ func initFeatures(
 			if shouldNaivelySkip {
 				continue
 			}
-			return []reflect.Value{f}, nil
+			resFields = append(resFields, f)
 		} else if f.Type().Elem().Kind() == reflect.Struct &&
 			f.Type().Elem() != reflect.TypeOf(time.Time{}) {
 			// RECURSIVE CASE.

--- a/init_features.go
+++ b/init_features.go
@@ -3,7 +3,9 @@ package chalk
 import (
 	"fmt"
 	"github.com/chalk-ai/chalk-go/internal"
+	"github.com/pkg/errors"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -15,10 +17,18 @@ func InitFeatures[T any](t *T) error {
 	return err
 }
 
+func initFeatureSingle(structValue reflect.Value, fqn string) ([]reflect.Value, error) {
+	parts := strings.Split(fqn, ".")
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("feature fqn should have at least two parts, found: '%s'", fqn)
+	}
+	return initFeatures(structValue, "", make(map[string]bool), strings.Join(parts[1:], "."))
+}
+
 // initFeatures is a recursive function that initializes all features
 // in the struct that is passed in. Each feature is initialized as
 // a pointer to a Feature struct with the appropriate FQN.
-func initFeatures(structValue reflect.Value, fqn string, visited map[string]bool, initFqn string) ([]reflect.Value, error) {
+func initFeatures(structValue reflect.Value, fqn string, visited map[string]bool, targetFqn string) ([]reflect.Value, error) {
 	if structValue.Kind() != reflect.Struct {
 		return nil, fmt.Errorf(
 			"feature initialization function argument must be a reflect.Value"+
@@ -41,20 +51,32 @@ func initFeatures(structValue reflect.Value, fqn string, visited map[string]bool
 		visited[namespace] = false
 	}()
 
+	type fieldAndMeta struct {
+		Field reflect.Value
+		Meta  reflect.StructField
+	}
+
+	var fms []fieldAndMeta
+	var nextInitFqn string
 	for i := 0; i < structValue.NumField(); i++ {
-		f := structValue.Field(i)
-		fieldMeta := structValue.Type().Field(i)
+		fms = append(
+			fms,
+			fieldAndMeta{
+				structValue.Field(i),
+				structValue.Type().Field(i),
+			},
+		)
+	}
+	for _, fm := range fms {
+		resolvedName := internal.ResolveFeatureName(fm.Meta)
+		updatedFqn := fqn + resolvedName
 
-		attributeName := SnakeCase(fieldMeta.Name)
-		nameOverride := fieldMeta.Tag.Get(internal.NameTag)
-		if nameOverride != "" {
-			attributeName = nameOverride
-		}
-		updatedFqn := fqn + attributeName
-
+		f := fm.Field
 		if !f.CanSet() {
 			continue
 		}
+
+		shouldNaivelySkip := targetFqn != "" && getFqnRoot(targetFqn) != resolvedName
 
 		if f.Type().Elem().Kind() == reflect.Struct && f.Type().Elem() != reflect.TypeOf(time.Time{}) {
 			// RECURSIVE CASE.
@@ -63,6 +85,9 @@ func initFeatures(structValue reflect.Value, fqn string, visited map[string]bool
 			//
 			//      Features.User.CreditReport = new(CreditReport)
 			//
+			if shouldNaivelySkip {
+				continue
+			}
 			if ptrErr := pointerCheck(f); ptrErr != nil {
 				return nil, ptrErr
 			}
@@ -70,11 +95,11 @@ func initFeatures(structValue reflect.Value, fqn string, visited map[string]bool
 			ptrInDisguiseToFeatureSet := reflect.NewAt(f.Type().Elem(), featureSet.UnsafePointer())
 			f.Set(ptrInDisguiseToFeatureSet)
 			featureSetInDisguise := f.Elem()
-			targetFields, initErr := initFeatures(featureSetInDisguise, updatedFqn+".", visited, initFqn)
+			targetFields, initErr := initFeatures(featureSetInDisguise, updatedFqn+".", visited, nextInitFqn)
 			if initErr != nil {
 				return nil, initErr
 			}
-			if initFqn != "" {
+			if targetFqn != "" {
 				return targetFields, nil
 			}
 		} else if f.Kind() == reflect.Map {
@@ -91,45 +116,71 @@ func initFeatures(structValue reflect.Value, fqn string, visited map[string]bool
 			// Notice that while the values is typed as *int64, it is
 			// actually a pointer to a Feature struct. See BASE CASE
 			// section below.
+
+			if targetFqn != "" {
+				fqnRoot := getFqnRoot(targetFqn)
+				// The target fqn here could be
+				//    - "some_other_feature_in_this_feature_class"
+				//    - "this_windowed_feature__600__"
+				//    - "other_windowed_feature__600__"
+				// So let's extract "this_windowed_feature" from the target fqn
+				// and compare it with the current feature's name.
+				pattern, err := regexp.Compile(fmt.Sprintf(`^%s__\d+__$`, resolvedName))
+				if err != nil {
+					return nil, errors.Wrap(err, "error compiling regex to match windowed feature names")
+				}
+				if !pattern.Match([]byte(fqnRoot)) {
+					// Not any bucket feature in this windowed feature class
+					continue
+				}
+			}
+
 			mapValueType := f.Type().Elem()
 			if mapValueType.Kind() != reflect.Pointer {
 				return nil, fmt.Errorf("the map type for Windowed features should a pointer as its value type, but found %s instead", mapValueType.Kind())
 			}
-			newMap := reflect.MakeMap(f.Type())
-			windows := fieldMeta.Tag.Get("windows")
-			for _, tag := range strings.Split(windows, ",") {
-				seconds, parseErr := internal.ParseBucketDuration(tag)
-				if parseErr != nil {
-					return nil, fmt.Errorf("error parsing bucket duration: %s", parseErr)
+
+			targetMap := f
+			if targetFqn == "" {
+				// Initializing all features, always
+				// make a new map.
+				targetMap = reflect.MakeMap(f.Type())
+				f.Set(targetMap)
+				windows := fm.Meta.Tag.Get("windows")
+				for _, tag := range strings.Split(windows, ",") {
+					seconds, parseErr := internal.ParseBucketDuration(tag)
+					if parseErr != nil {
+						return nil, fmt.Errorf("error parsing bucket duration: %s", parseErr)
+					}
+					windowFqn := updatedFqn + fmt.Sprintf("__%d__", seconds)
+					if targetFqn == "" {
+						feature := Feature{Fqn: windowFqn}
+						ptrInDisguiseToFeature := reflect.NewAt(mapValueType.Elem(), reflect.ValueOf(&feature).UnsafePointer())
+						targetMap.SetMapIndex(reflect.ValueOf(tag), ptrInDisguiseToFeature)
+					}
 				}
-				windowFqn := updatedFqn + fmt.Sprintf("__%d__", seconds)
-				if initFqn == "" {
-					feature := Feature{Fqn: windowFqn}
-					ptrInDisguiseToFeature := reflect.NewAt(mapValueType.Elem(), reflect.ValueOf(&feature).UnsafePointer())
-					newMap.SetMapIndex(reflect.ValueOf(tag), ptrInDisguiseToFeature)
-				} else {
-					// FIXME: This should be removed, I think, because we don't want
-					// 		  to initialize windowed features for which we don't have
-					//		  values.
-					nilPointer := reflect.New(f.Type().Elem()).Elem()
-					nilPointer.Set(reflect.Zero(nilPointer.Type()))
-					newMap.SetMapIndex(reflect.ValueOf(tag), nilPointer)
+			} else {
+				if targetMap.IsNil() {
+					// Selectively initializing features,
+					// use a new map only if the map is nil.
+					targetMap = reflect.MakeMap(f.Type())
+					f.Set(targetMap)
 				}
-			}
-			f.Set(newMap)
-			if initFqn != "" {
 				return []reflect.Value{f}, nil
 			}
 		} else {
 			// BASE CASE.
+			if shouldNaivelySkip {
+				continue
+			}
 			if ptrErr := pointerCheck(f); ptrErr != nil {
 				return nil, ptrErr
 			}
 
-			versioned := fieldMeta.Tag.Get("versioned")
+			versioned := fm.Meta.Tag.Get("versioned")
 			if versioned == "true" {
 				parts := strings.Split(updatedFqn, "_")
-				nameErr := fmt.Errorf("versioned feature must have a version suffix `VN` at the end of the attribute name, but found '%s' instead", fieldMeta.Name)
+				nameErr := fmt.Errorf("versioned feature must have a version suffix `VN` at the end of the attribute name, but found '%s' instead", fm.Meta.Name)
 				if len(parts) == 1 {
 					return nil, nameErr
 				}
@@ -157,7 +208,7 @@ func initFeatures(structValue reflect.Value, fqn string, visited map[string]bool
 				return nil, fmt.Errorf("Expected struct tag `versioned:\"true\"` or `versioned:\"default(N)\"` where N is an integer, but found '%s' instead", versioned)
 			}
 
-			if initFqn != "" {
+			if targetFqn != "" {
 				return []reflect.Value{f}, nil
 			} else {
 				// Create new Feature instance and point to it.
@@ -181,6 +232,10 @@ func initFeatures(structValue reflect.Value, fqn string, visited map[string]bool
 		}
 	}
 	return nil, nil
+}
+
+func getFqnRoot(s string) string {
+	return strings.Split(s, ".")[0]
 }
 
 func pointerCheck(field reflect.Value) error {

--- a/init_features.go
+++ b/init_features.go
@@ -91,7 +91,8 @@ func initFeatures(
 			// If dataclass child fields are being selectively
 			// initialized for purposes of deserialization of
 			// query results, we simply return the field, as we
-			// do in this block.
+			// do in this block, and let the feature setter set
+			// the value of the dataclass down the line.
 			if shouldNaivelySkip {
 				continue
 			}

--- a/init_features.go
+++ b/init_features.go
@@ -19,7 +19,11 @@ func InitFeatures[T any](t *T) error {
 // a pointer to a Feature struct with the appropriate FQN.
 func initFeatures(structValue reflect.Value, fqn string, visited map[string]bool, fieldMap fqnToFields) error {
 	if structValue.Kind() != reflect.Struct {
-		return fmt.Errorf("feature initialization function argument must be a reflect.Value of the kind reflect.Struct, found %s instead", structValue.Kind().String())
+		return fmt.Errorf(
+			"feature initialization function argument must be a reflect.Value"+
+				" of the kind reflect.Struct, found %s instead",
+			structValue.Kind().String(),
+		)
 	}
 
 	namespace := structValue.Type().Name()

--- a/init_features_internal_test.go
+++ b/init_features_internal_test.go
@@ -2,7 +2,6 @@ package chalk
 
 import (
 	assert "github.com/stretchr/testify/require"
-	"reflect"
 	"testing"
 )
 
@@ -30,27 +29,6 @@ var testFeatures struct {
 	User    *goUser
 	Card    *goCard
 	Address *goAddress
-}
-
-func TestInitFeaturesToNil(t *testing.T) {
-	initErr := initFeatures(reflect.ValueOf(&testFeatures).Elem(), "", make(map[string]bool), make(fqnToFields))
-	assert.Nil(t, initErr)
-	assert.Nil(t, testFeatures.User.Id)
-	assert.Nil(t, testFeatures.User.Name)
-	assert.Nil(t, testFeatures.User.Card.Id)
-	assert.Nil(t, testFeatures.User.Card.Number)
-	assert.Nil(t, testFeatures.User.Address.Id)
-	assert.Nil(t, testFeatures.User.Address.City)
-	assert.Nil(t, testFeatures.User.FamilySize)
-	assert.Nil(t, testFeatures.User.HasFamily)
-	assert.Nil(t, testFeatures.User.FamilyIncome)
-
-	assert.Nil(t, testFeatures.Card.Id)
-	assert.Nil(t, testFeatures.Card.Number)
-
-	assert.Nil(t, testFeatures.Address.Id)
-	assert.Nil(t, testFeatures.Address.City)
-
 }
 
 func TestUnmarshal(t *testing.T) {

--- a/internal/feather.go
+++ b/internal/feather.go
@@ -80,8 +80,12 @@ func convertReflectToArrowType(value reflect.Type) (arrow.DataType, error) {
 					field.Type,
 				)
 			}
+			resolved, err := ResolveFeatureName(field)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to resolve feature name for struct field '%d'", i)
+			}
 			arrowFields = append(arrowFields, arrow.Field{
-				Name:     ResolveFeatureName(field),
+				Name:     resolved,
 				Type:     dtype,
 				Nullable: field.Type.Kind() == reflect.Ptr,
 			})
@@ -232,7 +236,11 @@ func setBuilderValues(builder array.Builder, slice reflect.Value, valid []bool) 
 				)
 			}
 			for i := 0; i < numFieldsReflect; i++ {
-				namesReflect = append(namesReflect, ResolveFeatureName(elemType.Field(i)))
+				resolved, err := ResolveFeatureName(elemType.Field(i))
+				if err != nil {
+					return errors.Wrapf(err, "failed to resolve feature name for struct field '%d'", i)
+				}
+				namesReflect = append(namesReflect, resolved)
 				namesArrow = append(namesArrow, arrowStructType.Field(i).Name)
 			}
 			if !reflect.DeepEqual(namesReflect, namesArrow) {

--- a/internal/feather.go
+++ b/internal/feather.go
@@ -81,7 +81,7 @@ func convertReflectToArrowType(value reflect.Type) (arrow.DataType, error) {
 				)
 			}
 			arrowFields = append(arrowFields, arrow.Field{
-				Name:     resolveFeatureName(field),
+				Name:     ResolveFeatureName(field),
 				Type:     dtype,
 				Nullable: field.Type.Kind() == reflect.Ptr,
 			})
@@ -232,7 +232,7 @@ func setBuilderValues(builder array.Builder, slice reflect.Value, valid []bool) 
 				)
 			}
 			for i := 0; i < numFieldsReflect; i++ {
-				namesReflect = append(namesReflect, resolveFeatureName(elemType.Field(i)))
+				namesReflect = append(namesReflect, ResolveFeatureName(elemType.Field(i)))
 				namesArrow = append(namesArrow, arrowStructType.Field(i).Name)
 			}
 			if !reflect.DeepEqual(namesReflect, namesArrow) {

--- a/internal/unmarshal.go
+++ b/internal/unmarshal.go
@@ -39,7 +39,7 @@ func convertNumber[T Numbers](anyNumber any) (T, error) {
 	}
 }
 
-func isTypeDataclass(typ reflect.Type) bool {
+func IsTypeDataclass(typ reflect.Type) bool {
 	if typ.Kind() == reflect.Struct {
 		for i := 0; i < typ.NumField(); i++ {
 			fieldMeta := typ.Field(i)
@@ -52,7 +52,7 @@ func isTypeDataclass(typ reflect.Type) bool {
 }
 
 func IsDataclass(field reflect.Value) bool {
-	return isTypeDataclass(field.Type())
+	return IsTypeDataclass(field.Type())
 }
 
 func getInnerSliceFromArray(arr arrow.Array, offsets []int64, idx int) (any, error) {
@@ -183,7 +183,7 @@ func GetReflectValue(value any, typ reflect.Type) (*reflect.Value, error) {
 		}
 		return Ptr(ReflectPtr(*indirectValue)), nil
 	}
-	if isTypeDataclass(typ) {
+	if IsTypeDataclass(typ) {
 		structValue := reflect.New(typ).Elem()
 		if slice, isSlice := value.([]any); isSlice {
 			if len(slice) != structValue.NumField() {

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -123,7 +123,7 @@ func isASCIIUpper(c byte) bool {
 	return 'A' <= c && c <= 'Z'
 }
 
-func resolveFeatureName(field reflect.StructField) string {
+func ResolveFeatureName(field reflect.StructField) string {
 	if tag := field.Tag.Get(NameTag); tag != "" {
 		return tag
 	}

--- a/test_fixtures.go
+++ b/test_fixtures.go
@@ -18,26 +18,43 @@ type possessions struct {
 	Plane *string
 }
 
+type grandparent struct {
+	Name *string `dataclass_field:"true"`
+}
+
+type parent struct {
+	Name *string `dataclass_field:"true"`
+	Mom  *grandparent
+	Dad  *grandparent
+}
+
+type child struct {
+	Name *string `dataclass_field:"true"`
+	Mom  *parent
+	Dad  *parent
+}
+
 type anotherFeature struct {
 	Id *string
 }
 
 type allTypes struct {
-	Int                  *int64
-	Float                *float64
-	String               *string
-	Bool                 *bool
-	Timestamp            *time.Time
-	IntList              *[]int64
-	NestedIntPointerList *[]*[]int64
-	NestedIntList        *[][]int64
-	WindowedInt          map[string]*int64   `windows:"1m,5m,1h"`
-	WindowedList         map[string]*[]int64 `windows:"1m"`
-	Dataclass            *testLatLng         `dataclass:"true"`
-	DataclassList        *[]testLatLng
-	DataclassWithList    *favoriteThings
-	DataclassWithNils    *possessions
-	Nested               *anotherFeature
+	Int                    *int64
+	Float                  *float64
+	String                 *string
+	Bool                   *bool
+	Timestamp              *time.Time
+	IntList                *[]int64
+	NestedIntPointerList   *[]*[]int64
+	NestedIntList          *[][]int64
+	WindowedInt            map[string]*int64   `windows:"1m,5m,1h"`
+	WindowedList           map[string]*[]int64 `windows:"1m"`
+	Dataclass              *testLatLng         `dataclass:"true"`
+	DataclassList          *[]testLatLng
+	DataclassWithList      *favoriteThings
+	DataclassWithNils      *possessions
+	DataclassWithDataclass *child
+	Nested                 *anotherFeature
 }
 
 var testRootFeatures struct {

--- a/test_fixtures.go
+++ b/test_fixtures.go
@@ -34,8 +34,15 @@ type child struct {
 	Dad  *parent
 }
 
-type anotherFeature struct {
-	Id *string
+type levelOneNest struct {
+	Id                *string
+	ShouldAlwaysBeNil *string
+	Nested            *levelTwoNest
+}
+
+type levelTwoNest struct {
+	Id                *string
+	ShouldAlwaysBeNil *string
 }
 
 type allTypes struct {
@@ -54,7 +61,7 @@ type allTypes struct {
 	DataclassWithList      *favoriteThings
 	DataclassWithNils      *possessions
 	DataclassWithDataclass *child
-	Nested                 *anotherFeature
+	Nested                 *levelOneNest
 }
 
 var testRootFeatures struct {

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -191,7 +191,7 @@ func UnmarshalInto(resultHolder any, fqnToValue map[Fqn]any, expectedOutputs []s
 			// TODO: Add validation for optional fields
 			continue
 		}
-		targetFields, err := initFeatures(structValue, "", make(map[string]bool), fqn)
+		targetFields, err := initFeatureSingle(structValue, fqn)
 		if err != nil {
 			err = errors.Wrapf(
 				err,

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -10,16 +10,7 @@ import (
 	"strings"
 )
 
-type fqnToFields map[string][]reflect.Value
-
 var FieldNotFoundError = errors.New("field not found")
-
-func (f fqnToFields) addField(fqn string, field reflect.Value) {
-	if _, ok := f[fqn]; !ok {
-		f[fqn] = []reflect.Value{}
-	}
-	f[fqn] = append(f[fqn], field)
-}
 
 func setFeatureSingle(field reflect.Value, fqn string, value any) error {
 	if field.Type().Kind() == reflect.Ptr {
@@ -63,33 +54,6 @@ func setFeatureSingle(field reflect.Value, fqn string, value any) error {
 	} else {
 		return fmt.Errorf("expected a pointer type for feature '%s', found %s", fqn, field.Type().Kind())
 	}
-}
-
-func SetFeature(fields []reflect.Value, fqn string, value any) error {
-	// Versioned features can have multiple fields with the same FQN.
-	// We need to set the value for each field.
-	for _, field := range fields {
-		if err := setFeatureSingle(field, fqn, value); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (f fqnToFields) setFeature(fqn string, value any) error {
-	fields, ok := f[fqn]
-	if !ok {
-		return FieldNotFoundError
-	}
-
-	// Versioned features can have multiple fields with the same FQN.
-	// We need to set the value for each field.
-	for _, field := range fields {
-		if err := setFeatureSingle(field, fqn, value); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func (result *OnlineQueryResult) unmarshal(resultHolder any) (returnErr *ClientError) {
@@ -184,7 +148,7 @@ func UnmarshalTableInto(table arrow.Table, resultHolders any) *ClientError {
 func UnmarshalInto(resultHolder any, fqnToValue map[Fqn]any, expectedOutputs []string) (returnErr *ClientError) {
 	structValue := reflect.ValueOf(resultHolder).Elem()
 
-	fieldMap := fqnToFields{}
+	fieldMap := map[string][]reflect.Value{}
 	for fqn, value := range fqnToValue {
 		if value == nil {
 			// Some fields are optional, so we leave the field as nil
@@ -202,23 +166,25 @@ func UnmarshalInto(resultHolder any, fqnToValue map[Fqn]any, expectedOutputs []s
 			return &ClientError{Message: err.Error()}
 		}
 		for _, field := range targetFields {
-			fieldMap.addField(fqn, field)
-		}
-
-		if err := SetFeature(targetFields, fqn, value); err != nil {
-			structName := structValue.Type().String()
-			outputNamespace := "unknown namespace"
-			sections := strings.Split(fqn, ".")
-			if len(sections) > 0 {
-				outputNamespace = sections[0]
+			if _, ok := fieldMap[fqn]; !ok {
+				fieldMap[fqn] = []reflect.Value{}
 			}
-			if errors.Is(err, FieldNotFoundError) {
-				fieldError := fmt.Sprintf("Error unmarshaling feature '%s' into the struct '%s'. ", fqn, structName)
-				fieldError += fmt.Sprintf("First, check if you are passing a pointer to a struct that represents the output namespace '%s'. ", outputNamespace)
-				fieldError += fmt.Sprintf("Also, make sure the feature name can be traced to a field in the struct '%s' and or its nested structs.", structName)
-				return &ClientError{Message: fieldError}
-			} else {
-				return &ClientError{Message: errors.Wrapf(err, "error unmarshaling feature '%s' into the struct '%s'", fqn, structName).Error()}
+			fieldMap[fqn] = append(fieldMap[fqn], field)
+			if err := setFeatureSingle(field, fqn, value); err != nil {
+				structName := structValue.Type().String()
+				outputNamespace := "unknown namespace"
+				sections := strings.Split(fqn, ".")
+				if len(sections) > 0 {
+					outputNamespace = sections[0]
+				}
+				if errors.Is(err, FieldNotFoundError) {
+					fieldError := fmt.Sprintf("Error unmarshaling feature '%s' into the struct '%s'. ", fqn, structName)
+					fieldError += fmt.Sprintf("First, check if you are passing a pointer to a struct that represents the output namespace '%s'. ", outputNamespace)
+					fieldError += fmt.Sprintf("Also, make sure the feature name can be traced to a field in the struct '%s' and or its nested structs.", structName)
+					return &ClientError{Message: fieldError}
+				} else {
+					return &ClientError{Message: errors.Wrapf(err, "error unmarshaling feature '%s' into the struct '%s'", fqn, structName).Error()}
+				}
 			}
 		}
 

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -367,10 +367,47 @@ func TestUnmarshalOnlineQueryBulkResultDataclasses(t *testing.T) {
 
 	assert.Equal(t, 3, len(resultHolders))
 	assert.Equal(t, testLatLng{&lat, &lng}, *resultHolders[0].Dataclass)
+	assert.Nil(t, resultHolders[1].Dataclass)
 	assert.Equal(t, testLatLng{&lat2, &lng2}, *resultHolders[2].Dataclass)
+}
 
-	// TODO: Handle optional dataclasses in CHA-3655
-	//assert.Nil(t, resultHolders[1].Dataclass)
+// TestUnmarshalQueryBulkOptionalDataclassNested
+func TestUnmarshalQueryBulkOptionalDataclassNested(t *testing.T) {
+	initErr := InitFeatures(&testRootFeatures)
+	assert.Nil(t, initErr)
+	scalarsMap := map[any]any{
+		testRootFeatures.AllTypes.DataclassWithDataclass: []*child{
+			{
+				Name: internal.Ptr("Alice"),
+				Mom: &parent{
+					Name: internal.Ptr("Alice's Mom"),
+					Dad: &grandparent{
+						Name: internal.Ptr("Alice's Grandpa"),
+					},
+				},
+			},
+		},
+	}
+	scalarsTable, scalarsErr := buildTableFromFeatureToValuesMap(scalarsMap)
+	assert.Nil(t, scalarsErr)
+
+	bulkRes := OnlineQueryBulkResult{
+		ScalarsTable: scalarsTable,
+	}
+	defer bulkRes.Release()
+
+	resultHolders := make([]allTypes, 0)
+
+	if err := bulkRes.UnmarshalInto(&resultHolders); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 1, len(resultHolders))
+	assert.Equal(t, "Alice", *resultHolders[0].DataclassWithDataclass.Name)
+	assert.Equal(t, "Alice's Mom", *resultHolders[0].DataclassWithDataclass.Mom.Name)
+	assert.Equal(t, "Alice's Grandpa", *resultHolders[0].DataclassWithDataclass.Mom.Dad.Name)
+	assert.Nil(t, resultHolders[0].DataclassWithDataclass.Dad)
+	assert.Nil(t, resultHolders[0].DataclassWithDataclass.Mom.Mom)
 }
 
 func TestUnmarshalBulkQueryDataclassList(t *testing.T) {
@@ -767,6 +804,8 @@ func TestUnmarshalQueryBulkListOfPrimitives(t *testing.T) {
 	// primitives test above because `buildTableFromFeatureToValuesMap`
 	// does not yet support converting a 2D list of primitives to an Arrow
 	// array.
+	// TODO: We can now use `buildTableFromFeatureToValuesMap` for this test.
+	//       Migrate.
 	encoded, readErr := os.ReadFile(filepath.Join(".", "internal", "sample_data", "list_of_primitives.txt"))
 	if readErr != nil {
 		log.Fatal(readErr)

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -147,6 +147,8 @@ func TestOnlineQueryUnmarshalNonBulkAllTypes(t *testing.T) {
 	assert.Equal(t, float64(3.0), *(*features.DataclassList)[1].Lat)
 	assert.Equal(t, float64(4.0), *(*features.DataclassList)[1].Lng)
 	assert.Equal(t, "nested_id", *features.Nested.Id)
+	assert.Nil(t, features.Nested.ShouldAlwaysBeNil)
+	assert.Nil(t, features.Nested.Nested)
 }
 
 func TestUnmarshalVersionedFeatures(t *testing.T) {


### PR DESCRIPTION
When deserializing query results we used to abuse `InitFeatures` to initialize all features, this caused premature initialization of struct-like features, for example dataclasses or has-one feature classes. This PR initializes those struct-like features just-in-time, so that nil structs stay nil. 