### PR TITLE
make FeatureResult.Timestamp pseudo-optional

### DIFF
--- a/models.go
+++ b/models.go
@@ -216,6 +216,8 @@ type FeatureResult struct {
 
 	// The time at which this feature was computed.
 	// This value could be significantly in the past if you're using caching.
+	// <<< NOTE >>> This value is nullable, and if it is null, it will be set
+	// to the zero value of `time.Time`.
 	Timestamp time.Time
 
 	// Detailed information about how this feature was computed.

--- a/serializers.go
+++ b/serializers.go
@@ -88,9 +88,13 @@ func serializeStaleness(staleness map[string]time.Duration) map[string]string {
 }
 
 func (feature featureResultSerialized) deserialize() (FeatureResult, error) {
-	timeObj, err := time.Parse(time.RFC3339, feature.Timestamp)
-	if err != nil {
-		return FeatureResult{}, err
+	var timeObj time.Time
+	if feature.Timestamp != "" {
+		parsed, err := time.Parse(time.RFC3339, feature.Timestamp)
+		if err != nil {
+			return FeatureResult{}, err
+		}
+		timeObj = parsed
 	}
 
 	var dError *ServerError = nil

--- a/serializers_test.go
+++ b/serializers_test.go
@@ -9,6 +9,34 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+func TestFeatureResultDeserialization(t *testing.T) {
+	withTimestamp := featureResultSerialized{
+		Field:     "user.id",
+		Value:     "1",
+		Pkey:      "1",
+		Timestamp: "2021-09-01T00:00:00Z",
+		Meta:      nil,
+		Error:     nil,
+	}
+	withoutTimestamp := featureResultSerialized{
+		Field:     "user.id",
+		Value:     "1",
+		Pkey:      "1",
+		Timestamp: "",
+		Meta:      nil,
+		Error:     nil,
+	}
+	tsResult, err := withTimestamp.deserialize()
+	assert.NoError(t, err)
+	assert.Equal(t, "user.id", tsResult.Field)
+	assert.Equal(t, time.Date(2021, 9, 1, 0, 0, 0, 0, time.UTC), tsResult.Timestamp)
+
+	noTsResult, err := withoutTimestamp.deserialize()
+	assert.NoError(t, err)
+	assert.Equal(t, "user.id", noTsResult.Field)
+	assert.Equal(t, time.Time{}, noTsResult.Timestamp)
+}
+
 func TestConvertOnlineQueryParamsToProto(t *testing.T) {
 	tags := []string{"tag1", "tag2"}
 	requiredResolverTags := []string{"tag3", "tag4"}


### PR DESCRIPTION
We can't make `FeatureResult.Timestamp` optional ala making it a pointer because that's a breaking change, so here we simply make it the zero value if the timestamp returned is an empty string. We'll make the breaking change when we release v1. 