### PR TITLE
Add context.Context to all Client methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Query online features using the generated feature structs.  Access the results i
 ```go
 user := User{}
 _, err = client.OnlineQuery(
-	context.Background(),
+    context.Background(),
     chalk.OnlineQueryParams{}.
         WithInput(Features.User.Id, "u273489057").
 		WithInput(Features.User.Transactions, []Transaction{
@@ -115,7 +115,7 @@ you can specify a query name instead of outputs when making a query.
 ```go
 user := User{}
 _, err = client.OnlineQuery(
-	context.Background(),
+    context.Background(),
     chalk.OnlineQueryParams{}.
         WithInput(Features.User.Id, "u273489057").
         WithQueryName("user_underwriting_features"),
@@ -131,7 +131,7 @@ When executing an offline query, a dataset is returned and can be downloaded as 
 
 ```go
 res, _ := client.OfflineQuery(
-	context.Background(),
+    context.Background(),
     chalk.OfflineQueryParams{}.
         WithInput(Features.User.Id, []any{...}).
         WithOutputs(Features.User),
@@ -147,7 +147,7 @@ Chalk allows you to synchronously persist features directly to your online and o
 
 ```go
 res, err := client.UploadFeatures(
-	context.Background(),
+    context.Background(), 
     chalk.UploadFeaturesParams{
         Inputs: map[any]any{
             Features.User.Id: []string{"user-1", "user-2"},
@@ -186,7 +186,7 @@ class Transaction:
 Then to update the `txn_amount_total` feature, you would upload features corresponding to that aggregation:
 ```go
 res, err := client.UpdateAggregates(
-	context.Background(),
+    context.Background(),
     chalk.UpdateAggregatesParams{
         Inputs: map[any]any{
             "transaction.id": []string{"txn-1", "txn-2"},

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Query online features using the generated feature structs.  Access the results i
 ```go
 user := User{}
 _, err = client.OnlineQuery(
+	context.Background(),
     chalk.OnlineQueryParams{}.
         WithInput(Features.User.Id, "u273489057").
 		WithInput(Features.User.Transactions, []Transaction{
@@ -114,6 +115,7 @@ you can specify a query name instead of outputs when making a query.
 ```go
 user := User{}
 _, err = client.OnlineQuery(
+	context.Background(),
     chalk.OnlineQueryParams{}.
         WithInput(Features.User.Id, "u273489057").
         WithQueryName("user_underwriting_features"),

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Chalk allows you to synchronously persist features directly to your online and o
 
 ```go
 res, err := client.UploadFeatures(
+	context.Background(),
     chalk.UploadFeaturesParams{
         Inputs: map[any]any{
             Features.User.Id: []string{"user-1", "user-2"},
@@ -184,6 +185,7 @@ class Transaction:
 Then to update the `txn_amount_total` feature, you would upload features corresponding to that aggregation:
 ```go
 res, err := client.UpdateAggregates(
+	context.Background(),
     chalk.UpdateAggregatesParams{
         Inputs: map[any]any{
             "transaction.id": []string{"txn-1", "txn-2"},

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ When executing an offline query, a dataset is returned and can be downloaded as 
 
 ```go
 res, _ := client.OfflineQuery(
+	context.Background(),
     chalk.OfflineQueryParams{}.
         WithInput(Features.User.Id, []any{...}).
         WithOutputs(Features.User),

--- a/client.go
+++ b/client.go
@@ -28,6 +28,7 @@ type Client interface {
 	//
 	//		user := User{}
 	//		res, err := client.OnlineQuery(
+	//          context.Background(),
 	//			OnlineQueryParams{
 	//				IncludeMeta: true,
 	//				EnvironmentId: "pipkjlfc3gtmn",
@@ -41,7 +42,7 @@ type Client interface {
 	//
 	// [chalk codegen]: https://docs.chalk.ai/cli#codegen
 	// [query basics]: https://docs.chalk.ai/docs/query-basics
-	OnlineQuery(args OnlineQueryParamsComplete, resultHolder any) (OnlineQueryResult, error)
+	OnlineQuery(ctx context.Context, args OnlineQueryParamsComplete, resultHolder any) (OnlineQueryResult, error)
 
 	// OnlineQueryBulk computes features values using online resolvers,
 	// and has the ability to query multiple primary keys at once.
@@ -59,6 +60,7 @@ type Client interface {
 	//
 	//
 	//		res, err := client.OnlineQueryBulk(
+	//          context.Background(),
 	//			OnlineQueryParams{
 	//				IncludeMeta: true,
 	//				EnvironmentId: "pipkjlfc3gtmn",
@@ -82,7 +84,7 @@ type Client interface {
 	//
 	// [chalk codegen]: https://docs.chalk.ai/cli#codegen
 	// [query basics]: https://docs.chalk.ai/docs/query-basics
-	OnlineQueryBulk(args OnlineQueryParamsComplete) (OnlineQueryBulkResult, error)
+	OnlineQueryBulk(ctx context.Context, args OnlineQueryParamsComplete) (OnlineQueryBulkResult, error)
 
 	// UploadFeatures synchronously persists feature values to the online store and
 	// offline store. The `Inputs` parameter should be a map of features to values.
@@ -95,6 +97,7 @@ type Client interface {
 	// Example:
 	//
 	// 		res, err := client.UploadFeatures(
+	//          context.Background(),
 	// 			UploadFeaturesParams{
 	// 				Inputs: map[any]any{
 	// 					Features.User.Card.Id: []string{"5555-5555-5555-5555", "4444-4444-4444-4444"},
@@ -109,7 +112,7 @@ type Client interface {
 	//      }
 	//
 	// [chalk codegen]: https://docs.chalk.ai/cli#codegen
-	UploadFeatures(args UploadFeaturesParams) (UploadFeaturesResult, error)
+	UploadFeatures(ctx context.Context, args UploadFeaturesParams) (UploadFeaturesResult, error)
 
 	// UpdateAggregates synchronously persists feature values that back windowed aggregations,
 	// while updating the corresponding aggregate values themselves.
@@ -122,6 +125,7 @@ type Client interface {
 	// Example:
 	//
 	// 		res, err := client.UpdateAggregates(
+	//          context.Background(),
 	// 			UpdateAggregatesParams{
 	// 				Inputs: map[any]any{
 	// 					Features.Txns.Id: []string{5555-5555", "4444-4444"},
@@ -135,7 +139,7 @@ type Client interface {
 	//      }
 	//
 	// [chalk codegen]: https://docs.chalk.ai/cli#codegen
-	UpdateAggregates(args UpdateAggregatesParams) (UpdateAggregatesResult, error)
+	UpdateAggregates(ctx context.Context, args UpdateAggregatesParams) (UpdateAggregatesResult, error)
 
 	// OfflineQuery queries feature values from the offline store.
 	// See Dataset for more information.
@@ -143,25 +147,26 @@ type Client interface {
 	// Example:
 	//
 	//		client.OfflineQuery(
+	//          context.Background(),
 	//			OfflineQueryParams{
 	//				EnvironmentId: "pipkjlfc3gtmn",
 	//			}.
 	//	 		WithRequiredOutputs(Features.User.Email, Features.User.Card.Id),
 	//		)
 	//
-	OfflineQuery(args OfflineQueryParamsComplete) (Dataset, error)
+	OfflineQuery(ctx context.Context, args OfflineQueryParamsComplete) (Dataset, error)
 
 	// TriggerResolverRun triggers an offline resolver to run.
 	// See https://docs.chalk.ai/docs/runs for more information.
-	TriggerResolverRun(args TriggerResolverRunParams) (TriggerResolverRunResult, error)
+	TriggerResolverRun(ctx context.Context, args TriggerResolverRunParams) (TriggerResolverRunResult, error)
 
 	// GetRunStatus retrieves the status of an offline resolver run.
 	// See https://docs.chalk.ai/docs/runs for more information.
-	GetRunStatus(args GetRunStatusParams) (GetRunStatusResult, error)
+	GetRunStatus(ctx context.Context, args GetRunStatusParams) (GetRunStatusResult, error)
 
 	// GetToken retrieves a token that can be used to authenticate requests to the Chalk API
 	// along with other using the client's credentials.
-	GetToken() (*TokenResult, error)
+	GetToken(ctx context.Context) (*TokenResult, error)
 
 	GetAggregates(ctx context.Context, features []string) (*aggregatev1.GetAggregatesResponse, error)
 

--- a/client.go
+++ b/client.go
@@ -28,7 +28,7 @@ type Client interface {
 	//
 	//		user := User{}
 	//		res, err := client.OnlineQuery(
-	//          context.Background(),
+	//			context.Background(),
 	//			OnlineQueryParams{
 	//				IncludeMeta: true,
 	//				EnvironmentId: "pipkjlfc3gtmn",
@@ -60,7 +60,7 @@ type Client interface {
 	//
 	//
 	//		res, err := client.OnlineQueryBulk(
-	//          context.Background(),
+	//			context.Background(),
 	//			OnlineQueryParams{
 	//				IncludeMeta: true,
 	//				EnvironmentId: "pipkjlfc3gtmn",
@@ -97,7 +97,7 @@ type Client interface {
 	// Example:
 	//
 	// 		res, err := client.UploadFeatures(
-	//          context.Background(),
+	//			context.Background(),
 	// 			UploadFeaturesParams{
 	// 				Inputs: map[any]any{
 	// 					Features.User.Card.Id: []string{"5555-5555-5555-5555", "4444-4444-4444-4444"},
@@ -125,7 +125,7 @@ type Client interface {
 	// Example:
 	//
 	// 		res, err := client.UpdateAggregates(
-	//          context.Background(),
+	//			context.Background(),
 	// 			UpdateAggregatesParams{
 	// 				Inputs: map[any]any{
 	// 					Features.Txns.Id: []string{5555-5555", "4444-4444"},
@@ -147,7 +147,7 @@ type Client interface {
 	// Example:
 	//
 	//		client.OfflineQuery(
-	//          context.Background(),
+	//			context.Background(),
 	//			OfflineQueryParams{
 	//				EnvironmentId: "pipkjlfc3gtmn",
 	//			}.

--- a/client_grpc.go
+++ b/client_grpc.go
@@ -34,12 +34,12 @@ func newClientGrpc(cfg ClientConfig) (*clientGrpc, error) {
 	return &clientGrpc{underlying: nativeClient}, nil
 }
 
-func (c *clientGrpc) GetToken() (*TokenResult, error) {
-	return c.underlying.GetToken()
+func (c *clientGrpc) GetToken(ctx context.Context) (*TokenResult, error) {
+	return c.underlying.GetToken(ctx)
 }
 
-func (c *clientGrpc) onlineQueryBulk(args OnlineQueryParamsComplete) (OnlineQueryBulkResult, error) {
-	res, err := c.underlying.OnlineQueryBulk(context.Background(), args)
+func (c *clientGrpc) onlineQueryBulk(ctx context.Context, args OnlineQueryParamsComplete) (OnlineQueryBulkResult, error) {
+	res, err := c.underlying.OnlineQueryBulk(ctx, args)
 	if err != nil {
 		return OnlineQueryBulkResult{}, errors.Wrapf(err, "executing online query")
 	}
@@ -77,8 +77,8 @@ func (c *clientGrpc) onlineQueryBulk(args OnlineQueryParamsComplete) (OnlineQuer
 	}, nil
 }
 
-func (c *clientGrpc) OnlineQuery(args OnlineQueryParamsComplete, resultHolder any) (OnlineQueryResult, error) {
-	res, err := c.underlying.OnlineQuery(context.Background(), args)
+func (c *clientGrpc) OnlineQuery(ctx context.Context, args OnlineQueryParamsComplete, resultHolder any) (OnlineQueryResult, error) {
+	res, err := c.underlying.OnlineQuery(ctx, args)
 	if err != nil {
 		return OnlineQueryResult{}, err
 	}
@@ -149,12 +149,12 @@ func (c *clientGrpc) OnlineQuery(args OnlineQueryParamsComplete, resultHolder an
 
 }
 
-func (c *clientGrpc) OnlineQueryBulk(args OnlineQueryParamsComplete) (OnlineQueryBulkResult, error) {
-	return c.onlineQueryBulk(args)
+func (c *clientGrpc) OnlineQueryBulk(ctx context.Context, args OnlineQueryParamsComplete) (OnlineQueryBulkResult, error) {
+	return c.onlineQueryBulk(ctx, args)
 }
 
-func (c *clientGrpc) UpdateAggregates(args UpdateAggregatesParams) (UpdateAggregatesResult, error) {
-	res, err := c.underlying.UpdateAggregates(context.Background(), args)
+func (c *clientGrpc) UpdateAggregates(ctx context.Context, args UpdateAggregatesParams) (UpdateAggregatesResult, error) {
+	res, err := c.underlying.UpdateAggregates(ctx, args)
 	if err != nil {
 		return UpdateAggregatesResult{}, errors.Wrapf(err, "executing update aggregates")
 	}
@@ -187,18 +187,18 @@ func (c *clientGrpc) PlanAggregateBackfill(
 	return c.underlying.PlanAggregateBackfill(ctx, req)
 }
 
-func (c *clientGrpc) OfflineQuery(args OfflineQueryParamsComplete) (Dataset, error) {
+func (c *clientGrpc) OfflineQuery(ctx context.Context, args OfflineQueryParamsComplete) (Dataset, error) {
 	return Dataset{}, errors.New("not implemented")
 }
 
-func (c *clientGrpc) TriggerResolverRun(args TriggerResolverRunParams) (TriggerResolverRunResult, error) {
+func (c *clientGrpc) TriggerResolverRun(ctx context.Context, args TriggerResolverRunParams) (TriggerResolverRunResult, error) {
 	return TriggerResolverRunResult{}, errors.New("not implemented")
 }
 
-func (c *clientGrpc) GetRunStatus(args GetRunStatusParams) (GetRunStatusResult, error) {
+func (c *clientGrpc) GetRunStatus(ctx context.Context, args GetRunStatusParams) (GetRunStatusResult, error) {
 	return GetRunStatusResult{}, errors.New("not implemented")
 }
 
-func (c *clientGrpc) UploadFeatures(args UploadFeaturesParams) (UploadFeaturesResult, error) {
+func (c *clientGrpc) UploadFeatures(ctx context.Context, args UploadFeaturesParams) (UploadFeaturesResult, error) {
 	return UploadFeaturesResult{}, errors.New("not implemented")
 }

--- a/client_impl.go
+++ b/client_impl.go
@@ -450,7 +450,7 @@ func (c *clientImpl) sendRequest(ctx context.Context, args sendRequestParams) er
 	request.Header = headers
 
 	if !args.DontRefresh {
-		if err := c.config.refresh(false); err != nil {
+		if err := c.config.refresh(ctx, false); err != nil {
 			(c.logger).Debugf("Error pre-emptively refreshing access token: %s", err)
 		}
 	}
@@ -509,10 +509,11 @@ func (c *clientImpl) sendRequest(ctx context.Context, args sendRequestParams) er
 }
 
 func (c *clientImpl) retryRequest(
+	ctx context.Context,
 	originalRequest http.Request, originalBody any,
 	originalResponse *http.Response, originalError error,
 ) (*http.Response, error) {
-	if err := c.config.refresh(true); err != nil {
+	if err := c.config.refresh(ctx, true); err != nil {
 		(c.logger).Debugf("Error refreshing access token upon 401: %s", err.Error())
 		return originalResponse, originalError
 	}
@@ -682,7 +683,7 @@ func newClientImpl(
 		config: config,
 	}
 	client.config.getToken = client.getToken
-	if err := client.config.refresh(false); err != nil {
+	if err := client.config.refresh(context.Background(), false); err != nil {
 		return nil, errors.Wrap(err, "error fetching initial config")
 	}
 	return client, nil

--- a/client_impl.go
+++ b/client_impl.go
@@ -483,7 +483,7 @@ func (c *clientImpl) sendRequest(ctx context.Context, args sendRequestParams) er
 	defer res.Body.Close()
 
 	if res.StatusCode == 401 && !args.DontRefresh && request != nil {
-		res, err = c.retryRequest(*request, args.Body, res, err)
+		res, err = c.retryRequest(ctx, *request, args.Body, res, err)
 		if err != nil {
 			return err
 		}
@@ -525,7 +525,7 @@ func (c *clientImpl) retryRequest(
 
 	// New request needs to be constructed otherwise we were getting the error:
 	//     HTTP/1.x transport connection broken
-	ctx, cancel := internal.GetContextWithTimeout(context.Background(), c.timeout)
+	ctx, cancel := internal.GetContextWithTimeout(ctx, c.timeout)
 	defer cancel()
 	newRequest, err := http.NewRequestWithContext(
 		ctx,

--- a/config_manager.go
+++ b/config_manager.go
@@ -109,12 +109,12 @@ func (m *configManager) getQueryServer(queryServerOverride *string) string {
 	return endpoint
 }
 
-func (m *configManager) refresh(force bool) error {
+func (m *configManager) refresh(ctx context.Context, force bool) error {
 	if !force && m.jwt != nil && m.jwt.IsValid() {
 		return nil
 	}
 
-	config, err := m.getToken(m.clientId.Value, m.clientSecret.Value)
+	config, err := m.getToken(ctx, m.clientId.Value, m.clientSecret.Value)
 	if err != nil {
 		return errors.Wrap(err, "refreshing token")
 	}

--- a/config_manager.go
+++ b/config_manager.go
@@ -1,6 +1,7 @@
 package chalk
 
 import (
+	"context"
 	"github.com/chalk-ai/chalk-go/internal"
 	"github.com/chalk-ai/chalk-go/internal/auth"
 	"github.com/chalk-ai/chalk-go/internal/colls"
@@ -26,7 +27,7 @@ type configManager struct {
 
 	jwt      *auth.JWT
 	engines  map[string]string
-	getToken func(clientId string, clientSecret string) (*getTokenResult, error)
+	getToken func(ctx context.Context, clientId string, clientSecret string) (*getTokenResult, error)
 
 	logger LeveledLogger
 }

--- a/grpc_client.go
+++ b/grpc_client.go
@@ -26,7 +26,7 @@ type GRPCClient interface {
 
 	// GetToken retrieves a token that can be used to authenticate requests to the Chalk API
 	// along with other using the client's credentials.
-	GetToken() (*TokenResult, error)
+	GetToken(ctx context.Context) (*TokenResult, error)
 }
 
 type GRPCClientConfig struct {

--- a/grpc_client_impl.go
+++ b/grpc_client_impl.go
@@ -74,8 +74,8 @@ func newGrpcClient(configs ...*GRPCClientConfig) (*grpcClientImpl, error) {
 		connect.WithInterceptors(authInterceptors...),
 	)
 
-	config.getToken = func(clientId string, clientSecret string) (*getTokenResult, error) {
-		return getToken(clientId, clientSecret, config.logger, authClient)
+	config.getToken = func(ctx context.Context, clientId string, clientSecret string) (*getTokenResult, error) {
+		return getToken(ctx, clientId, clientSecret, config.logger, authClient)
 	}
 
 	// Necessary to get GRPC engines URL
@@ -142,7 +142,7 @@ func newGrpcClient(configs ...*GRPCClientConfig) (*grpcClientImpl, error) {
 	}, nil
 }
 
-func getToken(clientId string, clientSecret string, logger LeveledLogger, client serverv1connect.AuthServiceClient) (*getTokenResult, error) {
+func getToken(ctx context.Context, clientId string, clientSecret string, logger LeveledLogger, client serverv1connect.AuthServiceClient) (*getTokenResult, error) {
 	logger.Debugf("Getting new token via gRPC")
 	authRequest := connect.NewRequest(
 		&serverv1.GetTokenRequest{
@@ -152,7 +152,7 @@ func getToken(clientId string, clientSecret string, logger LeveledLogger, client
 		},
 	)
 
-	token, err := client.GetToken(context.Background(), authRequest)
+	token, err := client.GetToken(ctx, authRequest)
 	if err != nil {
 		logger.Debugf("Failed to get a new token: %s", err.Error())
 		return nil, err
@@ -375,8 +375,8 @@ func (c *grpcClientImpl) PlanAggregateBackfill(
 	return res.Msg, err
 }
 
-func (c *grpcClientImpl) GetToken() (*TokenResult, error) {
-	res, err := c.config.getToken(c.config.clientId.Value, c.config.clientSecret.Value)
+func (c *grpcClientImpl) GetToken(ctx context.Context) (*TokenResult, error) {
+	res, err := c.config.getToken(ctx, c.config.clientId.Value, c.config.clientSecret.Value)
 	if err != nil {
 		return nil, err
 	}

--- a/grpc_client_impl.go
+++ b/grpc_client_impl.go
@@ -79,7 +79,7 @@ func newGrpcClient(configs ...*GRPCClientConfig) (*grpcClientImpl, error) {
 	}
 
 	// Necessary to get GRPC engines URL
-	if err := config.refresh(false); err != nil {
+	if err := config.refresh(context.Background(), false); err != nil {
 		return nil, errors.Wrap(err, "fetching initial config")
 	}
 

--- a/grpc_utils.go
+++ b/grpc_utils.go
@@ -50,7 +50,7 @@ func makeTokenInterceptor(configManager *configManager) connect.UnaryInterceptor
 			ctx context.Context,
 			req connect.AnyRequest,
 		) (connect.AnyResponse, error) {
-			if err := configManager.refresh(false); err != nil {
+			if err := configManager.refresh(ctx, false); err != nil {
 				return nil, errors.Wrap(err, "error refreshing config")
 			}
 			req.Header().Set(HeaderKeyEnvironmentId, configManager.environmentId.Value)

--- a/internal/tests/integration/all_clients_test.go
+++ b/internal/tests/integration/all_clients_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"context"
 	"fmt"
 	"github.com/chalk-ai/chalk-go"
 	"github.com/chalk-ai/chalk-go/internal/ptr"
@@ -62,7 +63,7 @@ func TestHasManyInputsAndOutputs(t *testing.T) {
 				WithOutputs(testFeatures.Series.Name, testFeatures.Series.Investors)
 
 			var resultSeries series
-			res, err := client.OnlineQuery(params, &resultSeries)
+			res, err := client.OnlineQuery(context.Background(), params, &resultSeries)
 			assert.NoError(t, err)
 			assert.Equal(t, len(investorsInput), len(*resultSeries.Investors))
 			assert.Equal(t, "amylase", *(*resultSeries.Investors)[0].Id)
@@ -110,7 +111,7 @@ func TestOnlineQueryPlannerOptions(t *testing.T) {
 				}.
 					WithInput("user.id", 1).
 					WithOutputs("user.socure_score")
-				_, err := client.OnlineQuery(params, nil)
+				_, err := client.OnlineQuery(context.Background(), params, nil)
 				if optionFixture.isValid {
 					assert.NoError(t, err)
 				} else {
@@ -134,7 +135,7 @@ func TestOnlineQueryBulkPlannerOptions(t *testing.T) {
 				}.
 					WithInput("user.id", []int{1}).
 					WithOutputs("user.socure_score")
-				_, err := client.OnlineQueryBulk(params)
+				_, err := client.OnlineQueryBulk(context.Background(), params)
 				if optionFixture.isValid {
 					assert.NoError(t, err)
 				} else {
@@ -173,7 +174,7 @@ func TestTimeout(t *testing.T) {
 						WithOutputs("user.socure_score")
 					assert.NoError(t, err)
 					myUser := user{}
-					_, err := client.OnlineQuery(params, &myUser)
+					_, err := client.OnlineQuery(context.Background(), params, &myUser)
 					assert.NoError(t, err)
 					assert.NotNil(t, myUser.SocureScore)
 					assert.Equal(t, 123.0, *myUser.SocureScore)

--- a/internal/tests/integration/branch_test.go
+++ b/internal/tests/integration/branch_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"context"
 	"github.com/chalk-ai/chalk-go"
 	"github.com/chalk-ai/chalk-go/internal"
 	assert "github.com/stretchr/testify/require"
@@ -32,7 +33,7 @@ func TestOnlineQueryAndQueryBulkBranchInRequest(t *testing.T) {
 		WithInput(testFeatures.User.Id, userIds[0]).
 		WithOutputs(testFeatures.User.SocureScore).
 		WithBranchId(branchId)
-	_, _ = client.OnlineQuery(req, nil)
+	_, _ = client.OnlineQuery(context.Background(), req, nil)
 	assert.Equal(t, httpClient.Intercepted.Header.Get("X-Chalk-Branch-Id"), branchId)
 
 	bulkBranchId := "bulk-branch-id"
@@ -69,7 +70,7 @@ func TestOnlineQueryBranchInClient(t *testing.T) {
 	req := chalk.OnlineQueryParams{}.
 		WithInput(testFeatures.User.Id, userIds[0]).
 		WithOutputs(testFeatures.User.SocureScore)
-	_, _ = client.OnlineQuery(req, nil)
+	_, _ = client.OnlineQuery(context.Background(), req, nil)
 	assert.Equal(t, httpClient.Intercepted.Header.Get("X-Chalk-Branch-Id"), branchId)
 }
 

--- a/internal/tests/integration/branch_test.go
+++ b/internal/tests/integration/branch_test.go
@@ -41,7 +41,7 @@ func TestOnlineQueryAndQueryBulkBranchInRequest(t *testing.T) {
 		WithInput(testFeatures.User.Id, userIds).
 		WithOutputs(testFeatures.User.SocureScore).
 		WithBranchId(bulkBranchId)
-	_, _ = client.OnlineQueryBulk(bulkReq)
+	_, _ = client.OnlineQueryBulk(context.Background(), bulkReq)
 	assert.Equal(t, httpClient.Intercepted.Header.Get("X-Chalk-Branch-Id"), bulkBranchId)
 }
 
@@ -99,7 +99,7 @@ func TestOnlineQueryBulkBranchInClient(t *testing.T) {
 	req := chalk.OnlineQueryParams{}.
 		WithInput(testFeatures.User.Id, userIds).
 		WithOutputs(testFeatures.User.SocureScore)
-	_, _ = client.OnlineQueryBulk(req)
+	_, _ = client.OnlineQueryBulk(context.Background(), req)
 	assert.Equal(t, httpClient.Intercepted.Header.Get("X-Chalk-Branch-Id"), branchId)
 }
 
@@ -125,7 +125,7 @@ func TestClientBranchSetInFeatherHeader(t *testing.T) {
 	req := chalk.OnlineQueryParams{}.
 		WithInput(testFeatures.User.Id, userIds).
 		WithOutputs(testFeatures.User.SocureScore)
-	_, _ = client.OnlineQueryBulk(req)
+	_, _ = client.OnlineQueryBulk(context.Background(), req)
 	header, headerErr := internal.GetHeaderFromSerializedOnlineQueryBulkBody(httpClient.Intercepted.Body)
 	assert.Nil(t, headerErr)
 	actualBranchId, ok := header["branch_id"]

--- a/internal/tests/integration/bulk_test.go
+++ b/internal/tests/integration/bulk_test.go
@@ -25,7 +25,7 @@ func TestOnlineQueryBulk(t *testing.T) {
 		WithInput(testFeatures.User.Id, userIds).
 		WithOutputs(testFeatures.User.SocureScore)
 
-	res, queryErr := client.OnlineQueryBulk(req)
+	res, queryErr := client.OnlineQueryBulk(context.Background(), req)
 	if queryErr != nil {
 		t.Fatal("Failed querying features", queryErr)
 	}

--- a/internal/tests/integration/deployment_tag_test.go
+++ b/internal/tests/integration/deployment_tag_test.go
@@ -39,6 +39,6 @@ func TestOnlineQueryAndQueryBulkDeploymentTagInRequest(t *testing.T) {
 	bulkReq := chalk.OnlineQueryParams{}.
 		WithInput(testFeatures.User.Id, userIds).
 		WithOutputs(testFeatures.User.SocureScore)
-	_, _ = client.OnlineQueryBulk(bulkReq)
+	_, _ = client.OnlineQueryBulk(context.Background(), bulkReq)
 	assert.Equal(t, httpClient.Intercepted.Header.Get("X-Chalk-Deployment-Tag"), deploymentTag)
 }

--- a/internal/tests/integration/deployment_tag_test.go
+++ b/internal/tests/integration/deployment_tag_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"context"
 	"github.com/chalk-ai/chalk-go"
 	assert "github.com/stretchr/testify/require"
 	"testing"
@@ -31,7 +32,7 @@ func TestOnlineQueryAndQueryBulkDeploymentTagInRequest(t *testing.T) {
 	req := chalk.OnlineQueryParams{}.
 		WithInput(testFeatures.User.Id, userIds[0]).
 		WithOutputs(testFeatures.User.SocureScore)
-	_, _ = client.OnlineQuery(req, nil)
+	_, _ = client.OnlineQuery(context.Background(), req, nil)
 
 	assert.Equal(t, httpClient.Intercepted.Header.Get("X-Chalk-Deployment-Tag"), deploymentTag)
 

--- a/internal/tests/integration/grpc_test.go
+++ b/internal/tests/integration/grpc_test.go
@@ -67,12 +67,15 @@ func TestOnlineQueryGrpcIncludeMeta(t *testing.T) {
 
 	restClient, err := chalk.NewClient()
 	assert.NoError(t, err)
-	_, err = restClient.UploadFeatures(chalk.UploadFeaturesParams{
-		Inputs: map[any]any{
-			testFeatures.User.Id:          []int64{userId},
-			testFeatures.User.SocureScore: []float64{expectedSocureScore},
+	_, err = restClient.UploadFeatures(
+		context.Background(),
+		chalk.UploadFeaturesParams{
+			Inputs: map[any]any{
+				testFeatures.User.Id:          []int64{userId},
+				testFeatures.User.SocureScore: []float64{expectedSocureScore},
+			},
 		},
-	})
+	)
 	assert.NoError(t, err)
 
 	grpcClient, err := chalk.NewClient(&chalk.ClientConfig{UseGrpc: true})

--- a/internal/tests/integration/grpc_test.go
+++ b/internal/tests/integration/grpc_test.go
@@ -33,7 +33,7 @@ func TestOnlineQueryBulkGrpc(t *testing.T) {
 		WithInput(testFeatures.User.Id, userIds).
 		WithOutputs(testFeatures.User.Id, testFeatures.User.SocureScore)
 
-	res, queryErr := client.OnlineQueryBulk(req)
+	res, queryErr := client.OnlineQueryBulk(context.Background(), req)
 	if queryErr != nil {
 		t.Fatal("Failed querying features", queryErr)
 	}

--- a/internal/tests/integration/grpc_test.go
+++ b/internal/tests/integration/grpc_test.go
@@ -80,7 +80,7 @@ func TestOnlineQueryGrpcIncludeMeta(t *testing.T) {
 	req := chalk.OnlineQueryParams{IncludeMeta: true}.
 		WithInput(testFeatures.User.Id, userId).
 		WithOutputs(testFeatures.User.Id, testFeatures.User.SocureScore, testFeatures.User.Today)
-	res, err := grpcClient.OnlineQuery(req, nil)
+	res, err := grpcClient.OnlineQuery(context.Background(), req, nil)
 	assert.NoError(t, err)
 
 	socureScore, err := res.GetFeature("user.socure_score")

--- a/internal/tests/integration/grpc_upload_test.go
+++ b/internal/tests/integration/grpc_upload_test.go
@@ -122,7 +122,7 @@ func TestGrpcUpdateAggregates(t *testing.T) {
 	theoremIds := getRandomInts(len(proofIds))
 	now := time.Now().UTC()
 	params := getUpdateAggregateParams(proofIds, theoremIds, now)
-	_, err = client.UpdateAggregates(params)
+	_, err = client.UpdateAggregates(context.Background(), params)
 	assert.NoError(t, err)
 	// Query aggregation results
 	verifyUpdateAggregateResults(t, distinctProofIds, client)

--- a/internal/tests/integration/grpc_upload_test.go
+++ b/internal/tests/integration/grpc_upload_test.go
@@ -51,7 +51,7 @@ func verifyUpdateAggregateResults(t *testing.T, distinctProofIds []int64, client
 		Features.Proof.MeanTheoremLines["30d"],
 		Features.Proof.MeanTheoremLines["90d"],
 	)
-	bulkRes, err := client.OnlineQueryBulk(queryParams)
+	bulkRes, err := client.OnlineQueryBulk(context.Background(), queryParams)
 	assert.NoError(t, err)
 	var proofResults []Proof
 	assert.NoError(t, bulkRes.UnmarshalInto(&proofResults))

--- a/internal/tests/integration/interceptor_test.go
+++ b/internal/tests/integration/interceptor_test.go
@@ -33,7 +33,7 @@ func TestHeadersSetOnlineQueryBulk(t *testing.T) {
 	}.
 		WithInput(testFeatures.User.Id, userIds).
 		WithOutputs(testFeatures.User.SocureScore)
-	_, _ = client.OnlineQueryBulk(req)
+	_, _ = client.OnlineQueryBulk(context.Background(), req)
 	assert.Equal(t, httpClient.Intercepted.Header.Get("X-Chalk-Features-Versioned"), "true")
 	assert.Equal(t, resourceGroup, httpClient.Intercepted.Header.Get(chalk.HeaderKeyResourceGroup))
 }

--- a/internal/tests/integration/interceptor_test.go
+++ b/internal/tests/integration/interceptor_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"context"
 	"github.com/chalk-ai/chalk-go"
 	assert "github.com/stretchr/testify/require"
 	"net/url"
@@ -63,7 +64,7 @@ func TestHeadersSetOnlineQuery(t *testing.T) {
 	}.
 		WithInput(testFeatures.User.Id, 1).
 		WithOutputs(testFeatures.User.SocureScore)
-	_, _ = client.OnlineQuery(req, nil)
+	_, _ = client.OnlineQuery(context.Background(), req, nil)
 	assert.Equal(t, httpClient.Intercepted.Header.Get("X-Chalk-Features-Versioned"), "true")
 	assert.Equal(t, resourceGroup, httpClient.Intercepted.Header.Get(chalk.HeaderKeyResourceGroup))
 }
@@ -117,7 +118,7 @@ func TestQueryServerOverride(t *testing.T) {
 	req := chalk.OnlineQueryParams{}.
 		WithInput(testFeatures.User.Id, 1).
 		WithOutputs(testFeatures.User.SocureScore)
-	_, _ = client.OnlineQuery(req, nil)
+	_, _ = client.OnlineQuery(context.Background(), req, nil)
 	parsed, err := url.Parse(queryServer)
 	assert.Nil(t, err)
 	assert.Equal(t, httpClient.Intercepted.URL.Host, parsed.Host)

--- a/internal/tests/integration/interceptor_test.go
+++ b/internal/tests/integration/interceptor_test.go
@@ -91,7 +91,7 @@ func TestVersionHeaderSetOfflineQuery(t *testing.T) {
 	req := chalk.OfflineQueryParams{}.
 		WithInput(testFeatures.User.Id, userIds).
 		WithOutputs(testFeatures.User.SocureScore)
-	_, _ = client.OfflineQuery(req)
+	_, _ = client.OfflineQuery(context.Background(), req)
 	assert.Equal(t, httpClient.Intercepted.Header.Get("X-Chalk-Features-Versioned"), "true")
 }
 

--- a/internal/tests/integration/optional_test.go
+++ b/internal/tests/integration/optional_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"context"
 	"github.com/chalk-ai/chalk-go"
 	assert "github.com/stretchr/testify/require"
 	"testing"
@@ -20,7 +21,7 @@ func TestQueryOptionalFeatures(t *testing.T) {
 	}
 	res := chalk.OnlineQueryParams{}.WithInput(testFeatures.User.Id, userIds[0]).WithOutputs(testFeatures.User.FullNameOptional, testFeatures.User.SocureScore)
 	result := user{}
-	_, err = client.OnlineQuery(res, &result)
+	_, err = client.OnlineQuery(context.Background(), res, &result)
 	if err != nil {
 		t.Fatal("Failed querying features", err)
 	}

--- a/internal/tests/integration/params_test.go
+++ b/internal/tests/integration/params_test.go
@@ -72,7 +72,7 @@ func TestParamsSetInFeatherHeader(t *testing.T) {
 		req = req.WithStaleness(k, v)
 	}
 
-	_, _ = client.OnlineQueryBulk(req)
+	_, _ = client.OnlineQueryBulk(context.Background(), req)
 	headerMap, headerErr := internal.GetHeaderFromSerializedOnlineQueryBulkBody(httpClient.Intercepted.Body)
 	assert.Nil(t, headerErr)
 

--- a/internal/tests/integration/params_test.go
+++ b/internal/tests/integration/params_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"context"
 	"encoding/json"
 	"github.com/chalk-ai/chalk-go"
 	"github.com/chalk-ai/chalk-go/internal"
@@ -177,7 +178,7 @@ func TestParamsSetInOnlineQuery(t *testing.T) {
 		req = req.WithStaleness(k, v)
 	}
 
-	_, _ = client.OnlineQuery(req, nil)
+	_, _ = client.OnlineQuery(context.Background(), req, nil)
 	var request internal.OnlineQueryRequestSerialized
 	assert.NoError(t, json.Unmarshal(httpClient.Intercepted.Body, &request))
 	assert.Equal(t, expectedTags, request.Context.Tags)

--- a/internal/tests/integration/params_test.go
+++ b/internal/tests/integration/params_test.go
@@ -228,7 +228,7 @@ func TestParamsSetInOfflineQuery(t *testing.T) {
 	}.
 		WithInput(testFeatures.User.Id, []any{int64(1)}).
 		WithOutputs(testFeatures.User.SocureScore)
-	_, _ = client.OfflineQuery(req)
+	_, _ = client.OfflineQuery(context.Background(), req)
 	var request internal.OfflineQueryRequestSerialized
 	assert.NoError(t, json.Unmarshal(httpClient.Intercepted.Body, &request))
 	assert.Equal(t, expectedTags, request.Tags)

--- a/internal/tests/integration/query_test.go
+++ b/internal/tests/integration/query_test.go
@@ -83,7 +83,7 @@ func TestOnlineQueryE2E(t *testing.T) {
 			}
 
 			var implicitUser user
-			res, queryErr := client.OnlineQuery(getParams(), &implicitUser)
+			res, queryErr := client.OnlineQuery(context.Background(), getParams(), &implicitUser)
 			if queryErr != nil {
 				t.Fatal("Failed querying features", queryErr)
 			}
@@ -122,7 +122,7 @@ func TestNamedQueriesE2E(t *testing.T) {
 				WithInput("user.id", 1).
 				WithQueryName("user_socure_score")
 
-			_, queryErr := client.OnlineQuery(params, &implicitUser)
+			_, queryErr := client.OnlineQuery(context.Background(), params, &implicitUser)
 			if queryErr != nil {
 				t.Fatal("Failed querying features", queryErr)
 			}
@@ -258,7 +258,7 @@ func TestOnlineQueryParamsDoesNotErr(t *testing.T) {
 				WithOutputs(testFeatures.User.FullName).
 				WithStaleness(testFeatures.User.SocureScore, time.Minute*10)
 
-			_, err = client.OnlineQuery(req, nil)
+			_, err = client.OnlineQuery(context.Background(), req, nil)
 			assert.NoError(t, err)
 		})
 	}
@@ -301,7 +301,7 @@ func TestCustomCerts(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			var userObj user
-			_, queryErr := client.OnlineQuery(getParams(), &userObj)
+			_, queryErr := client.OnlineQuery(context.Background(), getParams(), &userObj)
 			assert.NoError(t, queryErr)
 		})
 	}

--- a/internal/tests/integration/query_test.go
+++ b/internal/tests/integration/query_test.go
@@ -206,7 +206,7 @@ func TestOnlineQueryBulkParamsDoesNotErr(t *testing.T) {
 				WithOutputs(testFeatures.User.FullName).
 				WithStaleness(testFeatures.User.SocureScore, time.Minute*10)
 
-			_, err = client.OnlineQueryBulk(req)
+			_, err = client.OnlineQueryBulk(context.Background(), req)
 			assert.NoError(t, err)
 		})
 	}

--- a/internal/tests/integration/upload_test.go
+++ b/internal/tests/integration/upload_test.go
@@ -52,7 +52,7 @@ func TestUploadFeatures(t *testing.T) {
 		t.Fatalf("Queried feature 'user.socure_score' value '%v' for does not match uploaded value '%v'", castAns, socureScores[0])
 	}
 
-	bulkRes, err := client.OnlineQueryBulk(chalk.OnlineQueryParams{}.WithInput("user.id", userIds).WithOutputs("user.socure_score"))
+	bulkRes, err := client.OnlineQueryBulk(context.Background(), chalk.OnlineQueryParams{}.WithInput("user.id", userIds).WithOutputs("user.socure_score"))
 	if err != nil {
 		t.Fatal("Failed querying features", err)
 	}

--- a/internal/tests/integration/upload_test.go
+++ b/internal/tests/integration/upload_test.go
@@ -26,12 +26,15 @@ func TestUploadFeatures(t *testing.T) {
 	userIds := []int{111, 222, 333}
 	socureScores := []float64{rand.Float64(), rand.Float64(), rand.Float64()}
 
-	_, err = client.UploadFeatures(chalk.UploadFeaturesParams{
-		Inputs: map[any]any{
-			"user.id":           userIds,
-			"user.socure_score": socureScores,
+	_, err = client.UploadFeatures(
+		context.Background(),
+		chalk.UploadFeaturesParams{
+			Inputs: map[any]any{
+				"user.id":           userIds,
+				"user.socure_score": socureScores,
+			},
 		},
-	})
+	)
 	if err != nil {
 		t.Fatal("Failed uploading features", err)
 	}

--- a/internal/tests/integration/upload_test.go
+++ b/internal/tests/integration/upload_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"context"
 	"fmt"
 	"github.com/apache/arrow/go/v16/arrow/array"
 	"github.com/chalk-ai/chalk-go"
@@ -35,7 +36,7 @@ func TestUploadFeatures(t *testing.T) {
 		t.Fatal("Failed uploading features", err)
 	}
 
-	res, err := client.OnlineQuery(chalk.OnlineQueryParams{}.WithInput("user.id", userIds[0]).WithOutputs("user.socure_score"), nil)
+	res, err := client.OnlineQuery(context.Background(), chalk.OnlineQueryParams{}.WithInput("user.id", userIds[0]).WithOutputs("user.socure_score"), nil)
 	if err != nil {
 		t.Fatal("Failed querying features", err)
 	}

--- a/models.go
+++ b/models.go
@@ -390,10 +390,14 @@ type OnlineQueryBulkResult struct {
 // Usage example:
 //
 //	func printUserDetails(chalkClient chalk.Client) {
-//		result, _ := chalkClient.OnlineQueryBulk(chalk.OnlineQueryParams{}.WithOutputs(
-//			Features.User.Family.Size,
-//			Features.User.SocureScore
-//		).WithInput(Features.User.Id, []int{1, 2}), nil)
+//		result, _ := chalkClient.OnlineQueryBulk(
+//			context.Background(),
+//	  	    chalk.OnlineQueryParams{}.WithOutputs(
+//			    Features.User.Family.Size,
+//			    Features.User.SocureScore
+//		    ).WithInput(Features.User.Id, []int{1, 2}),
+//		    nil,
+//		)
 //
 //		var users []User
 //		result.UnmarshalInto(&users)

--- a/models.go
+++ b/models.go
@@ -270,22 +270,22 @@ type FeatureResult struct {
 //
 // Equivalent explicit usage example:
 //
-//		func printUserDetails(chalkClient chalk.Client) {
-//			result, _ := chalkClient.OnlineQuery(
-//	            context.Background(),
-//			    chalk.OnlineQueryParams{}.WithOutputs(
-//				    Features.User.Family.Size,
-//				    Features.User.SocureScore
-//			    ).WithInput(Features.User.Id, 1),
-//			    nil
-//			)
+//	func printUserDetails(chalkClient chalk.Client) {
+//		result, _ := chalkClient.OnlineQuery(
+//		    context.Background(),
+//		    chalk.OnlineQueryParams{}.WithOutputs(
+//			    Features.User.Family.Size,
+//			    Features.User.SocureScore
+//		    ).WithInput(Features.User.Id, 1),
+//		    nil
+//		)
 //
-//			user := User{}
-//			result.UnmarshalInto(&user)
+//		user := User{}
+//		result.UnmarshalInto(&user)
 //
-//			fmt.Println("User family size: ", *user.Family.Size)
-//			fmt.Println("User Socure score: ", *user.SocureScore)
-//		}
+//		fmt.Println("User family size: ", *user.Family.Size)
+//		fmt.Println("User Socure score: ", *user.SocureScore)
+//	}
 //
 // To ensure fast unmarshals, see `WarmUpUnmarshaller`.
 func (result *OnlineQueryResult) UnmarshalInto(resultHolder any) (returnErr error) {
@@ -391,7 +391,7 @@ type OnlineQueryBulkResult struct {
 //
 //	func printUserDetails(chalkClient chalk.Client) {
 //		result, _ := chalkClient.OnlineQueryBulk(
-//			context.Background(),
+//	  	    context.Background(),
 //	  	    chalk.OnlineQueryParams{}.WithOutputs(
 //			    Features.User.Family.Size,
 //			    Features.User.SocureScore

--- a/models.go
+++ b/models.go
@@ -256,7 +256,7 @@ type FeatureResult struct {
 //		func printUserDetails(chalkClient chalk.Client) {
 //			user := User{}
 //			chalkClient.OnlineQuery(
-//	         context.Background(),
+//	            context.Background(),
 //		    	chalk.OnlineQueryParams{}.WithOutputs(
 //			    	 Features.User.Family.Size,
 //				     Features.User.SocureScore
@@ -272,7 +272,7 @@ type FeatureResult struct {
 //
 //		func printUserDetails(chalkClient chalk.Client) {
 //			result, _ := chalkClient.OnlineQuery(
-//	         context.Background(),
+//	            context.Background(),
 //			    chalk.OnlineQueryParams{}.WithOutputs(
 //				    Features.User.Family.Size,
 //				    Features.User.SocureScore

--- a/models.go
+++ b/models.go
@@ -650,12 +650,12 @@ type DatasetRevision struct {
 // Datasets are stored in Chalk as sharded Parquet files. With this
 // method, you can download those raw files into a directory for processing
 // with other tools.
-func (d *DatasetRevision) DownloadData(directory string) error {
+func (d *DatasetRevision) DownloadData(ctx context.Context, directory string) error {
 	urls, getUrlsErr := d.client.getDatasetUrls(d.RevisionId, "")
 	if getUrlsErr != nil {
 		return errors.Wrap(getUrlsErr, "get dataset urls")
 	}
-	g, _ := errgroup.WithContext(context.Background())
+	g, _ := errgroup.WithContext(ctx)
 	for _, url := range urls {
 		// Capture the loop variables in the closure.
 		u := url

--- a/models.go
+++ b/models.go
@@ -256,10 +256,10 @@ type FeatureResult struct {
 //	func printUserDetails(chalkClient chalk.Client) {
 //		user := User{}
 //		chalkClient.OnlineQuery(
-//	    	context.Background(),
-//	    	chalk.OnlineQueryParams{}.WithOutputs(
-//		    	 Features.User.Family.Size,
-//			     Features.User.SocureScore
+//		    context.Background(),
+//		    chalk.OnlineQueryParams{}.WithOutputs(
+//			    Features.User.Family.Size,
+//			    Features.User.SocureScore
 //		    ).WithInput(Features.User.Id, 1),
 //		    &user,
 //		)

--- a/models.go
+++ b/models.go
@@ -253,31 +253,39 @@ type FeatureResult struct {
 //
 // Implicit usage example (pass result struct into OnlineQuery):
 //
-//	func printUserDetails(chalkClient chalk.Client) {
-//		user := User{}
-//		chalkClient.OnlineQuery(chalk.OnlineQueryParams{}.WithOutputs(
-//			 Features.User.Family.Size,
-//			 Features.User.SocureScore
-//		).WithInput(Features.User.Id, 1), &user)
+//		func printUserDetails(chalkClient chalk.Client) {
+//			user := User{}
+//			chalkClient.OnlineQuery(
+//	         context.Background(),
+//		    	chalk.OnlineQueryParams{}.WithOutputs(
+//			    	 Features.User.Family.Size,
+//				     Features.User.SocureScore
+//			    ).WithInput(Features.User.Id, 1),
+//			    &user,
+//			)
 //
-//		fmt.Println("User family size: ", *user.Family.Size)
-//		fmt.Println("User Socure score: ", *user.SocureScore)
-//	}
+//			fmt.Println("User family size: ", *user.Family.Size)
+//			fmt.Println("User Socure score: ", *user.SocureScore)
+//		}
 //
 // Equivalent explicit usage example:
 //
-//	func printUserDetails(chalkClient chalk.Client) {
-//		result, _ := chalkClient.OnlineQuery(chalk.OnlineQueryParams{}.WithOutputs(
-//			Features.User.Family.Size,
-//			Features.User.SocureScore
-//		).WithInput(Features.User.Id, 1), nil)
+//		func printUserDetails(chalkClient chalk.Client) {
+//			result, _ := chalkClient.OnlineQuery(
+//	         context.Background(),
+//			    chalk.OnlineQueryParams{}.WithOutputs(
+//				    Features.User.Family.Size,
+//				    Features.User.SocureScore
+//			    ).WithInput(Features.User.Id, 1),
+//			    nil
+//			)
 //
-//		user := User{}
-//		result.UnmarshalInto(&user)
+//			user := User{}
+//			result.UnmarshalInto(&user)
 //
-//		fmt.Println("User family size: ", *user.Family.Size)
-//		fmt.Println("User Socure score: ", *user.SocureScore)
-//	}
+//			fmt.Println("User family size: ", *user.Family.Size)
+//			fmt.Println("User Socure score: ", *user.SocureScore)
+//		}
 //
 // To ensure fast unmarshals, see `WarmUpUnmarshaller`.
 func (result *OnlineQueryResult) UnmarshalInto(resultHolder any) (returnErr error) {
@@ -651,7 +659,7 @@ type DatasetRevision struct {
 // method, you can download those raw files into a directory for processing
 // with other tools.
 func (d *DatasetRevision) DownloadData(ctx context.Context, directory string) error {
-	urls, getUrlsErr := d.client.getDatasetUrls(d.RevisionId, "")
+	urls, getUrlsErr := d.client.getDatasetUrls(ctx, d.RevisionId, "")
 	if getUrlsErr != nil {
 		return errors.Wrap(getUrlsErr, "get dataset urls")
 	}

--- a/models.go
+++ b/models.go
@@ -253,20 +253,20 @@ type FeatureResult struct {
 //
 // Implicit usage example (pass result struct into OnlineQuery):
 //
-//		func printUserDetails(chalkClient chalk.Client) {
-//			user := User{}
-//			chalkClient.OnlineQuery(
-//	            context.Background(),
-//		    	chalk.OnlineQueryParams{}.WithOutputs(
-//			    	 Features.User.Family.Size,
-//				     Features.User.SocureScore
-//			    ).WithInput(Features.User.Id, 1),
-//			    &user,
-//			)
+//	func printUserDetails(chalkClient chalk.Client) {
+//		user := User{}
+//		chalkClient.OnlineQuery(
+//	    	context.Background(),
+//	    	chalk.OnlineQueryParams{}.WithOutputs(
+//		    	 Features.User.Family.Size,
+//			     Features.User.SocureScore
+//		    ).WithInput(Features.User.Id, 1),
+//		    &user,
+//		)
 //
-//			fmt.Println("User family size: ", *user.Family.Size)
-//			fmt.Println("User Socure score: ", *user.SocureScore)
-//		}
+//		fmt.Println("User family size: ", *user.Family.Size)
+//		fmt.Println("User Socure score: ", *user.SocureScore)
+//	}
 //
 // Equivalent explicit usage example:
 //

--- a/params_offline.go
+++ b/params_offline.go
@@ -18,7 +18,7 @@ import (
 //		     defaultObservedAt := time.Now().Add(-time.Hour)
 //				observedAt, _ := time.Parse(time.RFC822, "02 Jan 22 15:04 PST")
 //				client.OfflineQuery(
-//	             context.Background(),
+//	                context.Background(),
 //					OfflineQueryParams{
 //						EnvironmentId: "pipkjlfc3gtmn",
 //					}.

--- a/params_offline.go
+++ b/params_offline.go
@@ -15,16 +15,16 @@ import (
 //
 // Example:
 //
-//		     defaultObservedAt := time.Now().Add(-time.Hour)
-//				observedAt, _ := time.Parse(time.RFC822, "02 Jan 22 15:04 PST")
-//				client.OfflineQuery(
-//	                context.Background(),
-//					OfflineQueryParams{
-//						EnvironmentId: "pipkjlfc3gtmn",
-//					}.
-//			 		WithInput(Features.User.Id, []any{1, chalk.TsFeatureValue{Value: 2, ObservationTime: &observedAt}}).
-//			 		WithRequiredOutputs(Features.User.Email, Features.User.Card.Id),
-//				)
+//	     defaultObservedAt := time.Now().Add(-time.Hour)
+//			observedAt, _ := time.Parse(time.RFC822, "02 Jan 22 15:04 PST")
+//			client.OfflineQuery(
+//				context.Background(),
+//				OfflineQueryParams{
+//					EnvironmentId: "pipkjlfc3gtmn",
+//				}.
+//		 		WithInput(Features.User.Id, []any{1, chalk.TsFeatureValue{Value: 2, ObservationTime: &observedAt}}).
+//		 		WithRequiredOutputs(Features.User.Email, Features.User.Card.Id),
+//			)
 //
 // It is mandatory to call [OfflineQueryParams.WithOutput]
 // or [OfflineQueryParams.WithRequiredOutputs] at least once

--- a/params_offline.go
+++ b/params_offline.go
@@ -15,15 +15,16 @@ import (
 //
 // Example:
 //
-//	     defaultObservedAt := time.Now().Add(-time.Hour)
-//			observedAt, _ := time.Parse(time.RFC822, "02 Jan 22 15:04 PST")
-//			client.OfflineQuery(
-//				OfflineQueryParams{
-//					EnvironmentId: "pipkjlfc3gtmn",
-//				}.
-//		 		WithInput(Features.User.Id, []any{1, chalk.TsFeatureValue{Value: 2, ObservationTime: &observedAt}}).
-//		 		WithRequiredOutputs(Features.User.Email, Features.User.Card.Id),
-//			)
+//		     defaultObservedAt := time.Now().Add(-time.Hour)
+//				observedAt, _ := time.Parse(time.RFC822, "02 Jan 22 15:04 PST")
+//				client.OfflineQuery(
+//	             context.Background(),
+//					OfflineQueryParams{
+//						EnvironmentId: "pipkjlfc3gtmn",
+//					}.
+//			 		WithInput(Features.User.Id, []any{1, chalk.TsFeatureValue{Value: 2, ObservationTime: &observedAt}}).
+//			 		WithRequiredOutputs(Features.User.Email, Features.User.Card.Id),
+//				)
 //
 // It is mandatory to call [OfflineQueryParams.WithOutput]
 // or [OfflineQueryParams.WithRequiredOutputs] at least once

--- a/params_online.go
+++ b/params_online.go
@@ -15,14 +15,15 @@ import (
 //
 // Example:
 //
-//		client.OnlineQuery(
-//			OnlineQueryParams{
-//				IncludeMeta: true,
-//				EnvironmentId: "pipkjlfc3gtmn",
-//			}.
-//	 		WithInput(Features.User.Card.Id, 4).
-//	 		WithOutputs(Features.User.Email, Features.User.Card.Id),
-//		)
+//			client.OnlineQuery(
+//	         context.Background(),
+//				OnlineQueryParams{
+//					IncludeMeta: true,
+//					EnvironmentId: "pipkjlfc3gtmn",
+//				}.
+//		 		WithInput(Features.User.Card.Id, 4).
+//		 		WithOutputs(Features.User.Email, Features.User.Card.Id),
+//			)
 //
 // [OnlineQueryParams.WithInput] and [OnlineQueryParams.WithOutputs]
 // are mandatory methods. This means they must each be called at

--- a/params_online.go
+++ b/params_online.go
@@ -15,15 +15,15 @@ import (
 //
 // Example:
 //
-//			client.OnlineQuery(
-//	            context.Background(),
-//				OnlineQueryParams{
-//					IncludeMeta: true,
-//					EnvironmentId: "pipkjlfc3gtmn",
-//				}.
-//		 		WithInput(Features.User.Card.Id, 4).
-//		 		WithOutputs(Features.User.Email, Features.User.Card.Id),
-//			)
+//		client.OnlineQuery(
+//			context.Background(),
+//			OnlineQueryParams{
+//				IncludeMeta: true,
+//				EnvironmentId: "pipkjlfc3gtmn",
+//			}.
+//	 		WithInput(Features.User.Card.Id, 4).
+//	 		WithOutputs(Features.User.Email, Features.User.Card.Id),
+//		)
 //
 // [OnlineQueryParams.WithInput] and [OnlineQueryParams.WithOutputs]
 // are mandatory methods. This means they must each be called at

--- a/params_online.go
+++ b/params_online.go
@@ -16,7 +16,7 @@ import (
 // Example:
 //
 //			client.OnlineQuery(
-//	         context.Background(),
+//	            context.Background(),
 //				OnlineQueryParams{
 //					IncludeMeta: true,
 //					EnvironmentId: "pipkjlfc3gtmn",

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -298,9 +298,13 @@ func unmarshalTableInto(table arrow.Table, resultHolders any) (returnErr error) 
 // Usage:
 //
 //	func printNumRelatives(chalkClient chalk.Client) {
-//		result, _ := chalkClient.OnlineQueryBulk(chalk.OnlineQueryParams{}.WithOutputs(
-//			Features.User.Relatives,
-//		).WithInput(Features.User.Id, []int{1, 2}), nil)
+//		result, _ := chalkClient.OnlineQueryBulk(
+//		    context.Background(),
+//		    chalk.OnlineQueryParams{}.WithOutputs(
+//			    Features.User.Relatives,
+//		    ).WithInput(Features.User.Id, []int{1, 2}),
+//		    nil
+//		)
 //
 //		relatives := make([]Relative, 0)
 //		result.UnmarshalInto(&relatives)


### PR DESCRIPTION
This is a breaking change that merges first into the v1 base branch.

Adds context as a param to all `Client` methods so that users can do things such as specify timeouts and custom loggers. 