### PR TITLE
Fix allocators

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,6 +20,8 @@ jobs:
           go-version: "stable"
       - name: Run benchmark
         run: go test -bench=. ./... | tee output.txt
+        env:
+          CHALK_USE_CHECKED_ALLOCATOR: 1
 
       - name: Set benchmark directory
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,3 +38,5 @@ jobs:
           --junitfile-hide-empty-pkg \
           --format=github-actions -- \
             -shuffle=on -vet=all ./...
+      env:
+        CHALK_USE_CHECKED_ALLOCATOR: 1

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -25,3 +25,4 @@ jobs:
           CHALK_CLIENT_ID: ${{ secrets.CHALK_CLIENT_ID }}
           CHALK_CLIENT_SECRET: ${{ secrets.CHALK_CLIENT_SECRET }}
           CHALK_API_SERVER: ${{ secrets.CHALK_API_SERVER }}
+          CHALK_USE_CHECKED_ALLOCATOR: 1

--- a/internal/feather.go
+++ b/internal/feather.go
@@ -9,7 +9,6 @@ import (
 	"github.com/apache/arrow/go/v16/arrow"
 	"github.com/apache/arrow/go/v16/arrow/array"
 	"github.com/apache/arrow/go/v16/arrow/ipc"
-	"github.com/apache/arrow/go/v16/arrow/memory"
 	"github.com/chalk-ai/chalk-go/internal/colls"
 	"github.com/cockroachdb/errors"
 	"reflect"
@@ -363,7 +362,7 @@ func ColumnMapToRecord(inputs map[string]any) (arrow.Record, error) {
 		schema = append(schema, arrow.Field{Name: k, Type: arrowType})
 	}
 
-	recordBuilder := array.NewRecordBuilder(memory.DefaultAllocator, arrow.NewSchema(schema, nil))
+	recordBuilder := array.NewRecordBuilder(ChalkAllocator, arrow.NewSchema(schema, nil))
 	defer recordBuilder.Release()
 
 	for idx, field := range schema {
@@ -546,7 +545,7 @@ func recordToBytes(record arrow.Record) ([]byte, error) {
 	fileWriter, err := ipc.NewFileWriter(
 		bws,
 		ipc.WithSchema(record.Schema()),
-		ipc.WithAllocator(memory.DefaultAllocator),
+		ipc.WithAllocator(ChalkAllocator),
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create Arrow Table writer")
@@ -787,7 +786,7 @@ func ChalkUnmarshal(body []byte) (map[string]any, error) {
 
 func ConvertBytesToTable(byteArr []byte) (result arrow.Table, err error) {
 	bytesReader := bytes.NewReader(byteArr)
-	fileReader, err := ipc.NewFileReader(bytesReader, ipc.WithAllocator(memory.DefaultAllocator))
+	fileReader, err := ipc.NewFileReader(bytesReader, ipc.WithAllocator(ChalkAllocator))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create Arrow file reader")
 	}

--- a/internal/feather.go
+++ b/internal/feather.go
@@ -791,7 +791,10 @@ func ConvertBytesToTable(byteArr []byte) (result arrow.Table, err error) {
 		return nil, errors.Wrap(err, "failed to create Arrow file reader")
 	}
 	defer func() {
-		err = fileReader.Close()
+		closeErr := fileReader.Close()
+		if err == nil {
+			err = closeErr
+		}
 	}()
 
 	records := make([]arrow.Record, fileReader.NumRecords())

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"github.com/apache/arrow/go/v16/arrow/memory"
 	"github.com/chalk-ai/chalk-go/internal/colls"
 	"github.com/chalk-ai/chalk-go/internal/ptr"
 	"github.com/cockroachdb/errors"
@@ -15,6 +16,8 @@ import (
 	"time"
 )
 
+var ChalkAllocator memory.Allocator
+
 var NameTag = "name"
 var WindowsTag = "windows"
 var ChalkTag = "chalk"
@@ -24,6 +27,14 @@ var NowTimeFormat = "2006-01-02T15:04:05.000000-07:00"
 var wordGroupsPattern = regexp.MustCompile(`(.)([A-Z][a-z]+)`)
 var dunderPattern = regexp.MustCompile(`__([A-Z])`)
 var trailingUpperPattern = regexp.MustCompile(`([a-z0-9])([A-Z])`)
+
+func init() {
+	if os.Getenv("CHALK_USE_CHECKED_ALLOCATOR") == "1" {
+		ChalkAllocator = memory.NewCheckedAllocator(memory.DefaultAllocator)
+	} else {
+		ChalkAllocator = memory.DefaultAllocator
+	}
+}
 
 func FileExists(path string) bool {
 	if _, err := os.Stat(path); err != nil {

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/apache/arrow/go/v16/arrow"
 	"github.com/apache/arrow/go/v16/arrow/array"
-	"github.com/apache/arrow/go/v16/arrow/memory"
 	"github.com/chalk-ai/chalk-go/internal"
 	"github.com/chalk-ai/chalk-go/internal/ptr"
 	assert "github.com/stretchr/testify/require"
@@ -950,7 +949,7 @@ func TestUnmarshalBulkQueryOptionalValues(t *testing.T) {
 	schema := arrow.NewSchema([]arrow.Field{
 		{Name: "all_types.string", Type: arrow.BinaryTypes.LargeString},
 	}, nil)
-	recordBuilder := array.NewRecordBuilder(memory.DefaultAllocator, schema)
+	recordBuilder := array.NewRecordBuilder(internal.ChalkAllocator, schema)
 	defer recordBuilder.Release()
 	recordBuilder.Field(0).(*array.LargeStringBuilder).AppendValues(
 		[]string{"abc", "def", "ghi"},
@@ -1010,7 +1009,7 @@ func TestUnmarshalBulkQueryTimestampsWithUnitVariety(t *testing.T) {
 					TimeZone: "UTC",
 				}},
 			}, nil)
-			recordBuilder := array.NewRecordBuilder(memory.DefaultAllocator, schema)
+			recordBuilder := array.NewRecordBuilder(internal.ChalkAllocator, schema)
 			defer recordBuilder.Release()
 			recordBuilder.Field(0).(*array.TimestampBuilder).AppendValues(
 				[]arrow.Timestamp{

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -950,10 +950,7 @@ func TestUnmarshalBulkQueryOptionalValues(t *testing.T) {
 	schema := arrow.NewSchema([]arrow.Field{
 		{Name: "all_types.string", Type: arrow.BinaryTypes.LargeString},
 	}, nil)
-	recordBuilder := array.NewRecordBuilder(
-		memory.NewGoAllocator(),
-		schema,
-	)
+	recordBuilder := array.NewRecordBuilder(memory.DefaultAllocator, schema)
 	defer recordBuilder.Release()
 	recordBuilder.Field(0).(*array.LargeStringBuilder).AppendValues(
 		[]string{"abc", "def", "ghi"},
@@ -1013,10 +1010,7 @@ func TestUnmarshalBulkQueryTimestampsWithUnitVariety(t *testing.T) {
 					TimeZone: "UTC",
 				}},
 			}, nil)
-			recordBuilder := array.NewRecordBuilder(
-				memory.NewGoAllocator(),
-				schema,
-			)
+			recordBuilder := array.NewRecordBuilder(memory.DefaultAllocator, schema)
 			defer recordBuilder.Release()
 			recordBuilder.Field(0).(*array.TimestampBuilder).AppendValues(
 				[]arrow.Timestamp{


### PR DESCRIPTION
Replaces `NewGoAllocator` and `NewCheckedAllocator` with `DefaultAllocator` in prod, and `NewCheckedAllocator` in tests, gated by an env var. 

For additional context, `NewCheckedAllocator` is slightly more expensive to make and use (0.1 ms per 10_000 * 40 unmarshal operation), so replacement here was somewhat meaningful for perf + means we won't panic upon a memory leak. `NewGoAllocator` is essentially creating a new struct, and we see no noticeable perf improvement.