### PR TITLE
Bulk deser into structs with goroutines

### DIFF
--- a/internal/unmarshal.go
+++ b/internal/unmarshal.go
@@ -195,7 +195,7 @@ func extractFeatures(
 	}
 	chunkStartInt := int(chunkStart)
 	for i := chunkStartInt; i < chunkEndInt; i++ {
-		m := map[string]any{}
+		m := make(map[string]any, record.NumCols())
 		for j, col := range record.Columns() {
 			if colIndicesShouldSkip[j] {
 				continue

--- a/internal/unmarshal.go
+++ b/internal/unmarshal.go
@@ -188,7 +188,7 @@ func extractFeatures(
 	defer wg.Done()
 
 	var results []map[string]any
-	chunkEndInt, err := int64ToInt(chunkEnd)
+	chunkEndInt, err := Int64ToInt(chunkEnd)
 	if err != nil {
 		resChan <- ChunkResult{chunkIdx: chunkIdx, err: err}
 		return
@@ -280,12 +280,6 @@ func ExtractFeaturesFromTable(table arrow.Table) ([]map[string]any, error) {
 		}
 	}
 	return res, nil
-}
-
-func SliceAppend(slicePtr any, value reflect.Value) {
-	slicePtrValue := reflect.ValueOf(slicePtr)
-	sliceValue := slicePtrValue.Elem()
-	sliceValue.Set(reflect.Append(sliceValue, value))
 }
 
 func ReflectPtr(value reflect.Value) reflect.Value {

--- a/internal/unmarshal.go
+++ b/internal/unmarshal.go
@@ -17,7 +17,7 @@ import (
 )
 
 var tableReaderChunkSizeKey = "CHALK_TABLE_READER_CHUNK_SIZE"
-var defaultTableReaderChunkSize = 500_000
+var defaultTableReaderChunkSize = 10_000
 
 var tableReaderChunkSize = defaultTableReaderChunkSize
 

--- a/internal/unmarshal.go
+++ b/internal/unmarshal.go
@@ -16,8 +16,9 @@ import (
 	"time"
 )
 
-var tableReaderChunkSizeKey = "CHALK_TABLE_READER_CHUNK_SIZE"
-var defaultTableReaderChunkSize = 10_000
+const tableReaderChunkSizeKey = "CHALK_TABLE_READER_CHUNK_SIZE"
+
+const defaultTableReaderChunkSize = 10_000
 
 var tableReaderChunkSize = defaultTableReaderChunkSize
 

--- a/internal/unmarshal.go
+++ b/internal/unmarshal.go
@@ -7,14 +7,27 @@ import (
 	"github.com/chalk-ai/chalk-go/internal/colls"
 	"github.com/chalk-ai/chalk-go/internal/ptr"
 	"github.com/cockroachdb/errors"
+	"os"
 	"reflect"
 	"runtime"
 	"sort"
+	"strconv"
 	"sync"
 	"time"
 )
 
-var tableReaderChunkSize = 10_000
+var tableReaderChunkSizeKey = "CHALK_TABLE_READER_CHUNK_SIZE"
+var defaultTableReaderChunkSize = 500_000
+
+var tableReaderChunkSize = defaultTableReaderChunkSize
+
+func init() {
+	if chunkSizeStr := os.Getenv(tableReaderChunkSizeKey); chunkSizeStr != "" {
+		if newChunkSize, err := strconv.Atoi(chunkSizeStr); err == nil {
+			tableReaderChunkSize = newChunkSize
+		}
+	}
+}
 
 type Numbers interface {
 	int | int8 | int16 | int32 | int64 | uint8 | uint16 | uint32 | uint64 | float32 | float64

--- a/internal/unmarshal.go
+++ b/internal/unmarshal.go
@@ -217,7 +217,11 @@ func extractFeatures(
 }
 
 func ExtractFeaturesFromTable(table arrow.Table) ([]map[string]any, error) {
-	res := make([]map[string]any, 0)
+	numRows, err := Int64ToInt(table.NumRows())
+	if err != nil {
+		return nil, errors.Wrapf(err, "table too large, found %d rows", table.NumRows())
+	}
+	res := make([]map[string]any, 0, numRows)
 	reader := array.NewTableReader(table, int64(tableReaderChunkSize))
 	defer reader.Release()
 

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/chalk-ai/chalk-go/internal/colls"
 	"github.com/cockroachdb/errors"
+	"math"
 	"os"
 	"reflect"
 	"regexp"
@@ -100,6 +101,14 @@ func getFeatureNameFromFqn(fqn string) string {
 
 func getFqnRoot(s string) string {
 	return strings.Split(s, ".")[0]
+}
+
+func int64ToInt(value int64) (int, error) {
+	// Check if the value fits in the range of an int
+	if value < math.MinInt || value > math.MaxInt {
+		return 0, errors.New("value out of range for int conversion")
+	}
+	return int(value), nil
 }
 
 // ChalkpySnakeCase aims to be in parity with

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -103,7 +103,7 @@ func getFqnRoot(s string) string {
 	return strings.Split(s, ".")[0]
 }
 
-func int64ToInt(value int64) (int, error) {
+func Int64ToInt(value int64) (int, error) {
 	// Check if the value fits in the range of an int
 	if value < math.MinInt || value > math.MaxInt {
 		return 0, errors.New("value out of range for int conversion")

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -129,27 +129,18 @@ type ChunkResult struct {
 func unmarshalRows(
 	rows []map[string]any,
 	typ reflect.Type,
-	namespace string,
-	namespaceScope *scopeTrie,
-	namespaceMemoItem *internal.NamespaceMemoItem,
-	namespaceMemo internal.NamespaceMemo,
+	scope *scopeTrie,
+	memo internal.NamespaceMemo,
 	chunkIdx int,
 	resChan chan<- ChunkResult,
 	wg *sync.WaitGroup,
 ) {
 	defer wg.Done()
+
 	var results []reflect.Value
 	for _, row := range rows {
 		res := reflect.New(typ)
-		if err := thinUnmarshalInto(
-			res,
-			row,
-			namespace,
-			nil,
-			namespaceScope,
-			namespaceMemoItem,
-			namespaceMemo,
-		); err != nil {
+		if err := innerUnmarshalInto(res.Interface(), row, nil, scope, memo); err != nil {
 			resChan <- ChunkResult{chunkIdx: chunkIdx, err: err}
 			return
 		}
@@ -217,25 +208,6 @@ func unmarshalTableInto(table arrow.Table, resultHolders any) (returnErr error) 
 		return errors.Wrap(err, "building namespace memo")
 	}
 
-	structName := sliceElemType.Name()
-	namespace := SnakeCase(structName)
-	nsScope := scope.children[namespace]
-	if nsScope == nil {
-		return &ClientError{
-			errors.Newf(
-				"Attempted to unmarshal into the feature struct '%s', "+
-					"but results are from these feature class(es) '%v'",
-				structName,
-				colls.Keys(scope.children),
-			).Error(),
-		}
-	}
-
-	nsMemo, ok := memo[structName]
-	if !ok {
-		return &ClientError{errors.Newf("namespace '%s' not found in memo", structName).Error()}
-	}
-
 	var wg sync.WaitGroup
 	numWorkers := runtime.NumCPU()
 	resChan := make(chan ChunkResult, numWorkers)
@@ -245,17 +217,7 @@ func unmarshalTableInto(table arrow.Table, resultHolders any) (returnErr error) 
 	for chunkPtr := 0; chunkPtr < len(rows); chunkPtr += chunkSize {
 		chunkRows := rows[chunkPtr:min(chunkPtr+chunkSize, len(rows))]
 		wg.Add(1)
-		go unmarshalRows(
-			chunkRows,
-			sliceElemType,
-			namespace,
-			nsScope,
-			nsMemo,
-			memo,
-			chunkIdx,
-			resChan,
-			&wg,
-		)
+		go unmarshalRows(chunkRows, sliceElemType, scope, memo, chunkIdx, resChan, &wg)
 		chunkIdx += 1
 	}
 
@@ -353,9 +315,11 @@ func UnmarshalInto(resultHolder any, fqnToValue map[Fqn]any, expectedOutputs []s
 			errors.Wrap(err, "error building scope for initializing result holder struct").Error(),
 		}
 	}
-
-	holderValue := reflect.ValueOf(resultHolder)
-	structName := holderValue.Elem().Type().Name()
+	return innerUnmarshalInto(resultHolder, fqnToValue, expectedOutputs, scope, memo)
+}
+func innerUnmarshalInto(resultHolder any, fqnToValue map[Fqn]any, expectedOutputs []string, scope *scopeTrie, memo internal.NamespaceMemo) (returnErr *ClientError) {
+	structValue := reflect.ValueOf(resultHolder).Elem()
+	structName := structValue.Type().Name()
 	namespace := SnakeCase(structName)
 	nsScope := scope.children[namespace]
 	if nsScope == nil {
@@ -369,46 +333,22 @@ func UnmarshalInto(resultHolder any, fqnToValue map[Fqn]any, expectedOutputs []s
 		}
 	}
 
-	nsMemo, ok := memo[structName]
-	if !ok {
-		return &ClientError{errors.Newf("namespace '%s' not found in memo", structName).Error()}
-	}
-
-	return thinUnmarshalInto(
-		holderValue,
-		fqnToValue,
-		namespace,
-		expectedOutputs,
-		nsScope,
-		nsMemo,
-		memo,
-	)
-}
-
-// thinUnmarshalInto is called per row. Any operation that can be
-// done outside of this function must be done outside of this function.
-func thinUnmarshalInto(
-	resultHolder reflect.Value,
-	fqnToValue map[Fqn]any,
-	namespace string,
-	expectedOutputs []string,
-	namespaceScope *scopeTrie,
-	namespaceMemoItem *internal.NamespaceMemoItem,
-	namespaceMemo internal.NamespaceMemo,
-) (returnErr *ClientError) {
-	structValue := resultHolder.Elem()
-
 	remoteFeatureMap := map[string][]reflect.Value{}
 	if err := initRemoteFeatureMap(
 		remoteFeatureMap,
 		structValue,
 		namespace,
 		map[string]bool{},
-		namespaceScope,
-		namespaceMemo,
+		nsScope,
+		memo,
 		true,
 	); err != nil {
 		return &ClientError{errors.Wrap(err, "error initializing result holder struct").Error()}
+	}
+
+	nsMemo, ok := memo[structName]
+	if !ok {
+		return &ClientError{errors.Newf("namespace '%s' not found in memo", structName).Error()}
 	}
 
 	for fqn, value := range fqnToValue {
@@ -421,7 +361,7 @@ func thinUnmarshalInto(
 		targetFields, ok := remoteFeatureMap[fqn]
 		if !ok {
 			// If not a has-one remote feature, e.g. user.account.balance
-			fieldIndices, ok := namespaceMemoItem.ResolvedFieldNameToIndices[fqn]
+			fieldIndices, ok := nsMemo.ResolvedFieldNameToIndices[fqn]
 			if !ok {
 				// For forward compatibility, i.e. when clients add
 				// more fields to their dataclasses in chalkpy, we want
@@ -436,7 +376,7 @@ func thinUnmarshalInto(
 		}
 
 		for _, field := range targetFields {
-			if err := setFeatureSingle(field, fqn, value, namespaceMemo); err != nil {
+			if err := setFeatureSingle(field, fqn, value, memo); err != nil {
 				structName := structValue.Type().String()
 				outputNamespace := "unknown namespace"
 				sections := strings.Split(fqn, ".")

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -137,14 +137,14 @@ func unmarshalRows(
 ) {
 	defer wg.Done()
 
-	var results []reflect.Value
-	for _, row := range rows {
+	results := make([]reflect.Value, len(rows))
+	for rowIdx, row := range rows {
 		res := reflect.New(typ)
 		if err := innerUnmarshalInto(res.Interface(), row, nil, scope, memo); err != nil {
 			resChan <- ChunkResult{chunkIdx: chunkIdx, err: err}
 			return
 		}
-		results = append(results, res.Elem())
+		results[rowIdx] = res.Elem()
 	}
 	resChan <- ChunkResult{chunkIdx: chunkIdx, rows: results}
 }

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -129,18 +129,27 @@ type ChunkResult struct {
 func unmarshalRows(
 	rows []map[string]any,
 	typ reflect.Type,
-	scope *scopeTrie,
-	memo internal.NamespaceMemo,
+	namespace string,
+	namespaceScope *scopeTrie,
+	namespaceMemoItem *internal.NamespaceMemoItem,
+	namespaceMemo internal.NamespaceMemo,
 	chunkIdx int,
 	resChan chan<- ChunkResult,
 	wg *sync.WaitGroup,
 ) {
 	defer wg.Done()
-
 	results := make([]reflect.Value, len(rows))
 	for rowIdx, row := range rows {
 		res := reflect.New(typ)
-		if err := innerUnmarshalInto(res.Interface(), row, nil, scope, memo); err != nil {
+		if err := thinUnmarshalInto(
+			res,
+			row,
+			namespace,
+			nil,
+			namespaceScope,
+			namespaceMemoItem,
+			namespaceMemo,
+		); err != nil {
 			resChan <- ChunkResult{chunkIdx: chunkIdx, err: err}
 			return
 		}
@@ -213,6 +222,25 @@ func unmarshalTableInto(table arrow.Table, resultHolders any) (returnErr error) 
 		return errors.Wrap(err, "building namespace memo")
 	}
 
+	structName := sliceElemType.Name()
+	namespace := SnakeCase(structName)
+	nsScope := scope.children[namespace]
+	if nsScope == nil {
+		return &ClientError{
+			errors.Newf(
+				"Attempted to unmarshal into the feature struct '%s', "+
+					"but results are from these feature class(es) '%v'",
+				structName,
+				colls.Keys(scope.children),
+			).Error(),
+		}
+	}
+
+	nsMemo, ok := memo[structName]
+	if !ok {
+		return &ClientError{errors.Newf("namespace '%s' not found in memo", structName).Error()}
+	}
+
 	var wg sync.WaitGroup
 	numWorkers := runtime.NumCPU()
 	resChan := make(chan ChunkResult, numWorkers)
@@ -222,7 +250,17 @@ func unmarshalTableInto(table arrow.Table, resultHolders any) (returnErr error) 
 	for chunkPtr := 0; chunkPtr < len(rows); chunkPtr += chunkSize {
 		chunkRows := rows[chunkPtr:min(chunkPtr+chunkSize, len(rows))]
 		wg.Add(1)
-		go unmarshalRows(chunkRows, sliceElemType, scope, memo, chunkIdx, resChan, &wg)
+		go unmarshalRows(
+			chunkRows,
+			sliceElemType,
+			namespace,
+			nsScope,
+			nsMemo,
+			memo,
+			chunkIdx,
+			resChan,
+			&wg,
+		)
 		chunkIdx += 1
 	}
 
@@ -324,11 +362,9 @@ func UnmarshalInto(resultHolder any, fqnToValue map[Fqn]any, expectedOutputs []s
 			errors.Wrap(err, "error building scope for initializing result holder struct").Error(),
 		}
 	}
-	return innerUnmarshalInto(resultHolder, fqnToValue, expectedOutputs, scope, memo)
-}
-func innerUnmarshalInto(resultHolder any, fqnToValue map[Fqn]any, expectedOutputs []string, scope *scopeTrie, memo internal.NamespaceMemo) (returnErr *ClientError) {
-	structValue := reflect.ValueOf(resultHolder).Elem()
-	structName := structValue.Type().Name()
+
+	holderValue := reflect.ValueOf(resultHolder)
+	structName := holderValue.Elem().Type().Name()
 	namespace := SnakeCase(structName)
 	nsScope := scope.children[namespace]
 	if nsScope == nil {
@@ -342,22 +378,46 @@ func innerUnmarshalInto(resultHolder any, fqnToValue map[Fqn]any, expectedOutput
 		}
 	}
 
+	nsMemo, ok := memo[structName]
+	if !ok {
+		return &ClientError{errors.Newf("namespace '%s' not found in memo", structName).Error()}
+	}
+
+	return thinUnmarshalInto(
+		holderValue,
+		fqnToValue,
+		namespace,
+		expectedOutputs,
+		nsScope,
+		nsMemo,
+		memo,
+	)
+}
+
+// thinUnmarshalInto is called per row. Any operation that can be
+// done outside of this function must be done outside of this function.
+func thinUnmarshalInto(
+	resultHolder reflect.Value,
+	fqnToValue map[Fqn]any,
+	namespace string,
+	expectedOutputs []string,
+	namespaceScope *scopeTrie,
+	namespaceMemoItem *internal.NamespaceMemoItem,
+	namespaceMemo internal.NamespaceMemo,
+) (returnErr *ClientError) {
+	structValue := resultHolder.Elem()
+
 	remoteFeatureMap := map[string][]reflect.Value{}
 	if err := initRemoteFeatureMap(
 		remoteFeatureMap,
 		structValue,
 		namespace,
 		map[string]bool{},
-		nsScope,
-		memo,
+		namespaceScope,
+		namespaceMemo,
 		true,
 	); err != nil {
 		return &ClientError{errors.Wrap(err, "error initializing result holder struct").Error()}
-	}
-
-	nsMemo, ok := memo[structName]
-	if !ok {
-		return &ClientError{errors.Newf("namespace '%s' not found in memo", structName).Error()}
 	}
 
 	for fqn, value := range fqnToValue {
@@ -370,7 +430,7 @@ func innerUnmarshalInto(resultHolder any, fqnToValue map[Fqn]any, expectedOutput
 		targetFields, ok := remoteFeatureMap[fqn]
 		if !ok {
 			// If not a has-one remote feature, e.g. user.account.balance
-			fieldIndices, ok := nsMemo.ResolvedFieldNameToIndices[fqn]
+			fieldIndices, ok := namespaceMemoItem.ResolvedFieldNameToIndices[fqn]
 			if !ok {
 				// For forward compatibility, i.e. when clients add
 				// more fields to their dataclasses in chalkpy, we want
@@ -385,7 +445,7 @@ func innerUnmarshalInto(resultHolder any, fqnToValue map[Fqn]any, expectedOutput
 		}
 
 		for _, field := range targetFields {
-			if err := setFeatureSingle(field, fqn, value, memo); err != nil {
+			if err := setFeatureSingle(field, fqn, value, namespaceMemo); err != nil {
 				structName := structValue.Type().String()
 				outputNamespace := "unknown namespace"
 				sections := strings.Split(fqn, ".")

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -1286,7 +1286,7 @@ func TestBulkUnmarshalExtraFeatures(t *testing.T) {
 }
 
 /*
-TestBenchmarkListOfStructsUnmarshal prints the time it takes to unmarshal a list of structs that appear as:
+TestBenchmarkListOfStructsUnmarshal prints the time it takes to unmarshal the same list of structs that appear as:
 1. a has-many feature
 2. a list of root feature classes
 */

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -1334,6 +1334,7 @@ func TestBenchmarkListOfStructsUnmarshal(t *testing.T) {
 	t.Logf("unmarshalled as has-many elapsed: %v", elapsed)
 	assert.Equal(t, 1, len(resultUser))
 	assert.NotNil(t, resultUser[0].Txns)
+	assert.Equal(t, len(transactions), len(*resultUser[0].Txns))
 	assert.Equal(t, transactions, *resultUser[0].Txns)
 
 	transactionFqnsToValue := map[string]any{
@@ -1388,5 +1389,6 @@ func TestBenchmarkListOfStructsUnmarshal(t *testing.T) {
 	}
 	elapsed = time.Since(start)
 	t.Logf("unmarshalled as bulk rows elapsed: %v", elapsed)
+	assert.Equal(t, len(transactions), len(resultTransaction))
 	assert.Equal(t, transactions, resultTransaction)
 }

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -1332,6 +1332,9 @@ func TestBenchmarkListOfStructsUnmarshal(t *testing.T) {
 	}
 	elapsed := time.Since(start)
 	t.Logf("unmarshalled as has-many elapsed: %v", elapsed)
+	assert.Equal(t, 1, len(resultUser))
+	assert.NotNil(t, resultUser[0].Txns)
+	assert.Equal(t, transactions, *resultUser[0].Txns)
 
 	transactionFqnsToValue := map[string]any{
 		"unmarshal_transaction.id":                        []string{},
@@ -1385,4 +1388,5 @@ func TestBenchmarkListOfStructsUnmarshal(t *testing.T) {
 	}
 	elapsed = time.Since(start)
 	t.Logf("unmarshalled as bulk rows elapsed: %v", elapsed)
+	assert.Equal(t, transactions, resultTransaction)
 }

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -1285,7 +1285,12 @@ func TestBulkUnmarshalExtraFeatures(t *testing.T) {
 	}
 }
 
-func TestBenchmarkHasManyUnmarshal(t *testing.T) {
+/*
+TestBenchmarkListOfStructsUnmarshal prints the time it takes to unmarshal a list of structs that appear as:
+1. a has-many feature
+2. a list of root feature classes
+*/
+func TestBenchmarkListOfStructsUnmarshal(t *testing.T) {
 	// TODO: Make this an actual benchmark
 	var transactions []unmarshalTransaction
 	for i := 0; i < 100_000; i++ {


### PR DESCRIPTION
Use goroutines to parallelize `ExtractFeaturesFromTable` and `UnmarshalInto`. For the test `TestBenchmarkListOfStructsUnmarshal`, bulk unmarshal went from taking ~500ms to ~100ms