### PR TITLE
[xs] remove expectedOutputs

### DIFF
--- a/client_impl.go
+++ b/client_impl.go
@@ -244,7 +244,6 @@ func (c *clientImpl) OnlineQuery(params OnlineQueryParamsComplete, resultHolder 
 		return emptyResult, errors.Wrap(err, "deserializing online query response")
 	}
 
-	response.expectedOutputs = params.underlying.outputs
 	if resultHolder != nil {
 		unmarshalErr := response.UnmarshalInto(resultHolder)
 		if unmarshalErr != nil {

--- a/models.go
+++ b/models.go
@@ -177,9 +177,6 @@ type OnlineQueryResult struct {
 
 	// Used to efficiently get a FeatureResult by FQN.
 	features map[string]FeatureResult
-
-	// Used to validate result holder expected outputs are not nil.
-	expectedOutputs []string
 }
 
 // GetFeature returns a wrapper for the raw, uncasted value of the specified feature.

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -431,7 +431,7 @@ func UnmarshalInto(resultHolder any, fqnToValue map[Fqn]any) (returnErr error) {
 			field,
 			fqnToValue,
 			fieldNamespace,
-s			fieldNsScope,
+			fieldNsScope,
 			fieldNsMemo,
 			allMemo,
 		); err != nil {

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -145,7 +145,6 @@ func unmarshalRows(
 			res.Elem(),
 			row,
 			namespace,
-			nil,
 			namespaceScope,
 			namespaceMemo,
 			allMemo,
@@ -541,7 +540,7 @@ func UnmarshalOnlineQueryResponse(response *commonv1.OnlineQueryResponse, result
 		}
 		fqnToValue[featureResult.Field] = convertedValue
 	}
-	return UnmarshalInto(resultHolder, fqnToValue, nil)
+	return UnmarshalInto(resultHolder, fqnToValue)
 }
 
 func UnmarshalOnlineQueryBulkResponse(response *commonv1.OnlineQueryBulkResponse, resultHolders any) error {

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -117,7 +117,7 @@ func (result *OnlineQueryResult) unmarshal(resultHolder any) (returnErr error) {
 		}
 		fqnToValue[featureResult.Field] = convertedValue
 	}
-	return UnmarshalInto(resultHolder, fqnToValue, result.expectedOutputs)
+	return UnmarshalInto(resultHolder, fqnToValue)
 }
 
 type ChunkResult struct {
@@ -348,7 +348,7 @@ fields correspond to the FQNs. An illustration:
 
 To ensure fast unmarshals, see `WarmUpUnmarshaller`.
 */
-func UnmarshalInto(resultHolder any, fqnToValue map[Fqn]any, expectedOutputs []string) (returnErr error) {
+func UnmarshalInto(resultHolder any, fqnToValue map[Fqn]any) (returnErr error) {
 	allMemo := internal.AllNamespaceMemo
 	if err := internal.PopulateAllNamespaceMemo(reflect.ValueOf(resultHolder).Elem().Type()); err != nil {
 		return errors.Wrap(err, "building namespace memo")
@@ -384,7 +384,6 @@ func UnmarshalInto(resultHolder any, fqnToValue map[Fqn]any, expectedOutputs []s
 			holderValue.Elem(),
 			fqnToValue,
 			namespace,
-			expectedOutputs,
 			nsScope,
 			nsMemo,
 			allMemo,
@@ -432,8 +431,7 @@ func UnmarshalInto(resultHolder any, fqnToValue map[Fqn]any, expectedOutputs []s
 			field,
 			fqnToValue,
 			fieldNamespace,
-			expectedOutputs,
-			fieldNsScope,
+s			fieldNsScope,
 			fieldNsMemo,
 			allMemo,
 		); err != nil {
@@ -450,7 +448,6 @@ func thinUnmarshalInto(
 	structValue reflect.Value,
 	fqnToValue map[Fqn]any,
 	namespace string,
-	expectedOutputs []string,
 	namespaceScope *scopeTrie,
 	namespaceMemo *internal.NamespaceMemo,
 	allMemo *internal.AllNamespaceMemoT,

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -247,11 +247,10 @@ func TestOnlineQueryUnmarshalNonBulkAllTypes(t *testing.T) {
 		},
 	}
 	result := OnlineQueryResult{
-		Data:            data,
-		Meta:            nil,
-		features:        nil,
-		expectedOutputs: nil,
-	}
+		Data:     data,
+		Meta:     nil,
+		features: nil,
+		s}
 	features := allTypes{}
 	unmarshalErr := result.UnmarshalInto(&features)
 	if unmarshalErr != nil {
@@ -346,10 +345,9 @@ func TestUnmarshalVersionedFeatures(t *testing.T) {
 		},
 	}
 	result := OnlineQueryResult{
-		Data:            data,
-		Meta:            nil,
-		features:        nil,
-		expectedOutputs: nil,
+		Data:     data,
+		Meta:     nil,
+		features: nil,
 	}
 	user := unmarshalUSER{}
 	unmarshalErr := result.UnmarshalInto(&user)
@@ -390,10 +388,9 @@ func TestUnmarshalWindowedFeatures(t *testing.T) {
 		},
 	}
 	result := OnlineQueryResult{
-		Data:            data,
-		Meta:            nil,
-		features:        nil,
-		expectedOutputs: nil,
+		Data:     data,
+		Meta:     nil,
+		features: nil,
 	}
 	user := unmarshalUSER{}
 	unmarshalErr := result.UnmarshalInto(&user)
@@ -434,10 +431,9 @@ func TestUnmarshalWindowedFeaturesChildrenAllNil(t *testing.T) {
 		},
 	}
 	result := OnlineQueryResult{
-		Data:            data,
-		Meta:            nil,
-		features:        nil,
-		expectedOutputs: nil,
+		Data:     data,
+		Meta:     nil,
+		features: nil,
 	}
 	user := unmarshalUSER{}
 	unmarshalErr := result.UnmarshalInto(&user)
@@ -463,10 +459,9 @@ func TestUnmarshalDataclassFeatures(t *testing.T) {
 		},
 	}
 	result := OnlineQueryResult{
-		Data:            data,
-		Meta:            nil,
-		features:        nil,
-		expectedOutputs: nil,
+		Data:     data,
+		Meta:     nil,
+		features: nil,
 	}
 	user := unmarshalUSER{}
 	unmarshalErr := result.UnmarshalInto(&user)
@@ -491,10 +486,9 @@ func TestUnmarshalWrongType(t *testing.T) {
 		},
 	}
 	result := OnlineQueryResult{
-		Data:            data,
-		Meta:            nil,
-		features:        nil,
-		expectedOutputs: nil,
+		Data:     data,
+		Meta:     nil,
+		features: nil,
 	}
 	user := unmarshalUSER{}
 	unmarshalErr := result.UnmarshalInto(&user)
@@ -1143,10 +1137,9 @@ func TestSingleUnmarshalIntoExtraFields(t *testing.T) {
 	} {
 		t.Run(fixture.name, func(t *testing.T) {
 			result := OnlineQueryResult{
-				Data:            fixture.data,
-				Meta:            nil,
-				features:        nil,
-				expectedOutputs: nil,
+				Data:     fixture.data,
+				Meta:     nil,
+				features: nil,
 			}
 			featureStruct := allTypes{}
 			unmarshalErr := result.UnmarshalInto(&featureStruct)

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -250,7 +250,7 @@ func TestOnlineQueryUnmarshalNonBulkAllTypes(t *testing.T) {
 		Data:     data,
 		Meta:     nil,
 		features: nil,
-		s}
+	}
 	features := allTypes{}
 	unmarshalErr := result.UnmarshalInto(&features)
 	if unmarshalErr != nil {


### PR DESCRIPTION
This is a breaking change that merges first into the v1 base branch.

Remove an unused var that's being passed around. This was a relic from an attempt to validate requested features are all returned in the response. 