### PR TITLE
serialize datetimes as arrow micro timestamps instead of nano

### DIFF
--- a/internal/feather.go
+++ b/internal/feather.go
@@ -67,7 +67,7 @@ func convertReflectToArrowType(value reflect.Type) (arrow.DataType, error) {
 	} else if kind == reflect.Struct {
 		if value == reflect.TypeOf(time.Time{}) {
 			return &arrow.TimestampType{
-				Unit:     arrow.Nanosecond,
+				Unit:     arrow.Microsecond,
 				TimeZone: "UTC",
 			}, nil
 		}
@@ -213,7 +213,7 @@ func setBuilderValues(builder array.Builder, slice reflect.Value, valid []bool) 
 			timeSlice := values.([]time.Time)
 			timestampSlice := make([]arrow.Timestamp, 0, len(timeSlice))
 			for _, t := range timeSlice {
-				timestampSlice = append(timestampSlice, arrow.Timestamp(t.UnixNano()))
+				timestampSlice = append(timestampSlice, arrow.Timestamp(t.UnixMicro()))
 			}
 			builder.(*array.TimestampBuilder).AppendValues(timestampSlice, valid)
 		} else {


### PR DESCRIPTION
This fixes a couple of integration tests. 

We recently made a change to the GRPC engine such that we error out if we provide nano timestamps. On the backend we will make the move to reject nano timestamps with a more user-understandable error. On the frontend we move towards serializing as micro, because we think nobody really needs the extra precision. 