### PR TITLE
(fix): fix panic on wrong env supplied

### DIFF
--- a/config_manager.go
+++ b/config_manager.go
@@ -63,6 +63,10 @@ func newConfigManager(
 		return nil, chalkYamlErr
 	}
 
+	if logger == nil {
+		logger = DefaultLeveledLogger
+	}
+
 	return &configManager{
 		apiServer:          apiServerConfig,
 		clientId:           clientIdConfig,

--- a/config_manager.go
+++ b/config_manager.go
@@ -80,12 +80,20 @@ func (m *configManager) getQueryServer(queryServerOverride *string) string {
 
 	endpoint, ok := m.engines[m.environmentId.Value]
 	if !ok {
-		m.logger.Errorf(
-			"query endpoint falling back to api server - no engine "+
-				"found for environment '%s' - engine map keys: '%s'",
-			m.environmentId.Value,
-			colls.Keys(m.engines),
-		)
+		if m.engines != nil {
+			m.logger.Errorf(
+				"query endpoint falling back to api server - no engine "+
+					"found for environment '%s' - engine map keys: '%s'",
+				m.environmentId.Value,
+				colls.Keys(m.engines),
+			)
+		} else {
+			m.logger.Errorf(
+				"query endpoint falling back to api server - no engine "+
+					"found for environment '%s'",
+				m.environmentId.Value,
+			)
+		}
 		endpoint = m.apiServer.Value
 	}
 	return endpoint

--- a/grpc_client_impl.go
+++ b/grpc_client_impl.go
@@ -53,13 +53,8 @@ func newGrpcClient(cfg GRPCClientConfig) (*grpcClientImpl, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating auth client")
 	}
-	logger := cfg.Logger
-	if logger == nil {
-		logger = DefaultLeveledLogger
-		config.logger = DefaultLeveledLogger
-	}
 	config.getToken = func(clientId string, clientSecret string) (*getTokenResult, error) {
-		return getToken(clientId, clientSecret, logger, authClient)
+		return getToken(clientId, clientSecret, config.logger, authClient)
 	}
 
 	// Necessary to get GRPC engines URL
@@ -80,7 +75,7 @@ func newGrpcClient(cfg GRPCClientConfig) (*grpcClientImpl, error) {
 	return &grpcClientImpl{
 		branch:      cfg.Branch,
 		httpClient:  httpClient,
-		logger:      logger,
+		logger:      config.logger,
 		config:      config,
 		authClient:  authClient,
 		queryClient: queryClient,

--- a/grpc_client_impl.go
+++ b/grpc_client_impl.go
@@ -56,6 +56,7 @@ func newGrpcClient(cfg GRPCClientConfig) (*grpcClientImpl, error) {
 	logger := cfg.Logger
 	if logger == nil {
 		logger = DefaultLeveledLogger
+		config.logger = DefaultLeveledLogger
 	}
 	config.getToken = func(clientId string, clientSecret string) (*getTokenResult, error) {
 		return getToken(clientId, clientSecret, logger, authClient)

--- a/internal/tests/integration/new_client_test.go
+++ b/internal/tests/integration/new_client_test.go
@@ -15,7 +15,7 @@ func TestWrongEnvironment(t *testing.T) {
 		},
 	)
 	if err != nil {
-		t.Fatal("Failed creating a Chalk Client", err)
+		t.Fatal("Failed creating a Chalk GRPC Client", err)
 	}
 	_, err = chalk.NewClient(
 		&chalk.ClientConfig{

--- a/internal/tests/integration/new_client_test.go
+++ b/internal/tests/integration/new_client_test.go
@@ -7,6 +7,7 @@ import (
 
 // Supplied an incorrect environment used to cause a panic
 func TestWrongEnvironment(t *testing.T) {
+	SkipIfNotIntegrationTester(t)
 	_, err := chalk.NewClient(
 		&chalk.ClientConfig{
 			UseGrpc:       true,

--- a/internal/tests/integration/new_client_test.go
+++ b/internal/tests/integration/new_client_test.go
@@ -5,9 +5,7 @@ import (
 	"testing"
 )
 
-// TestOnlineQueryBulkGrpc mainly tests that a
-// gRPC bulk query works e2e. Correctness is
-// tested elsewhere.
+// Supplied an incorrect environment used to cause a panic
 func TestWrongEnvironment(t *testing.T) {
 	_, err := chalk.NewClient(
 		&chalk.ClientConfig{

--- a/internal/tests/integration/new_client_test.go
+++ b/internal/tests/integration/new_client_test.go
@@ -12,7 +12,16 @@ func TestWrongEnvironment(t *testing.T) {
 		&chalk.ClientConfig{
 			UseGrpc:       true,
 			EnvironmentId: "wrong",
-		})
+		},
+	)
+	if err != nil {
+		t.Fatal("Failed creating a Chalk Client", err)
+	}
+	_, err = chalk.NewClient(
+		&chalk.ClientConfig{
+			EnvironmentId: "wrong",
+		},
+	)
 	if err != nil {
 		t.Fatal("Failed creating a Chalk Client", err)
 	}

--- a/internal/tests/integration/new_client_test.go
+++ b/internal/tests/integration/new_client_test.go
@@ -1,0 +1,20 @@
+package integration
+
+import (
+	"github.com/chalk-ai/chalk-go"
+	"testing"
+)
+
+// TestOnlineQueryBulkGrpc mainly tests that a
+// gRPC bulk query works e2e. Correctness is
+// tested elsewhere.
+func TestWrongEnvironment(t *testing.T) {
+	_, err := chalk.NewClient(
+		&chalk.ClientConfig{
+			UseGrpc:       true,
+			EnvironmentId: "wrong",
+		})
+	if err != nil {
+		t.Fatal("Failed creating a Chalk Client", err)
+	}
+}


### PR DESCRIPTION
Passing an invalid environment id would cause chalk-gi create client to panic—this should address.