### PR TITLE
[xs] Encode structs as objects by default

### DIFF
--- a/internal/tests/integration/params_test.go
+++ b/internal/tests/integration/params_test.go
@@ -165,10 +165,7 @@ func TestParamsSetInOnlineQuery(t *testing.T) {
 		IncludeMeta:          true,
 		IncludeMetrics:       true,
 		QueryContext:         queryContext,
-		EncodingOptions: &chalk.FeatureEncodingOptions{
-			EncodeStructsAsObjects: true,
-		},
-		PlannerOptions: plannerOption,
+		PlannerOptions:       plannerOption,
 	}.
 		WithInput(testFeatures.User.Id, "1").
 		WithOutputs(testFeatures.User.SocureScore)

--- a/serializers.go
+++ b/serializers.go
@@ -51,7 +51,9 @@ func (p OnlineQueryParams) serialize() (*internal.OnlineQueryRequestSerialized, 
 	var encodingOptions internal.FeatureEncodingOptions
 	if p.EncodingOptions == nil {
 		encodingOptions = internal.FeatureEncodingOptions{
-			EncodeStructsAsObjects: false,
+			// To ensure backcompat with codegen'd structs.
+			// See https://github.com/chalk-ai/chalk-go/pull/159
+			EncodeStructsAsObjects: true,
 		}
 	} else {
 		encodingOptions = internal.FeatureEncodingOptions{


### PR DESCRIPTION
This is a breaking change that merges first into the v1 base branch.

Encodes structs as objects in `OnlineQuery` by default. This ensures backwards compatibility with old codegen'd feature structs. In online query bulk and gRPC online query, we already do that by default. 