### PR TITLE
GRPC OnlineQuery (single)

### DIFF
--- a/client_grpc.go
+++ b/client_grpc.go
@@ -114,11 +114,12 @@ func (c *clientGrpc) NewQueryClient() (enginev1connect.QueryServiceClient, error
 
 	endpoint, ok := c.config.engines[c.config.environmentId.Value]
 	if !ok {
-		return nil, errors.Newf(
+		c.logger.Errorf(
 			"no engine found for environment '%s' - engine map keys: '%s'",
 			c.config.environmentId.Value,
 			lo.Keys(c.config.engines),
 		)
+		endpoint = c.config.apiServer.Value
 	}
 
 	return enginev1connect.NewQueryServiceClient(

--- a/client_grpc.go
+++ b/client_grpc.go
@@ -334,7 +334,7 @@ func (c *clientGrpc) OnlineQuery(args OnlineQueryParamsComplete, resultHolder an
 		var structType = holderType.Elem()
 		var sliceType = reflect.SliceOf(structType)
 		var ptrToSlice = reflect.New(sliceType)
-		if err := bulkRes.UnmarshalInto(ptrToSlice); err != nil {
+		if err := bulkRes.UnmarshalInto(ptrToSlice.Interface()); err != nil {
 			return OnlineQueryResult{}, errors.Wrap(err, "error unmarshalling result into result holder struct")
 		}
 

--- a/client_grpc.go
+++ b/client_grpc.go
@@ -115,7 +115,8 @@ func (c *clientGrpc) NewQueryClient() (enginev1connect.QueryServiceClient, error
 	endpoint, ok := c.config.engines[c.config.environmentId.Value]
 	if !ok {
 		c.logger.Errorf(
-			"no engine found for environment '%s' - engine map keys: '%s'",
+			"query endpoint falling back to api server - no engine "+
+				"found for environment '%s' - engine map keys: '%s'",
 			c.config.environmentId.Value,
 			lo.Keys(c.config.engines),
 		)

--- a/client_grpc.go
+++ b/client_grpc.go
@@ -344,9 +344,9 @@ func (c *clientGrpc) OnlineQuery(args OnlineQueryParamsComplete, resultHolder an
 				holderType.Kind(),
 			)
 		}
-		var structType = holderType.Elem()
-		var sliceType = reflect.SliceOf(structType)
-		var ptrToSlice = reflect.New(sliceType)
+		structType := holderType.Elem()
+		sliceType := reflect.SliceOf(structType)
+		ptrToSlice := reflect.New(sliceType)
 		if err := bulkRes.UnmarshalInto(ptrToSlice.Interface()); err != nil {
 			return OnlineQueryResult{}, errors.Wrap(err, "error unmarshalling result into result holder struct")
 		}

--- a/internal/tests/integration/fixtures.go
+++ b/internal/tests/integration/fixtures.go
@@ -24,7 +24,7 @@ type franchiseSet struct {
 }
 
 type location struct {
-	LatLng      *latLng   `dataclass_field:"true"`
+	Latlng      *latLng   `dataclass_field:"true"`
 	Owners      *[]string `dataclass_field:"true"`
 	Coordinates *[]latLng `dataclass_field:"true"`
 }

--- a/internal/tests/integration/query_test.go
+++ b/internal/tests/integration/query_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"fmt"
 	"github.com/chalk-ai/chalk-go"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -11,46 +12,55 @@ import (
 // does not crash. Correctness is partially tested here,
 // but is mainly tested in TestOnlineQueryUnmarshalNonBulkAllTypes.
 func TestOnlineQueryAllTypesUnmarshalling(t *testing.T) {
+	t.Parallel()
 	SkipIfNotIntegrationTester(t)
-	client, err := chalk.NewClient()
-	if err != nil {
-		t.Fatal("Failed creating a Chalk Client", err)
-	}
-	err = chalk.InitFeatures(&testFeatures)
-	if err != nil {
-		t.Fatal("Failed initializing features", err)
-	}
-	req := chalk.OnlineQueryParams{}.
-		WithInput(testFeatures.User.Id, 1).
-		WithOutputs(
-			testFeatures.User.Id,
-			testFeatures.User.Gender,
-			testFeatures.User.Today,
-			testFeatures.User.NiceNewFeature,
-			testFeatures.User.SocureScore,
-			testFeatures.User.FavoriteNumbers,
-			testFeatures.User.FavoriteColors,
-			testFeatures.User.FranchiseSet,
-		)
+	for _, fixture := range []struct {
+		useGrpc bool
+	}{
+		//{useGrpc: false},
+		{useGrpc: true},
+	} {
+		t.Run(fmt.Sprintf("grpc=%v", fixture.useGrpc), func(t *testing.T) {
+			client, err := chalk.NewClient(&chalk.ClientConfig{UseGrpc: fixture.useGrpc})
+			if err != nil {
+				t.Fatal("Failed creating a Chalk Client", err)
+			}
+			err = chalk.InitFeatures(&testFeatures)
+			if err != nil {
+				t.Fatal("Failed initializing features", err)
+			}
+			req := chalk.OnlineQueryParams{}.
+				WithInput(testFeatures.User.Id, 1).
+				WithOutputs(
+					testFeatures.User.Id,
+					testFeatures.User.Gender,
+					testFeatures.User.Today,
+					testFeatures.User.NiceNewFeature,
+					testFeatures.User.SocureScore,
+					testFeatures.User.FavoriteNumbers,
+					testFeatures.User.FavoriteColors,
+					testFeatures.User.FranchiseSet,
+				)
 
-	res, queryErr := client.OnlineQuery(req, nil)
-	if queryErr != nil {
-		t.Fatal("Failed querying features", queryErr)
+			res, queryErr := client.OnlineQuery(req, nil)
+			if queryErr != nil {
+				t.Fatal("Failed querying features", queryErr)
+			}
+			var testUser user
+			err = res.UnmarshalInto(&testUser)
+			// TODO: We need to fix this nil check
+			//       to just be `!= nil`
+			if err != (*chalk.ClientError)(nil) {
+				t.Fatal("Failed unmarshaling result", err)
+			}
+			assert.Equal(t, *testUser.Id, int64(1))
+			assert.Equal(t, *testUser.Gender, "f")
+			assert.NotNil(t, testUser.Today)
+			assert.Equal(t, *testUser.NiceNewFeature, int64(9))
+			assert.Equal(t, *testUser.SocureScore, 123.0)
+			assert.Equal(t, *testUser.FavoriteNumbers, []int64{1, 2, 3})
+			assert.Equal(t, *testUser.FavoriteColors, []string{"red", "green", "blue"})
+			assert.NotNil(t, testUser.FranchiseSet)
+		})
 	}
-	var testUser user
-	err = res.UnmarshalInto(&testUser)
-	// TODO: We need to fix this nil check
-	//       to just be `!= nil`
-	if err != (*chalk.ClientError)(nil) {
-		t.Fatal("Failed unmarshaling result", err)
-	}
-	assert.Equal(t, *testUser.Id, int64(1))
-	assert.Equal(t, *testUser.Gender, "f")
-	assert.NotNil(t, testUser.Today)
-	assert.Equal(t, *testUser.NiceNewFeature, int64(9))
-	assert.Equal(t, *testUser.SocureScore, 123.0)
-	assert.Equal(t, *testUser.FavoriteNumbers, []int64{1, 2, 3})
-	assert.Equal(t, *testUser.FavoriteColors, []string{"red", "green", "blue"})
-	assert.NotNil(t, testUser.FranchiseSet)
-
 }

--- a/internal/tests/integration/query_test.go
+++ b/internal/tests/integration/query_test.go
@@ -50,7 +50,9 @@ func TestOnlineQueryAllTypesUnmarshalling(t *testing.T) {
 
 			var explicitUser user
 			err = res.UnmarshalInto(&explicitUser)
-			if err != nil {
+			// TODO: We need to fix this nil check
+			//       to just be `!= nil`
+			if err != (*chalk.ClientError)(nil) {
 				t.Fatal("Failed unmarshaling result", err)
 			}
 

--- a/internal/tests/integration/query_test.go
+++ b/internal/tests/integration/query_test.go
@@ -17,7 +17,7 @@ func TestOnlineQueryAllTypesUnmarshalling(t *testing.T) {
 	for _, fixture := range []struct {
 		useGrpc bool
 	}{
-		//{useGrpc: false},
+		{useGrpc: false},
 		{useGrpc: true},
 	} {
 		t.Run(fmt.Sprintf("grpc=%v", fixture.useGrpc), func(t *testing.T) {
@@ -42,25 +42,28 @@ func TestOnlineQueryAllTypesUnmarshalling(t *testing.T) {
 					testFeatures.User.FranchiseSet,
 				)
 
-			res, queryErr := client.OnlineQuery(req, nil)
+			var implicitUser user
+			res, queryErr := client.OnlineQuery(req, &implicitUser)
 			if queryErr != nil {
 				t.Fatal("Failed querying features", queryErr)
 			}
-			var testUser user
-			err = res.UnmarshalInto(&testUser)
-			// TODO: We need to fix this nil check
-			//       to just be `!= nil`
-			if err != (*chalk.ClientError)(nil) {
+
+			var explicitUser user
+			err = res.UnmarshalInto(&explicitUser)
+			if err != nil {
 				t.Fatal("Failed unmarshaling result", err)
 			}
-			assert.Equal(t, *testUser.Id, int64(1))
-			assert.Equal(t, *testUser.Gender, "f")
-			assert.NotNil(t, testUser.Today)
-			assert.Equal(t, *testUser.NiceNewFeature, int64(9))
-			assert.Equal(t, *testUser.SocureScore, 123.0)
-			assert.Equal(t, *testUser.FavoriteNumbers, []int64{1, 2, 3})
-			assert.Equal(t, *testUser.FavoriteColors, []string{"red", "green", "blue"})
-			assert.NotNil(t, testUser.FranchiseSet)
+
+			for _, testUser := range []user{implicitUser, explicitUser} {
+				assert.Equal(t, *testUser.Id, int64(1))
+				assert.Equal(t, *testUser.Gender, "f")
+				assert.NotNil(t, testUser.Today)
+				assert.Equal(t, *testUser.NiceNewFeature, int64(9))
+				assert.Equal(t, *testUser.SocureScore, 123.0)
+				assert.Equal(t, *testUser.FavoriteNumbers, []int64{1, 2, 3})
+				assert.Equal(t, *testUser.FavoriteColors, []string{"red", "green", "blue"})
+				assert.NotNil(t, testUser.FranchiseSet)
+			}
 		})
 	}
 }

--- a/internal/tests/integration/query_test.go
+++ b/internal/tests/integration/query_test.go
@@ -21,6 +21,7 @@ func TestOnlineQueryAllTypesUnmarshalling(t *testing.T) {
 		{useGrpc: true},
 	} {
 		t.Run(fmt.Sprintf("grpc=%v", fixture.useGrpc), func(t *testing.T) {
+			t.Parallel()
 			client, err := chalk.NewClient(&chalk.ClientConfig{UseGrpc: fixture.useGrpc})
 			if err != nil {
 				t.Fatal("Failed creating a Chalk Client", err)

--- a/internal/tests/integration/query_test.go
+++ b/internal/tests/integration/query_test.go
@@ -21,7 +21,6 @@ func TestOnlineQueryAllTypesUnmarshalling(t *testing.T) {
 		{useGrpc: true},
 	} {
 		t.Run(fmt.Sprintf("grpc=%v", fixture.useGrpc), func(t *testing.T) {
-			t.Parallel()
 			client, err := chalk.NewClient(&chalk.ClientConfig{UseGrpc: fixture.useGrpc})
 			if err != nil {
 				t.Fatal("Failed creating a Chalk Client", err)

--- a/internal/tests/integration/query_test.go
+++ b/internal/tests/integration/query_test.go
@@ -56,7 +56,7 @@ func TestOnlineQueryAllTypesUnmarshalling(t *testing.T) {
 				t.Fatal("Failed unmarshaling result", err)
 			}
 
-			for _, testUser := range []user{implicitUser, explicitUser} {
+			testUserValues := func(testUser user) {
 				assert.Equal(t, *testUser.Id, int64(1))
 				assert.Equal(t, *testUser.Gender, "f")
 				assert.NotNil(t, testUser.Today)
@@ -66,6 +66,8 @@ func TestOnlineQueryAllTypesUnmarshalling(t *testing.T) {
 				assert.Equal(t, *testUser.FavoriteColors, []string{"red", "green", "blue"})
 				assert.NotNil(t, testUser.FranchiseSet)
 			}
+			testUserValues(implicitUser)
+			testUserValues(explicitUser)
 		})
 	}
 }


### PR DESCRIPTION
Add non-bulk GRPC online query. Implemented via GRPC bulk query underneath. 

**Limitations**
- [x] Each `FeatureResult` has no `FeatureResolutionMeta`, `Pkey`, `QueryTimestamp`, `Error` (errors exist at top level)