### PR TITLE
[ci] Benchmark bulk multi-namespace unmarshal

### DIFF
--- a/internal/tests/benchmark/unmarshal_test.go
+++ b/internal/tests/benchmark/unmarshal_test.go
@@ -2,7 +2,10 @@ package benchmark
 
 import (
 	"fmt"
+	"github.com/apache/arrow/go/v16/arrow"
+	"github.com/apache/arrow/go/v16/arrow/array"
 	"github.com/chalk-ai/chalk-go"
+	"github.com/chalk-ai/chalk-go/internal"
 	"github.com/chalk-ai/chalk-go/internal/tests/benchmark/fixtures"
 	assert "github.com/stretchr/testify/require"
 	"sync"
@@ -42,6 +45,89 @@ func benchmarkParallel(b *testing.B, benchmarkFunc func()) {
 	avg := b.Elapsed() / time.Duration(b.N)
 	b.ReportMetric(0, "ns/op")                                  // Effective hides the default ns/op metric
 	b.ReportMetric((float64(avg.Nanoseconds()) / 1e6), "ms/op") // The same metric but in ms
+}
+
+func getBenchmarkBulkMultiNsPrimitives(b *testing.B) func() {
+	bulkData := make(map[string]any)
+	for i := 0; i < 100; i++ {
+		for j := 1; j <= 40; j++ {
+			fqn := fmt.Sprintf("int_features.int_%d", j)
+			if _, ok := bulkData[fqn]; !ok {
+				bulkData[fqn] = []float64{}
+			}
+			bulkData[fqn] = append(bulkData[fqn].([]float64), float64(122.0))
+
+			fqn = fmt.Sprintf("float_features.float_%d", j)
+			if _, ok := bulkData[fqn]; !ok {
+				bulkData[fqn] = []float64{}
+			}
+			bulkData[fqn] = append(bulkData[fqn].([]float64), float64(1.234))
+
+			fqn = fmt.Sprintf("bool_features.bool_%d", j)
+			if _, ok := bulkData[fqn]; !ok {
+				bulkData[fqn] = []bool{}
+			}
+			bulkData[fqn] = append(bulkData[fqn].([]bool), true)
+
+			fqn = fmt.Sprintf("string_features.string_%d", j)
+			if _, ok := bulkData[fqn]; !ok {
+				bulkData[fqn] = []string{}
+			}
+			bulkData[fqn] = append(bulkData[fqn].([]string), fmt.Sprintf("string_val_%d", i))
+
+			fqn = fmt.Sprintf("timestamp_features.timestamp_%d", j)
+			if _, ok := bulkData[fqn]; !ok {
+				bulkData[fqn] = []string{}
+			}
+			bulkData[fqn] = append(bulkData[fqn].([]string), "2024-05-09T22:29:00Z")
+		}
+	}
+
+	record, err := internal.ColumnMapToRecord(bulkData)
+	assert.NoError(b, err)
+
+	table := array.NewTableFromRecords(record.Schema(), []arrow.Record{record})
+
+	res := chalk.OnlineQueryBulkResult{
+		ScalarsTable: table,
+	}
+
+	assertOnce := sync.Once{}
+	benchFunc := func() {
+		intFeatures := []fixtures.IntFeatures{}
+		floatFeatures := []fixtures.FloatFeatures{}
+		boolFeatures := []fixtures.BoolFeatures{}
+		stringFeatures := []fixtures.StringFeatures{}
+		timestampFeatures := []fixtures.TimestampFeatures{}
+
+		err := res.UnmarshalInto(&intFeatures)
+		assert.Equal(b, (*chalk.ClientError)(nil), err)
+		err = res.UnmarshalInto(&floatFeatures)
+		assert.Equal(b, (*chalk.ClientError)(nil), err)
+		err = res.UnmarshalInto(&boolFeatures)
+		assert.Equal(b, (*chalk.ClientError)(nil), err)
+		err = res.UnmarshalInto(&stringFeatures)
+		assert.Equal(b, (*chalk.ClientError)(nil), err)
+		err = res.UnmarshalInto(&timestampFeatures)
+		assert.Equal(b, (*chalk.ClientError)(nil), err)
+
+		assertOnce.Do(func() {
+			for i := 0; i < 100; i++ {
+				assert.Equal(b, int64(122.0), *intFeatures[i].Int1)
+				assert.Equal(b, int64(122.0), *intFeatures[i].Int40)
+				assert.Equal(b, float64(1.234), *floatFeatures[i].Float1)
+				assert.Equal(b, float64(1.234), *floatFeatures[i].Float40)
+				assert.Equal(b, fmt.Sprintf("string_val_%d", i), *stringFeatures[i].String1)
+				assert.Equal(b, fmt.Sprintf("string_val_%d", i), *stringFeatures[i].String40)
+				assert.True(b, *boolFeatures[i].Bool1)
+				assert.True(b, *boolFeatures[i].Bool40)
+				assert.Equal(b, time.Date(2024, 5, 9, 22, 29, 0, 0, time.UTC), *timestampFeatures[i].Timestamp1)
+				assert.Equal(b, time.Date(2024, 5, 9, 22, 29, 0, 0, time.UTC), *timestampFeatures[i].Timestamp40)
+			}
+		})
+	}
+
+	return benchFunc
 }
 
 func getBenchmarkMultiNsPrimitives(b *testing.B) func() {
@@ -241,4 +327,15 @@ func BenchmarkUnmarshalMultiNsPrimitivesSingle(b *testing.B) {
  */
 func BenchmarkUnmarshalMultiNsPrimitivesParallel(b *testing.B) {
 	benchmarkParallel(b, getBenchmarkMultiNsPrimitives(b))
+}
+
+/*
+ * Query: Bulk
+ * Namespaces: Multi
+ * Feature Type: Primitives
+ * Protocol: REST
+ * Run Type: Single
+ */
+func BenchmarkUnmarshalBulkMultiNsPrimitivesSingle(b *testing.B) {
+	benchmark(b, getBenchmarkBulkMultiNsPrimitives(b))
 }

--- a/internal/tests/benchmark/unmarshal_test.go
+++ b/internal/tests/benchmark/unmarshal_test.go
@@ -339,3 +339,14 @@ func BenchmarkUnmarshalMultiNsPrimitivesParallel(b *testing.B) {
 func BenchmarkUnmarshalBulkMultiNsPrimitivesSingle(b *testing.B) {
 	benchmark(b, getBenchmarkBulkMultiNsPrimitives(b))
 }
+
+/*
+ * Query: Bulk
+ * Namespaces: Multi
+ * Feature Type: Primitives
+ * Protocol: REST
+ * Run Type: Parallel
+ */
+func BenchmarkUnmarshalBulkMultiNsPrimitivesParallel(b *testing.B) {
+	benchmarkParallel(b, getBenchmarkBulkMultiNsPrimitives(b))
+}


### PR DESCRIPTION
Adds a benchmark for bulk multi-namespace unmarshal, in preparation for introducing single-call multi-namespace unmarshal for bulk queries. i.e. the bulk version of #289 