### PR TITLE
fix FQN resolution function

### DIFF
--- a/init_features_internal_test.go
+++ b/init_features_internal_test.go
@@ -96,6 +96,9 @@ func TestUnmarshal(t *testing.T) {
 	assert.Nil(t, user.Card.Number)
 }
 
+// TestSnakeCase serves as a unit test.
+// We should also add all test cases here
+// to the integration test in `init_features_test.go`.
 func TestSnakeCase(t *testing.T) {
 	testCases := []struct {
 		input    string

--- a/init_features_test.go
+++ b/init_features_test.go
@@ -33,6 +33,9 @@ type goUser struct {
 	FamilyIncome *float32
 
 	CustomUnderscoresL90DP90DAustralia *int `name:"custom_underscores_l90d_p90d_australia"`
+	ChargeL30mP30mRate                 *float64
+	ContactsDeliveredAl7dHow           *float64
+	Test123                            *float64
 
 	// Versioned features
 	Grade   *int `versioned:"default(2)"`
@@ -56,6 +59,8 @@ func init() {
 	initFeaturesErr = chalk.InitFeatures(&testFeatures)
 }
 
+// TestInitFeatures serves to test feature FQN resolution e2e,
+// on top of the snake casing unit tests.
 func TestInitFeatures(t *testing.T) {
 	assert.Nil(t, initFeaturesErr)
 
@@ -114,6 +119,18 @@ func TestInitFeatures(t *testing.T) {
 	customUnderscore, err := chalk.UnwrapFeature(testFeatures.User.CustomUnderscoresL90DP90DAustralia)
 	assert.Nil(t, err)
 	assert.Equal(t, "user.custom_underscores_l90d_p90d_australia", customUnderscore.Fqn)
+
+	capitalWithNumber, err := chalk.UnwrapFeature(testFeatures.User.ChargeL30mP30mRate)
+	assert.Nil(t, err)
+	assert.Equal(t, "user.charge_l30m_p30m_rate", capitalWithNumber.Fqn)
+
+	contactsDelivered, err := chalk.UnwrapFeature(testFeatures.User.ContactsDeliveredAl7dHow)
+	assert.Nil(t, err)
+	assert.Equal(t, "user.contacts_delivered_al_7d_how", contactsDelivered.Fqn)
+
+	test123, err := chalk.UnwrapFeature(testFeatures.User.Test123)
+	assert.Nil(t, err)
+	assert.Equal(t, "user.test_123", test123.Fqn)
 
 	grade, err := chalk.UnwrapFeature(testFeatures.User.Grade)
 	assert.Nil(t, err)

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -170,7 +170,7 @@ func ResolveFeatureName(field reflect.StructField) (string, error) {
 			versioned,
 		)
 	}
-	return ChalkpySnakeCase(fieldName), nil
+	return fieldName, nil
 }
 
 func Ptr[T any](value T) *T {


### PR DESCRIPTION
We regressed this in #96 because we were calling the snake case function twice. This PR adds the special cases as integration tests to avoid regression. 