### PR TITLE
[unmarshaller] Fix concurrent map read and write

### DIFF
--- a/internal/unmarshal.go
+++ b/internal/unmarshal.go
@@ -89,17 +89,16 @@ func (m *AllNamespaceMemoT) Load(key reflect.Type) (*NamespaceMemo, bool) {
 }
 
 func (m *AllNamespaceMemoT) LoadOrStoreLockedMutex(key reflect.Type, memo *NamespaceMemo) (*NamespaceMutex, bool) {
-	underlyingMutex := sync.RWMutex{}
+	namespaceMutex := &NamespaceMutex{
+		mu:   sync.RWMutex{},
+		memo: memo,
+	}
 	// The mutex should always be inserted in a locked state.
 	// Otherwise, there is an albeit slim possibility where
 	// concurrent readers of the memo retrieve and obtain an
 	// RLock on the mutex before the writer obtains a write
 	// lock.
-	underlyingMutex.Lock()
-	namespaceMutex := &NamespaceMutex{
-		mu:   underlyingMutex,
-		memo: memo,
-	}
+	namespaceMutex.mu.Lock()
 	v, loaded := (*sync.Map)(m).LoadOrStore(key, namespaceMutex)
 	return v.(*NamespaceMutex), loaded
 }

--- a/internal/unmarshal.go
+++ b/internal/unmarshal.go
@@ -90,7 +90,11 @@ func (m *AllNamespaceMemoT) Load(key reflect.Type) (*NamespaceMemo, bool) {
 
 func (m *AllNamespaceMemoT) LoadOrStoreLockedMutex(key reflect.Type, memo *NamespaceMemo) (*NamespaceMutex, bool) {
 	underlyingMutex := sync.RWMutex{}
-	// Always lock. Once data is written, unlock.
+	// The mutex should always be inserted in a locked state.
+	// Otherwise, there is an albeit slim possibility where
+	// concurrent readers of the memo retrieve and obtain an
+	// RLock on the mutex before the writer obtains a write
+	// lock.
 	underlyingMutex.Lock()
 	namespaceMutex := &NamespaceMutex{
 		mu:   underlyingMutex,

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -1335,43 +1335,89 @@ func TestWarmUpUnmarshallerConcurrent(t *testing.T) {
 	wg.Wait()
 }
 
+/*
+ * TestUnmarshalConcurrently tests that unmarshalling the same data concurrently
+ * works. Particularly the `internal.AllNamespaceMemo` variable has to be thread-safe.
+ */
 func TestUnmarshalConcurrently(t *testing.T) {
 	t.Parallel()
-	chalkClient, chalkClientErr := chalk.NewClient(&chalk.ClientConfig{UseGrpc: true})
-	if chalkClientErr != nil {
-		fmt.Println("ChalkClient ERROR: ", chalkClientErr)
-		return
-	}
 
-	for {
-		var wg sync.WaitGroup
-		numConcurrent := 100
-		for i := 0; i < numConcurrent; i++ {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				res, err := chalkClient.OnlineQuery(
-					chalk.OnlineQueryParams{}.
-						WithInput("user.id", 1).
-						WithOutputs(
-							"user.socure_score",
-						),
-					nil,
-				)
-				if err != nil {
-					fmt.Println("ONLINE QUERY ERROR: ", err)
-					return
-				}
-				fmt.Println(">>> RESULT: ", res)
-				myUser := User{}
-				res.UnmarshalInto(&myUser)
-				//fmt.Println(">>>> RESULT: ", myUser.SocureScore)
-			}()
-		}
-		wg.Wait()
-		time.Sleep(1 * time.Second)
+	data := []FeatureResult{
+		{
+			Field: "all_types.int",
+			Value: float64(123),
+		},
+		{
+			Field: "all_types.float",
+			Value: float64(123),
+		},
+		{
+			Field: "all_types.string",
+			Value: "abc",
+		},
+		{
+			Field: "all_types.bool",
+			Value: true,
+		},
+		{
+			Field: "all_types.timestamp",
+			Value: "2024-05-09T22:29:00Z",
+		},
+		{
+			Field: "all_types.int_list",
+			Value: []any{float64(1), float64(2), float64(3)},
+		},
+		{
+			Field: "all_types.nested_int_pointer_list",
+			Value: []any{[]any{float64(1), float64(2)}, []any{float64(3), float64(4)}},
+		},
+		{
+			Field: "all_types.nested_int_list",
+			Value: []any{[]any{float64(1), float64(2)}, []any{float64(3), float64(4)}},
+		},
+		{
+			Field: "all_types.windowed_int__60__",
+			Value: 1,
+		},
+		{
+			Field: "all_types.windowed_int__300__",
+			Value: 2,
+		},
+		{
+			Field: "all_types.windowed_int__3600__",
+			Value: 3,
+		},
+		{
+			Field: "all_types.dataclass",
+			Value: []any{float64(1.0), float64(2.0)},
+		},
+		{
+			Field: "all_types.dataclass_list",
+			Value: []any{[]any{float64(1.0), float64(2.0)}, []any{float64(3.0), float64(4.0)}},
+		},
+		{
+			Field: "all_types.nested.id",
+			Value: "nested_id",
+		},
 	}
+	queryRes := OnlineQueryResult{Data: data}
 
+	numBatch := 100
+	for i := 0; i < numBatch; i++ {
+		t.Run(fmt.Sprintf("batch-%d", i), func(t *testing.T) {
+			t.Parallel()
+			var wg sync.WaitGroup
+			batchSize := 1000
+			for i := 0; i < batchSize; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					queryRes.UnmarshalInto(&allTypes{})
+				}()
+			}
+			wg.Wait()
+		})
+	}
 }
 
 /*

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -1337,7 +1337,8 @@ func TestWarmUpUnmarshallerConcurrent(t *testing.T) {
 
 /*
  * TestUnmarshalConcurrently tests that unmarshalling the same data concurrently
- * works. Particularly the `internal.AllNamespaceMemo` variable has to be thread-safe.
+ * works. Particularly the `internal.AllNamespaceMemo` object has to have thread-
+ * safe methods.
  */
 func TestUnmarshalConcurrently(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Fixes the case where we concurrently write to a map during unmarshalling, particularly when populating the global variable that stores namespace memos. 