### PR TITLE
Add the correct chalkpy snake-case function

### DIFF
--- a/init_features.go
+++ b/init_features.go
@@ -370,5 +370,5 @@ func pointerCheck(field reflect.Value) error {
 }
 
 func SnakeCase(s string) string {
-	return internal.ChalkpySnakeCase(s)
+	return internal.LegacySnakeCase(s)
 }

--- a/init_features_internal_test.go
+++ b/init_features_internal_test.go
@@ -1,6 +1,7 @@
 package chalk
 
 import (
+	"github.com/chalk-ai/chalk-go/internal"
 	assert "github.com/stretchr/testify/require"
 	"testing"
 )
@@ -90,10 +91,10 @@ func TestUnmarshal(t *testing.T) {
 	assert.Nil(t, user.Card.Number)
 }
 
-// TestSnakeCase serves as a unit test.
+// TestLegacySnakeCase serves as a unit test.
 // We should also add all test cases here
 // to the integration test in `init_features_test.go`.
-func TestSnakeCase(t *testing.T) {
+func TestLegacySnakeCase(t *testing.T) {
 	testCases := []struct {
 		input    string
 		expected string
@@ -121,5 +122,28 @@ func TestSnakeCase(t *testing.T) {
 				t.Errorf("SnakeCase(%q) = %q, expected to fail", tc.input, result)
 			}
 		})
+	}
+}
+
+// TestChalkpySnakeCase aims to have to same test cases as chalkpy's snake case function.
+func TestChalkpySnakeCase(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		// Aims to be the exact same test cases as chalkpy's snake case function.
+		{"SEGMENT_ID_HASH", "segment_id_hash"},
+		{"accountId", "account_id"},
+		{"account_id", "account_id"},
+		{"foo", "foo"},
+		{"FOO", "foo"},
+		{"FooBar", "foo_bar"},
+	}
+
+	for _, test := range tests {
+		result := internal.ChalkpySnakeCase(test.input)
+		if result != test.expected {
+			t.Errorf("chalkpySnakeCase(%q) = %q; want %q", test.input, result, test.expected)
+		}
 	}
 }

--- a/internal/feather.go
+++ b/internal/feather.go
@@ -71,7 +71,7 @@ func convertReflectToArrowType(value reflect.Type) (arrow.DataType, error) {
 			}, nil
 		}
 		var arrowFields []arrow.Field
-		structName := LegacySnakeCase(value.Name())
+		namespace := ChalkpySnakeCase(value.Name())
 		isFeaturesClass := IsFeaturesClass(value)
 		for i := 0; i < value.NumField(); i++ {
 			field := value.Field(i)
@@ -88,7 +88,7 @@ func convertReflectToArrowType(value reflect.Type) (arrow.DataType, error) {
 				return nil, errors.Wrapf(err, "failed to resolve feature name for struct field '%d'", i)
 			}
 			if isFeaturesClass {
-				resolved = structName + "." + resolved
+				resolved = namespace + "." + resolved
 			}
 			arrowFields = append(arrowFields, arrow.Field{
 				Name:     resolved,
@@ -247,7 +247,7 @@ func setBuilderValues(builder array.Builder, slice reflect.Value, valid []bool) 
 				)
 			}
 
-			structName := LegacySnakeCase(elemType.Name())
+			namespace := ChalkpySnakeCase(elemType.Name())
 			isFeaturesClass := IsFeaturesClass(elemType)
 			for i := 0; i < numFieldsReflect; i++ {
 				resolved, err := ResolveFeatureName(elemType.Field(i))
@@ -255,7 +255,7 @@ func setBuilderValues(builder array.Builder, slice reflect.Value, valid []bool) 
 					return errors.Wrapf(err, "failed to resolve feature name for struct field '%d'", i)
 				}
 				if isFeaturesClass {
-					resolved = structName + "." + resolved
+					resolved = namespace + "." + resolved
 				}
 				namesReflect = append(namesReflect, resolved)
 				namesArrow = append(namesArrow, arrowStructType.Field(i).Name)

--- a/internal/feather.go
+++ b/internal/feather.go
@@ -71,7 +71,7 @@ func convertReflectToArrowType(value reflect.Type) (arrow.DataType, error) {
 			}, nil
 		}
 		var arrowFields []arrow.Field
