### PR TITLE
skip deser if no scalar bytes

### DIFF
--- a/internal/tests/integration/fixtures.go
+++ b/internal/tests/integration/fixtures.go
@@ -87,10 +87,17 @@ type newGradAngelInvestor struct {
 	HowBroke *int64
 }
 
+type kindInvestor struct {
+	Id       *string
+	SeriesId *string
+	HowRich  *int64
+}
+
 type series struct {
-	Id        *string
-	Name      *string
-	Investors *[]newGradAngelInvestor `has_many:"id,series_id"`
+	Id                *string
+	Name              *string
+	Investors         *[]newGradAngelInvestor `has_many:"id,series_id"`
+	CrashingInvestors *[]kindInvestor         `has_many:"id,series_id"`
 }
 
 var testFeatures struct {

--- a/internal/tests/integration/grpc_bulk_test.go
+++ b/internal/tests/integration/grpc_bulk_test.go
@@ -69,7 +69,7 @@ func TestOnlineQueryGrpcErringScalar(t *testing.T) {
 	assert.NotNil(t, resp.Errors)
 }
 
-// TestOnlineQueryGrpcErringGroup tests requests with an erring has-many feature as the sole output
+// TestOnlineQueryGrpcErringHasMany tests requests with an erring has-many feature as the sole output
 func TestOnlineQueryGrpcErringHasMany(t *testing.T) {
 	SkipIfNotIntegrationTester(t)
 	if initFeaturesErr != nil {
@@ -85,4 +85,23 @@ func TestOnlineQueryGrpcErringHasMany(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp.Errors)
 	assert.Equal(t, len(resp.GetData().GetResults()), 0)
+}
+
+// TestOnlineQueryGrpcSoleHasManyOutput tests requests with a has-many feature as the sole output
+func TestOnlineQueryGrpcSoleHasManyOutput(t *testing.T) {
+	t.Skip("Has-many not yet supported in gRPC")
+	SkipIfNotIntegrationTester(t)
+	if initFeaturesErr != nil {
+		t.Fatal("Failed initializing features", initFeaturesErr)
+	}
+
+	client, err := chalk.NewGRPCClient()
+	assert.NoError(t, err)
+	params := chalk.OnlineQueryParams{}.
+		WithInput(testFeatures.Series.Id, "seed").
+		WithOutputs(testFeatures.Series.Investors)
+	resp, err := client.OnlineQuery(context.Background(), params)
+	assert.NoError(t, err)
+	assert.Nil(t, resp.Errors)
+	assert.Equal(t, len(resp.GetData().GetResults()), 1)
 }

--- a/internal/tests/integration/grpc_bulk_test.go
+++ b/internal/tests/integration/grpc_bulk_test.go
@@ -1,25 +1,33 @@
 package integration
 
 import (
+	"context"
 	"github.com/chalk-ai/chalk-go"
 	assert "github.com/stretchr/testify/require"
 	"testing"
 )
+
+var initFeaturesErr error
+
+func init() {
+	initFeaturesErr = chalk.InitFeatures(&testFeatures)
+}
 
 // TestOnlineQueryBulkGrpc mainly tests that a
 // gRPC bulk query works e2e. Correctness is
 // tested elsewhere.
 func TestOnlineQueryBulkGrpc(t *testing.T) {
 	SkipIfNotIntegrationTester(t)
+	if initFeaturesErr != nil {
+		t.Fatal("Failed initializing features", initFeaturesErr)
+	}
+
 	client, err := chalk.NewClient(&chalk.ClientConfig{UseGrpc: true})
 	if err != nil {
 		t.Fatal("Failed creating a Chalk Client", err)
 	}
 	userIds := []int64{1, 2}
-	err = chalk.InitFeatures(&testFeatures)
-	if err != nil {
-		t.Fatal("Failed initializing features", err)
-	}
+
 	req := chalk.OnlineQueryParams{}.
 		WithInput(testFeatures.User.Id, userIds).
 		WithOutputs(testFeatures.User.Id, testFeatures.User.SocureScore)
@@ -42,4 +50,39 @@ func TestOnlineQueryBulkGrpc(t *testing.T) {
 	assert.Equal(t, *users[1].Id, userIds[1])
 	assert.NotNil(t, users[1].SocureScore)
 	assert.Equal(t, *users[1].SocureScore, socureScore)
+}
+
+// TestOnlineQueryGrpcErringScalar tests requests with an erring scalar feature as the sole output
+func TestOnlineQueryGrpcErringScalar(t *testing.T) {
+	SkipIfNotIntegrationTester(t)
+	if initFeaturesErr != nil {
+		t.Fatal("Failed initializing features", initFeaturesErr)
+	}
+
+	client, err := chalk.NewGRPCClient()
+	assert.NoError(t, err)
+	params := chalk.OnlineQueryParams{}.
+		WithInput(testFeatures.User.Id, 1).
+		WithOutputs(testFeatures.User.CrashingFeature)
+	resp, err := client.OnlineQuery(context.Background(), params)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp.Errors)
+}
+
+// TestOnlineQueryGrpcErringGroup tests requests with an erring has-many feature as the sole output
+func TestOnlineQueryGrpcErringHasMany(t *testing.T) {
+	SkipIfNotIntegrationTester(t)
+	if initFeaturesErr != nil {
+		t.Fatal("Failed initializing features", initFeaturesErr)
+	}
+
+	client, err := chalk.NewGRPCClient()
+	assert.NoError(t, err)
+	params := chalk.OnlineQueryParams{}.
+		WithInput(testFeatures.Series.Id, 1).
+		WithOutputs(testFeatures.Series.CrashingInvestors)
+	resp, err := client.OnlineQuery(context.Background(), params)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp.Errors)
+	assert.Equal(t, len(resp.GetData().GetResults()), 0)
 }


### PR DESCRIPTION
A customer was reporting an error (see bottom) where scalar bytes returned was 0. Was not able to reproduce this by either:
1. requesting a crashing scalar as the sole output
2. requesting a crashing has-many as the sole output

But here we add tests for (1) and (2) and also skip deserialization if scalar bytes is empty. 


```
error converting scalars data to table: failed to create Arrow file reader: arrow/ipc: could not decode footer: arrow/ipc: file too small (size=0)
```