### PR TITLE
[xs] Remove `IncludeMetrics`

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -20,7 +20,6 @@ type OnlineQueryRequestSerialized struct {
 	Context          OnlineQueryContext     `json:"context"`
 	Staleness        map[string]string      `json:"staleness"`
 	IncludeMeta      bool                   `json:"include_meta"`
-	IncludeMetrics   bool                   `json:"include_metrics"`
 	DeploymentId     *string                `json:"deployment_id"`
 	QueryName        *string                `json:"query_name"`
 	CorrelationId    *string                `json:"correlation_id"`

--- a/internal/tests/integration/params_test.go
+++ b/internal/tests/integration/params_test.go
@@ -164,10 +164,7 @@ func TestParamsSetInOnlineQuery(t *testing.T) {
 		Explain:              true,
 		IncludeMeta:          true,
 		QueryContext:         queryContext,
-		EncodingOptions: &chalk.FeatureEncodingOptions{
-			EncodeStructsAsObjects: true,
-		},
-		PlannerOptions: plannerOption,
+		PlannerOptions:       plannerOption,
 	}.
 		WithInput(testFeatures.User.Id, "1").
 		WithOutputs(testFeatures.User.SocureScore)

--- a/internal/tests/integration/params_test.go
+++ b/internal/tests/integration/params_test.go
@@ -164,7 +164,10 @@ func TestParamsSetInOnlineQuery(t *testing.T) {
 		Explain:              true,
 		IncludeMeta:          true,
 		QueryContext:         queryContext,
-		PlannerOptions:       plannerOption,
+		EncodingOptions: &chalk.FeatureEncodingOptions{
+			EncodeStructsAsObjects: true,
+		},
+		PlannerOptions: plannerOption,
 	}.
 		WithInput(testFeatures.User.Id, "1").
 		WithOutputs(testFeatures.User.SocureScore)

--- a/internal/tests/integration/params_test.go
+++ b/internal/tests/integration/params_test.go
@@ -163,7 +163,6 @@ func TestParamsSetInOnlineQuery(t *testing.T) {
 		Now:                  now,
 		Explain:              true,
 		IncludeMeta:          true,
-		IncludeMetrics:       true,
 		QueryContext:         queryContext,
 		EncodingOptions: &chalk.FeatureEncodingOptions{
 			EncodeStructsAsObjects: true,
@@ -196,7 +195,6 @@ func TestParamsSetInOnlineQuery(t *testing.T) {
 	assert.Equal(t, meta, request.Meta)
 	assert.True(t, request.Explain)
 	assert.True(t, request.IncludeMeta)
-	assert.True(t, request.IncludeMetrics)
 	assert.True(t, request.EncodingOptions.EncodeStructsAsObjects)
 	assert.NotNil(t, request.QueryContext)
 	assert.Equal(t, &map[string]any{"key": "value"}, request.QueryContext)

--- a/models.go
+++ b/models.go
@@ -25,9 +25,6 @@ type OnlineQueryParams struct {
 	// If true, returns metadata about the query execution in the response.
 	IncludeMeta bool
 
-	// If true, returns performance metrics about the query execution in the response.
-	IncludeMetrics bool
-
 	// The environment under which to run the resolvers. API tokens can be scoped to an
 	// environment. If no environment is specified in the query, but the token supports
 	// only a single environment, then that environment will be taken as the scope for

--- a/serializers.go
+++ b/serializers.go
@@ -67,7 +67,6 @@ func (p OnlineQueryParams) serialize() (*internal.OnlineQueryRequestSerialized, 
 		Context:          context,
 		Staleness:        serializeStaleness(p.staleness),
 		IncludeMeta:      p.IncludeMeta || p.Explain,
-		IncludeMetrics:   p.IncludeMetrics,
 		DeploymentId:     internal.StringOrNil(p.PreviewDeploymentId),
 		QueryName:        internal.StringOrNil(p.QueryName),
 		QueryNameVersion: internal.StringOrNil(p.QueryNameVersion),
@@ -317,9 +316,6 @@ func convertOnlineQueryParamsToProto(params *OnlineQueryParams) (*commonv1.Onlin
 	options := map[string]*structpb.Value{}
 	if params.StorePlanStages {
 		options["store_plan_stages"] = structpb.NewBoolValue(params.StorePlanStages)
-	}
-	if params.IncludeMetrics {
-		options["include_metrics"] = structpb.NewBoolValue(params.IncludeMetrics)
 	}
 	for k, v := range params.PlannerOptions {
 		protoVal, err := structpb.NewValue(v)

--- a/serializers.go
+++ b/serializers.go
@@ -51,9 +51,7 @@ func (p OnlineQueryParams) serialize() (*internal.OnlineQueryRequestSerialized, 
 	var encodingOptions internal.FeatureEncodingOptions
 	if p.EncodingOptions == nil {
 		encodingOptions = internal.FeatureEncodingOptions{
-			// Default to true to ensure backcompat.
-			// See https://github.com/chalk-ai/chalk-go/pull/159
-			EncodeStructsAsObjects: true,
+			EncodeStructsAsObjects: false,
 		}
 	} else {
 		encodingOptions = internal.FeatureEncodingOptions{

--- a/serializers.go
+++ b/serializers.go
@@ -51,7 +51,9 @@ func (p OnlineQueryParams) serialize() (*internal.OnlineQueryRequestSerialized, 
 	var encodingOptions internal.FeatureEncodingOptions
 	if p.EncodingOptions == nil {
 		encodingOptions = internal.FeatureEncodingOptions{
-			EncodeStructsAsObjects: false,
+			// Default to true to ensure backcompat.
+			// See https://github.com/chalk-ai/chalk-go/pull/159
+			EncodeStructsAsObjects: true,
 		}
 	} else {
 		encodingOptions = internal.FeatureEncodingOptions{

--- a/serializers_test.go
+++ b/serializers_test.go
@@ -75,7 +75,6 @@ func TestConvertOnlineQueryParamsToProto(t *testing.T) {
 
 	params := OnlineQueryParams{
 		IncludeMeta:          true,
-		IncludeMetrics:       true,
 		StorePlanStages:      true,
 		Explain:              true,
 		Tags:                 tags,

--- a/serializers_test.go
+++ b/serializers_test.go
@@ -105,7 +105,6 @@ func TestConvertOnlineQueryParamsToProto(t *testing.T) {
 	assert.True(t, request.GetResponseOptions().GetIncludeMeta())
 	assert.NotNil(t, request.GetResponseOptions().GetExplain())
 	optionsActual := request.GetContext().GetOptions()
-	assert.True(t, optionsActual["include_metrics"].GetBoolValue())
 	assert.True(t, optionsActual["store_plan_stages"].GetBoolValue())
 }
 


### PR DESCRIPTION
This is a breaking change that merges first into the v1 base branch.

Removes the `IncludeMetrics` field in online query params that was never effectual. 