-		structName := ChalkpySnakeCase(value.Name())
+		structName := LegacySnakeCase(value.Name())
 		isFeaturesClass := IsFeaturesClass(value)
 		for i := 0; i < value.NumField(); i++ {
 			field := value.Field(i)
@@ -247,7 +247,7 @@ func setBuilderValues(builder array.Builder, slice reflect.Value, valid []bool) 
 				)
 			}
 
-			structName := ChalkpySnakeCase(elemType.Name())
+			structName := LegacySnakeCase(elemType.Name())
 			isFeaturesClass := IsFeaturesClass(elemType)
 			for i := 0; i < numFieldsReflect; i++ {
 				resolved, err := ResolveFeatureName(elemType.Field(i))

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -115,9 +115,9 @@ func Int64ToInt(value int64) (int, error) {
 // We are supposed to use this in all places over LegacySnakeCase, but that's a breaking
 // change because our CLI generates the `name` struct tag if and only if the snake case
 // generated using LegacySnakeCase does not match the actual feature name. If we switch to
-// using ChalkpySnakeCase, that would make old codegen code incompatible with new chalk-go
-// versions, and vice-versa. In short, we want to keep using LegacySnakeCase in chalk-go
-// to snake-case field names, and ChalkpySnakeCase to snake-case struct names.
+// using ChalkpySnakeCase, that would make new codegen code incompatible with old chalk-go
+// versions. In short, we want to keep using LegacySnakeCase in chalk-go to snake-case
+// field names, and ChalkpySnakeCase to snake-case struct names.
 func ChalkpySnakeCase(s string) string {
 	re1 := regexp.MustCompile(`(.)([A-Z][a-z]+)`)
 	s = re1.ReplaceAllString(s, "${1}_${2}")
@@ -135,10 +135,9 @@ func ChalkpySnakeCase(s string) string {
 // should be using ChalkpySnakeCase, but we can't change it now because it would break existing
 // codegen customers. Using this in our CLI to convert struct field names to snake case
 // is still correct because if it does not correctly match the feature name, it generates
-// the `name` struct tag. If we switch to using ChalkpySnakeCase, that would make old codegen
-// code incompatible with new chalk-go versions, and vice-versa. In short, we want to keep
-// using LegacySnakeCase in chalk-go to snake-case field names, and ChalkpySnakeCase to
-// snake-case struct names.
+// the `name` struct tag. If we switch to using ChalkpySnakeCase, that would make new codegen
+// code incompatible with old chalk-go versions. In short, we want to keep using LegacySnakeCase
+// in chalk-go to snake-case field names, and ChalkpySnakeCase to snake-case struct names.
 func LegacySnakeCase(s string) string {
 	var b []byte
 	for i := 0; i < len(s); i++ {

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -18,6 +18,10 @@ var ChalkTag = "chalk"
 
 var NowTimeFormat = "2006-01-02T15:04:05.000000-07:00"
 
+var wordGroupsPattern = regexp.MustCompile(`(.)([A-Z][a-z]+)`)
+var dunderPattern = regexp.MustCompile(`__([A-Z])`)
+var trailingUpperPattern = regexp.MustCompile(`([a-z0-9])([A-Z])`)
+
 func FileExists(path string) bool {
 	if _, err := os.Stat(path); err != nil {
 		return false
@@ -119,15 +123,9 @@ func Int64ToInt(value int64) (int, error) {
 // versions. In short, we want to keep using LegacySnakeCase in chalk-go to snake-case
 // field names, and ChalkpySnakeCase to snake-case struct names.
 func ChalkpySnakeCase(s string) string {
-	re1 := regexp.MustCompile(`(.)([A-Z][a-z]+)`)
-	s = re1.ReplaceAllString(s, "${1}_${2}")
-
-	re2 := regexp.MustCompile(`__([A-Z])`)
-	s = re2.ReplaceAllString(s, "_${1}")
-
-	re3 := regexp.MustCompile(`([a-z0-9])([A-Z])`)
-	s = re3.ReplaceAllString(s, "${1}_${2}")
-
+	s = wordGroupsPattern.ReplaceAllString(s, "${1}_${2}")
+	s = dunderPattern.ReplaceAllString(s, "_${1}")
+	s = trailingUpperPattern.ReplaceAllString(s, "${1}_${2}")
 	return strings.ToLower(s)
 }
 

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -298,7 +298,7 @@ func SingleInputsToBulkInputs(singleInputs map[string]any) (map[string]any, erro
 func getFieldToPythonName(structType reflect.Type) (map[string]string, error) {
 	isDataclass := IsTypeDataclass(structType)
 	res := make(map[string]string)
-	namespace := LegacySnakeCase(structType.Name())
+	namespace := ChalkpySnakeCase(structType.Name())
 	for i := 0; i < structType.NumField(); i++ {
 		pythonName, err := ResolveFeatureName(structType.Field(i))
 		if err != nil {

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -113,10 +113,11 @@ func Int64ToInt(value int64) (int, error) {
 
 // ChalkpySnakeCase aims to be in parity with our Python implementation of snake_case.
 // We are supposed to use this in all places over LegacySnakeCase, but that's a breaking
-// change because our CLI generates the `name` struct tag if and only if the snake case generated
-// using LegacySnakeCase does not match the actual feature name. If we switch to using
-// ChalkpySnakeCase, that would make old codegen code incompatible with new chalk-go versions,
-// and vice-versa.
+// change because our CLI generates the `name` struct tag if and only if the snake case
+// generated using LegacySnakeCase does not match the actual feature name. If we switch to
+// using ChalkpySnakeCase, that would make old codegen code incompatible with new chalk-go
+// versions, and vice-versa. In short, we want to keep using LegacySnakeCase in chalk-go
+// to snake-case field names, and ChalkpySnakeCase to snake-case struct names.
 func ChalkpySnakeCase(s string) string {
 	re1 := regexp.MustCompile(`(.)([A-Z][a-z]+)`)
 	s = re1.ReplaceAllString(s, "${1}_${2}")
@@ -135,7 +136,9 @@ func ChalkpySnakeCase(s string) string {
 // codegen customers. Using this in our CLI to convert struct field names to snake case
 // is still correct because if it does not correctly match the feature name, it generates
 // the `name` struct tag. If we switch to using ChalkpySnakeCase, that would make old codegen
-// code incompatible with new chalk-go versions, and vice-versa.
+// code incompatible with new chalk-go versions, and vice-versa. In short, we want to keep
+// using LegacySnakeCase in chalk-go to snake-case field names, and ChalkpySnakeCase to
+// snake-case struct names.
 func LegacySnakeCase(s string) string {
 	var b []byte
 	for i := 0; i < len(s); i++ {

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -115,7 +115,8 @@ func Int64ToInt(value int64) (int, error) {
 // We are supposed to use this in all places over LegacySnakeCase, but that's a breaking
 // change because our CLI generates the `name` struct tag if and only if the snake case generated
 // using LegacySnakeCase does not match the actual feature name. If we switch to using
-// ChalkpySnakeCase, that would make old codegen code incompatible with new chalk-go versions.
+// ChalkpySnakeCase, that would make old codegen code incompatible with new chalk-go versions,
+// and vice-versa.
 func ChalkpySnakeCase(s string) string {
 	re1 := regexp.MustCompile(`(.)([A-Z][a-z]+)`)
 	s = re1.ReplaceAllString(s, "${1}_${2}")
@@ -134,7 +135,7 @@ func ChalkpySnakeCase(s string) string {
 // codegen customers. Using this in our CLI to convert struct field names to snake case
 // is still correct because if it does not correctly match the feature name, it generates
 // the `name` struct tag. If we switch to using ChalkpySnakeCase, that would make old codegen
-// code incompatible with new chalk-go versions.
+// code incompatible with new chalk-go versions, and vice-versa.
 func LegacySnakeCase(s string) string {
 	var b []byte
 	for i := 0; i < len(s); i++ {

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -223,7 +223,7 @@ func unmarshalTableInto(table arrow.Table, resultHolders any) (returnErr error) 
 	}
 
 	structName := sliceElemType.Name()
-	namespace := SnakeCase(structName)
+	namespace := internal.ChalkpySnakeCase(structName)
 	nsScope := scope.children[namespace]
 	if nsScope == nil {
 		return &ClientError{
@@ -365,7 +365,7 @@ func UnmarshalInto(resultHolder any, fqnToValue map[Fqn]any, expectedOutputs []s
 
 	holderValue := reflect.ValueOf(resultHolder)
 	structName := holderValue.Elem().Type().Name()
-	namespace := SnakeCase(structName)
+	namespace := internal.ChalkpySnakeCase(structName)
 	nsScope := scope.children[namespace]
 	if nsScope == nil {
 		return &ClientError{

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -35,7 +35,7 @@ type unmarshalTransaction struct {
 	FeatureWithLongName13 *string
 }
 
-type unmarshalLatLng struct {
+type unmarshalLatLNG struct {
 	Lat *float64 `dataclass_field:"true"`
 	Lng *float64 `dataclass_field:"true"`
 }
@@ -54,7 +54,7 @@ type unmarshalUser struct {
 	AvgSpend map[string]*float64 `windows:"1m,5m,1h"`
 
 	// Dataclass features
-	LatLng *unmarshalLatLng
+	LatLng *unmarshalLatLNG
 
 	// Has-many features
 	Txns *[]unmarshalTransaction

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -40,7 +40,7 @@ type unmarshalLatLNG struct {
 	Lng *float64 `dataclass_field:"true"`
 }
 
-type unmarshalUser struct {
+type unmarshalUSER struct {
 	Id *string
 
 	Int *int64
@@ -344,7 +344,7 @@ func TestUnmarshalVersionedFeatures(t *testing.T) {
 		features:        nil,
 		expectedOutputs: nil,
 	}
-	user := unmarshalUser{}
+	user := unmarshalUSER{}
 	unmarshalErr := result.UnmarshalInto(&user)
 	if unmarshalErr != nil {
 		t.Fatal(unmarshalErr)
@@ -388,7 +388,7 @@ func TestUnmarshalWindowedFeatures(t *testing.T) {
 		features:        nil,
 		expectedOutputs: nil,
 	}
-	user := unmarshalUser{}
+	user := unmarshalUSER{}
 	unmarshalErr := result.UnmarshalInto(&user)
 	if unmarshalErr != nil {
 		t.Fatal(unmarshalErr)
@@ -416,7 +416,7 @@ func TestUnmarshalDataclassFeatures(t *testing.T) {
 		features:        nil,
 		expectedOutputs: nil,
 	}
-	user := unmarshalUser{}
+	user := unmarshalUSER{}
 	unmarshalErr := result.UnmarshalInto(&user)
 	if unmarshalErr != nil {
 		t.Fatal(unmarshalErr)
@@ -444,7 +444,7 @@ func TestUnmarshalWrongType(t *testing.T) {
 		features:        nil,
 		expectedOutputs: nil,
 	}
-	user := unmarshalUser{}
+	user := unmarshalUSER{}
 	unmarshalErr := result.UnmarshalInto(&user)
 	if unmarshalErr == nil {
 		fmt.Println("We successfully unmarshalled the wrong type into a struct field - the value is: ", *user.Int)
@@ -1324,7 +1324,7 @@ func TestBenchmarkListOfStructsUnmarshal(t *testing.T) {
 		ScalarsTable: table,
 	}
 	defer bulkRes.Release()
-	var resultUser []unmarshalUser
+	var resultUser []unmarshalUSER
 
 	start := time.Now()
 	if err = bulkRes.UnmarshalInto(&resultUser); err != (*ClientError)(nil) {


### PR DESCRIPTION
Introduces a snake-casing function that's in parity with chalkpy. This fixes a bug where a customer has a struct whose name is incorrectly snake-cased into a namespace string. We want to use this chalkpy snake-caser for converting struct names, but keep using the legacy snake-caser for converting field names to maintain back-compat