### PR TITLE
[xs] add feature encoding options to params

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -1,6 +1,8 @@
 package internal
 
-import "time"
+import (
+	"time"
+)
 
 type OnlineQueryContext struct {
 	Environment          *string  `json:"environment"`
@@ -8,21 +10,28 @@ type OnlineQueryContext struct {
 	RequiredResolverTags []string `json:"required_resolver_tags"`
 }
 
+type FeatureEncodingOptions struct {
+	// If true, Chalk will return structs as objects
+	// instead of arrays in the response.
+	EncodeStructsAsObjects bool `json:"encode_structs_as_objects"`
+}
+
 type OnlineQueryRequestSerialized struct {
-	Inputs           map[string]any     `json:"inputs"`
-	Outputs          []string           `json:"outputs"`
-	Context          OnlineQueryContext `json:"context"`
-	Staleness        map[string]string  `json:"staleness"`
-	IncludeMeta      bool               `json:"include_meta"`
-	IncludeMetrics   bool               `json:"include_metrics"`
-	DeploymentId     *string            `json:"deployment_id"`
-	QueryName        *string            `json:"query_name"`
-	CorrelationId    *string            `json:"correlation_id"`
-	Meta             map[string]string  `json:"meta"`
-	QueryNameVersion *string            `json:"query_name_version"`
-	Now              *string            `json:"now"`
-	Explain          bool               `json:"explain"`
-	StorePlanStages  bool               `json:"store_plan_stages"`
+	Inputs           map[string]any         `json:"inputs"`
+	Outputs          []string               `json:"outputs"`
+	Context          OnlineQueryContext     `json:"context"`
+	Staleness        map[string]string      `json:"staleness"`
+	IncludeMeta      bool                   `json:"include_meta"`
+	IncludeMetrics   bool                   `json:"include_metrics"`
+	DeploymentId     *string                `json:"deployment_id"`
+	QueryName        *string                `json:"query_name"`
+	CorrelationId    *string                `json:"correlation_id"`
+	Meta             map[string]string      `json:"meta"`
+	QueryNameVersion *string                `json:"query_name_version"`
+	Now              *string                `json:"now"`
+	Explain          bool                   `json:"explain"`
+	StorePlanStages  bool                   `json:"store_plan_stages"`
+	EncodingOptions  FeatureEncodingOptions `json:"encoding_options"`
 }
 
 type OfflineQueryInputSerialized struct {

--- a/internal/client.go
+++ b/internal/client.go
@@ -11,8 +11,6 @@ type OnlineQueryContext struct {
 }
 
 type FeatureEncodingOptions struct {
-	// If true, Chalk will return structs as objects
-	// instead of arrays in the response.
 	EncodeStructsAsObjects bool `json:"encode_structs_as_objects"`
 }
 

--- a/internal/tests/integration/params_test.go
+++ b/internal/tests/integration/params_test.go
@@ -149,7 +149,7 @@ func TestParamsSetInOnlineQuery(t *testing.T) {
 		Explain:              true,
 		IncludeMeta:          true,
 		IncludeMetrics:       true,
-		EncodingOptions: chalk.FeatureEncodingOptions{
+		EncodingOptions: &chalk.FeatureEncodingOptions{
 			EncodeStructsAsObjects: true,
 		},
 	}.

--- a/internal/tests/integration/params_test.go
+++ b/internal/tests/integration/params_test.go
@@ -149,6 +149,9 @@ func TestParamsSetInOnlineQuery(t *testing.T) {
 		Explain:              true,
 		IncludeMeta:          true,
 		IncludeMetrics:       true,
+		EncodingOptions: chalk.FeatureEncodingOptions{
+			EncodeStructsAsObjects: true,
+		},
 	}.
 		WithInput(testFeatures.User.Id, "1").
 		WithOutputs(testFeatures.User.SocureScore)
@@ -177,6 +180,7 @@ func TestParamsSetInOnlineQuery(t *testing.T) {
 	assert.True(t, request.Explain)
 	assert.True(t, request.IncludeMeta)
 	assert.True(t, request.IncludeMetrics)
+	assert.True(t, request.EncodingOptions.EncodeStructsAsObjects)
 }
 
 // TestTagsSetInOfflineQuery tests that we set tags in

--- a/models.go
+++ b/models.go
@@ -76,6 +76,9 @@ type OnlineQueryParams struct {
 	// to `true` as well.
 	Explain bool
 
+	// EncodingOptions is used to specify how features should be encoded in the response.
+	EncodingOptions FeatureEncodingOptions
+
 	/**************
 	 PRIVATE FIELDS
 	***************/
@@ -751,4 +754,10 @@ type TokenResult struct {
 
 	// The GRPC endpoint for the engine.
 	Engines map[string]string `json:"engines"`
+}
+
+type FeatureEncodingOptions struct {
+	// If true, Chalk will return structs as objects
+	// instead of arrays in the response.
+	EncodeStructsAsObjects bool `json:"encode_structs_as_objects"`
 }

--- a/models.go
+++ b/models.go
@@ -77,7 +77,7 @@ type OnlineQueryParams struct {
 	Explain bool
 
 	// EncodingOptions is used to specify how features should be encoded in the response.
-	EncodingOptions FeatureEncodingOptions
+	EncodingOptions *FeatureEncodingOptions
 
 	/**************
 	 PRIVATE FIELDS

--- a/serializers.go
+++ b/serializers.go
@@ -56,6 +56,9 @@ func (p OnlineQueryParams) serialize() (*internal.OnlineQueryRequestSerialized, 
 		StorePlanStages:  p.StorePlanStages,
 		Now:              now,
 		Explain:          p.Explain,
+		EncodingOptions: internal.FeatureEncodingOptions{
+			EncodeStructsAsObjects: p.EncodingOptions.EncodeStructsAsObjects,
+		},
 	}, nil
 }
 

--- a/serializers.go
+++ b/serializers.go
@@ -41,6 +41,17 @@ func (p OnlineQueryParams) serialize() (*internal.OnlineQueryRequestSerialized, 
 		convertedInputs[fqn] = convertedValues
 	}
 
+	var encodingOptions internal.FeatureEncodingOptions
+	if p.EncodingOptions == nil {
+		encodingOptions = internal.FeatureEncodingOptions{
+			EncodeStructsAsObjects: false,
+		}
+	} else {
+		encodingOptions = internal.FeatureEncodingOptions{
+			EncodeStructsAsObjects: p.EncodingOptions.EncodeStructsAsObjects,
+		}
+	}
+
 	return &internal.OnlineQueryRequestSerialized{
 		Inputs:           convertedInputs,
 		Outputs:          p.outputs,
@@ -56,9 +67,7 @@ func (p OnlineQueryParams) serialize() (*internal.OnlineQueryRequestSerialized, 
 		StorePlanStages:  p.StorePlanStages,
 		Now:              now,
 		Explain:          p.Explain,
-		EncodingOptions: internal.FeatureEncodingOptions{
-			EncodeStructsAsObjects: p.EncodingOptions.EncodeStructsAsObjects,
-		},
+		EncodingOptions:  encodingOptions,
 	}, nil
 }
 


### PR DESCRIPTION
In #158 we made a change to support forward compatibility with deployments containing new features and dataclass fields. However, given the special case where structs are encoded as arrays, `OnlineQueryResult.UnmarshalInto` does not support this forward compatibility. 

Here we add the option to get dataclass features back as objects (structs) instead of arrays in `OnlineQuery`, thereby fully enabling forward compatibility with deployments containing new features. This encoding option will default to true in the future release of `chalk-go` `v1`. 

```
	params := chalk.OnlineQueryParams{
		EncodingOptions: &chalk.FeatureEncodingOptions{
			EncodeStructsAsObjects: true,
		},
	}.
        WithOutputs(
	        Features.User.FranchiseSet,
        ).
        WithInput(Features.User.Id, 1)
```



Further context on the limitation:
e.g. if we have
```
@dataclass
class LatLng:
  lat: float
  lng: float
  ```
which gets updated to
```
@dataclass
class LatLng:
  lat: float
  new_field: float
  lng: float
  ```
we could not accurately deserialize into
```
type LatLng struct{
   	Lat *float64 `dataclass_field:"true"`
	Lng *float64 
}
```
 if the result comes back as
```
[1.0, 2.0, 3.0]
```
