### PR TITLE
Make UnmarshalInto forward compat with new fields [CHA-4576]

### DIFF
--- a/internal/unmarshal.go
+++ b/internal/unmarshal.go
@@ -280,10 +280,12 @@ func GetReflectValue(value any, typ reflect.Type) (*reflect.Value, error) {
 			for k, v := range mapz {
 				memberField, fieldOk := nameToField[k]
 				if !fieldOk {
-					return nil, fmt.Errorf(
-						"field '%s' not found in struct '%s'",
-						k, structValue.Type().Name(),
-					)
+					// For forward compatibility, i.e. when clients add
+					// more fields to their dataclasses in chalkpy, we want
+					// to default to not erring when trying to deserialize
+					// a new field that does not yet exist in the Go struct.
+					// Eventually we might consider exposing a flag.
+					continue
 				}
 				if v == nil {
 					continue

--- a/test_fixtures.go
+++ b/test_fixtures.go
@@ -7,6 +7,12 @@ type testLatLng struct {
 	Lng *float64 `dataclass_field:"true"`
 }
 
+type testLatLngWithExtraField struct {
+	Lat   *float64 `dataclass_field:"true"`
+	Lng   *float64 `dataclass_field:"true"`
+	Extra *string  `dataclass_field:"true"`
+}
+
 type favoriteThings struct {
 	Numbers *[]int64 `dataclass_field:"true"`
 	Words   *[]string

--- a/test_utils.go
+++ b/test_utils.go
@@ -18,6 +18,10 @@ func buildTableFromFeatureToValuesMap(featureToValues map[any]any) (arrow.Table,
 		}
 		fqnToValues[feature.Fqn] = values
 	}
+	return tableFromFqnToValues(fqnToValues)
+}
+
+func tableFromFqnToValues(fqnToValues map[string]any) (arrow.Table, error) {
 	record, recordErr := internal.ColumnMapToRecord(fqnToValues)
 	if recordErr != nil {
 		return nil, fmt.Errorf("error converting a map of column values to an Arrow Record: %w", recordErr)

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -245,9 +245,12 @@ func UnmarshalInto(resultHolder any, fqnToValue map[Fqn]any, expectedOutputs []s
 		}
 		targetFields, ok := initializer.fieldsMap[fqn]
 		if !ok {
-			return &ClientError{
-				errors.Newf("error locating fields associated with feature '%s'", fqn).Error(),
-			}
+			// For forward compatibility, i.e. when clients add
+			// more fields to their dataclasses in chalkpy, we want
+			// to default to not erring when trying to deserialize
+			// a new field that does not yet exist in the Go struct.
+			// Eventually we might consider exposing a flag.
+			continue
 		}
 		if err != nil {
 			err = errors.Wrapf(

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -1181,7 +1181,6 @@ func TestSingleUnmarshalIntoExtraFields(t *testing.T) {
 		},
 	} {
 		t.Run(fixture.name, func(t *testing.T) {
-			t.Parallel()
 			result := OnlineQueryResult{
 				Data:            fixture.data,
 				Meta:            nil,
@@ -1190,7 +1189,7 @@ func TestSingleUnmarshalIntoExtraFields(t *testing.T) {
 			}
 			featureStruct := allTypes{}
 			unmarshalErr := result.UnmarshalInto(&featureStruct)
-			if fixture.shouldErr {
+			if !fixture.shouldErr {
 				assert.Nil(t, unmarshalErr)
 			}
 		})

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -1189,7 +1189,9 @@ func TestSingleUnmarshalIntoExtraFields(t *testing.T) {
 			}
 			featureStruct := allTypes{}
 			unmarshalErr := result.UnmarshalInto(&featureStruct)
-			if !fixture.shouldErr {
+			if fixture.shouldErr {
+				assert.NotNil(t, unmarshalErr)
+			} else {
 				assert.Nil(t, unmarshalErr)
 			}
 		})

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -1199,7 +1199,9 @@ func TestSingleUnmarshalIntoExtraFields(t *testing.T) {
 }
 
 func TestBulkUnmarshalExtraFields(t *testing.T) {
-	t.Parallel()
+	// DO NOT USE PARALLEL
+	//    InitFeatures can not be run in parallel
+	//
 	// For forward compatibility, i.e. when clients add
 	// more fields to their dataclasses in chalkpy, we want
 	// to default to not erring when trying to deserialize
@@ -1235,7 +1237,9 @@ func TestBulkUnmarshalExtraFields(t *testing.T) {
 }
 
 func TestBulkUnmarshalExtraFeatures(t *testing.T) {
-	t.Parallel()
+	// DO NOT USE PARALLEL
+	//    InitFeatures can not be run in parallel
+	//
 	// For forward compatibility, i.e. when clients add
 	// more fields to their dataclasses in chalkpy, we want
 	// to default to not erring when trying to deserialize

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -1180,7 +1180,8 @@ func TestSingleUnmarshalIntoExtraFields(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(fixture.name, func(t *testing.T) {
+		t.Run(fixture.name, func(m *testing.T) {
+			m.Parallel()
 			result := OnlineQueryResult{
 				Data:            fixture.data,
 				Meta:            nil,

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -1133,3 +1133,140 @@ func TestEnsureTimelyUnmarshal(t *testing.T) {
 	limit := 0.5
 	assert.True(t, multiplier < limit, "multiplier should be less than %v", limit)
 }
+
+/*
+Test matrix:
+ 1. single unmarshal list into dataclass struct
+ 2. single unmarshal struct into dataclass struct
+ 3. single unmarshal feature class into feature struct
+ 4. bulk unmarshal for 1, 2, 3
+*/
+func TestSingleUnmarshalIntoExtraFields(t *testing.T) {
+	// This test tests that we don't error.
+	// Correctness is tested elsewhere.
+	//
+	// Context:
+	// For forward compatibility, i.e. when clients add
+	// more fields to their dataclasses in chalkpy, we want
+	// to default to not erring when trying to deserialize
+	// a new field that does not yet exist in the Go struct.
+	for _, fixture := range []struct {
+		name string
+		data []FeatureResult
+	}{
+		{
+			name: "single unmarshal list into dataclass struct",
+			data: []FeatureResult{
+				{
+					Field: "all_types.dataclass",
+					Value: []any{1.0, 2.0, 3.0},
+				},
+			},
+		},
+		{
+			name: "single unmarshal struct into dataclass struct",
+			data: []FeatureResult{
+				{
+					Field: "all_types.dataclass",
+					Value: map[string]any{
+						"lat":         1.0,
+						"lng":         2.0,
+						"extra_field": 3.0,
+					},
+				},
+			},
+		},
+		{
+			name: "single unmarshal feature class into feature struct",
+			data: []FeatureResult{
+				{
+					Field: "all_types.extra_feature",
+					Value: float64(1.0),
+				},
+			},
+		},
+	} {
+		t.Run(fixture.name, func(t *testing.T) {
+			result := OnlineQueryResult{
+				Data:            fixture.data,
+				Meta:            nil,
+				features:        nil,
+				expectedOutputs: nil,
+			}
+			featureStruct := allTypes{}
+			unmarshalErr := result.UnmarshalInto(&featureStruct)
+			if unmarshalErr != nil {
+				t.Fatal(unmarshalErr)
+			}
+			assert.Nil(t, unmarshalErr)
+		})
+	}
+}
+
+func TestBulkUnmarshalExtraFields(t *testing.T) {
+	// Only tests that we don't error. Correctness tested elsewhere.
+	//
+	// Context:
+	// For forward compatibility, i.e. when clients add
+	// more fields to their dataclasses in chalkpy, we want
+	// to default to not erring when trying to deserialize
+	// a new field that does not yet exist in the Go struct.
+	initErr := InitFeatures(&testRootFeatures)
+	assert.Nil(t, initErr)
+	lat := 37.7749
+	lng := 122.4194
+	extra := "extra"
+	scalarsMap := map[any]any{
+		testRootFeatures.AllTypes.Dataclass: []*testLatLngWithExtraField{
+			{
+				Lat:   &lat,
+				Lng:   &lng,
+				Extra: &extra,
+			},
+		},
+	}
+	scalarsTable, scalarsErr := buildTableFromFeatureToValuesMap(scalarsMap)
+	assert.Nil(t, scalarsErr)
+
+	bulkRes := OnlineQueryBulkResult{
+		ScalarsTable: scalarsTable,
+	}
+	defer bulkRes.Release()
+
+	resultHolders := make([]allTypes, 0)
+
+	if err := bulkRes.UnmarshalInto(&resultHolders); err != nil {
+		t.Fatal(err)
+	}
+	// Only tests that we don't error. Correctness tested elsewhere.
+}
+
+func TestBulkUnmarshalExtraFeatures(t *testing.T) {
+	// Only tests that we don't error. Correctness tested elsewhere.
+	//
+	// Context:
+	// For forward compatibility, i.e. when clients add
+	// more fields to their dataclasses in chalkpy, we want
+	// to default to not erring when trying to deserialize
+	// a new field that does not yet exist in the Go struct.
+	initErr := InitFeatures(&testRootFeatures)
+	assert.Nil(t, initErr)
+	scalarsMap := map[any]any{
+		: []float64{1.0},
+	}
+	scalarsTable, scalarsErr := buildTableFromFeatureToValuesMap(scalarsMap)
+	assert.Nil(t, scalarsErr)
+
+	bulkRes := OnlineQueryBulkResult{
+		ScalarsTable: scalarsTable,
+	}
+	defer bulkRes.Release()
+
+	resultHolders := make([]allTypes, 0)
+
+	if err := bulkRes.UnmarshalInto(&resultHolders); err != nil {
+		t.Fatal(err)
+	}
+	// Only tests that we don't error. Correctness tested elsewhere.
+}
+

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -1180,8 +1180,7 @@ func TestSingleUnmarshalIntoExtraFields(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(fixture.name, func(m *testing.T) {
-			m.Parallel()
+		t.Run(fixture.name, func(t *testing.T) {
 			result := OnlineQueryResult{
 				Data:            fixture.data,
 				Meta:            nil,


### PR DESCRIPTION
When new features or dataclass fields are defined in a deployment, we want to not error upon deserializing into old Golang structs. 