### PR TITLE
Use sync.Once instead of sync.RWMutex for namespace memos [CHA-5929]

### DIFF
--- a/init_features.go
+++ b/init_features.go
@@ -198,7 +198,7 @@ func WarmUpUnmarshaller[T any](featureStruct *T) error {
 			elemType.Kind(),
 		)
 	}
-	return internal.PopulateAllNamespaceMemo(elemType, nil)
+	return internal.PopulateNamespaceMemos(elemType, nil)
 }
 
 func pointerCheck(field reflect.Value) error {

--- a/internal/memo.go
+++ b/internal/memo.go
@@ -1,0 +1,25 @@
+package internal
+
+import (
+	"sync"
+)
+
+type Memo[V any] struct {
+	object *V
+	err    error
+	once   sync.Once
+}
+
+type MemosT[K, V any] sync.Map
+
+func (m *MemosT[K, V]) LoadOrStore(key K, generateObject func() (*V, error)) (*V, error) {
+	value, loaded := (*sync.Map)(m).Load(key)
+	if !loaded {
+		value, _ = (*sync.Map)(m).LoadOrStore(key, &Memo[V]{})
+	}
+	memo := value.(*Memo[V])
+	memo.once.Do(func() {
+		memo.object, memo.err = generateObject()
+	})
+	return memo.object, memo.err
+}

--- a/internal/memo_namespace.go
+++ b/internal/memo_namespace.go
@@ -1,0 +1,144 @@
+package internal
+
+import (
+	"github.com/cockroachdb/errors"
+	"reflect"
+	"strconv"
+	"time"
+)
+
+type NamespaceMemo struct {
+	// Rooted and non-rooted FQN as keys
+	ResolvedFieldNameToIndices map[string][]int
+	// Non-rooted FQN as keys only
+	StructFieldsSet map[string]bool
+}
+
+type NamespaceMemosT MemosT[reflect.Type, NamespaceMemo]
+
+var NamespaceMemos = &NamespaceMemosT{}
+
+func (m *NamespaceMemosT) LoadOrStore(structType reflect.Type) (*NamespaceMemo, error) {
+	return (*MemosT[reflect.Type, NamespaceMemo])(m).LoadOrStore(structType, func() (*NamespaceMemo, error) {
+		return populateNamespaceMemoStruct(structType, nil)
+	})
+}
+
+func (m *NamespaceMemosT) LoadOrStoreWithVisited(structType reflect.Type, visited map[reflect.Type]bool) (*NamespaceMemo, error) {
+	return (*MemosT[reflect.Type, NamespaceMemo])(m).LoadOrStore(structType, func() (*NamespaceMemo, error) {
+		return populateNamespaceMemoStruct(structType, visited)
+	})
+}
+
+func populateNamespaceMemoStruct(typ reflect.Type, visited map[reflect.Type]bool) (*NamespaceMemo, error) {
+	if visited == nil {
+		visited = map[reflect.Type]bool{}
+	}
+	structName := typ.Name()
+	namespace := ChalkpySnakeCase(structName)
+	nsMemo := NamespaceMemo{
+		ResolvedFieldNameToIndices: map[string][]int{},
+		StructFieldsSet:            map[string]bool{},
+	}
+	for fieldIdx := 0; fieldIdx < typ.NumField(); fieldIdx++ {
+		fm := typ.Field(fieldIdx)
+		resolvedName, err := ResolveFeatureName(fm)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error resolving feature name: %s", fm.Name)
+		}
+		nsMemo.ResolvedFieldNameToIndices[resolvedName] = append(nsMemo.ResolvedFieldNameToIndices[resolvedName], fieldIdx)
+		// Has-many features come back as a list of structs whose keys are namespaced FQNs.
+		// Here we map those keys to their respective indices in the struct, so that we
+		// don't have to do any string manipulation to deprefix the FQN when unmarshalling.
+		rootFqn := namespace + "." + resolvedName
+		nsMemo.ResolvedFieldNameToIndices[rootFqn] = append(nsMemo.ResolvedFieldNameToIndices[rootFqn], fieldIdx)
+
+		// Handle exploding windowed features
+		if fm.Type.Kind() == reflect.Map {
+			// Is a windowed feature
+			intTags, err := GetWindowBucketsSecondsFromStructTag(fm)
+			if err != nil {
+				return nil, errors.Wrapf(
+					err,
+					"error getting window buckets for field '%s' in struct '%s'",
+					fm.Name,
+					structName,
+				)
+			}
+			for _, tag := range intTags {
+				bucketFqn := resolvedName + "__" + strconv.Itoa(tag) + "__"
+				nsMemo.ResolvedFieldNameToIndices[bucketFqn] = append(nsMemo.ResolvedFieldNameToIndices[bucketFqn], fieldIdx)
+				rootBucketFqn := namespace + "." + bucketFqn
+				nsMemo.ResolvedFieldNameToIndices[rootBucketFqn] = append(nsMemo.ResolvedFieldNameToIndices[rootBucketFqn], fieldIdx)
+			}
+		} else {
+			if err := PopulateNamespaceMemos(fm.Type, visited); err != nil {
+				return nil, errors.Wrapf(err, "populating namespace memo for field '%s'", fm.Name)
+			}
+		}
+
+		if fm.Type.Kind() == reflect.Ptr && IsStruct(fm.Type.Elem()) && !IsTypeDataclass(fm.Type.Elem()) {
+			nsMemo.StructFieldsSet[resolvedName] = true
+		}
+	}
+
+	return &nsMemo, nil
+}
+
+/*PopulateNamespaceMemos populates a memo for each struct to make bulk-unmarshalling and has-many unmarshalling
+* efficient. i.e. Given:
+ *  type User struct {
+ *      Id *string
+ *      Transactions *[]Transactions `has_many:"id,user_id"`
+ *      Grade   *int `versioned:"default(2)"`
+ *      GradeV1 *int `versioned:"true"`
+ *      GradeV2 *int `versioned:"true"`
+ *  }
+ *  type Transactions struct {
+ *      Id *string
+ *      UserId *string
+ *      Amount *float64
+ *  }
+ *  The namespace memo will be:
+ *  {
+ *      "User": {
+ *          ResolvedFieldNameToIndices: {
+ *              "id": [0],
+ *              "user.id": [0],
+ *              "grade@2": [2, 4],
+ *              "user.grade@2": [2, 4],
+ *              "grade": [3],
+ *              "user.grade": [3],
+ *              "transactions": [1],
+ *              "user.transactions": [1],
+ *          }
+ *      },
+ *      "Transactions": {
+ *          ResolvedFieldNameToIndices: {
+ *              "id": [0],
+ *              "transactions.id": [0],
+ *              "user_id": [1],
+ *              "transactions.user_id": [1],
+ *              "amount": [2],
+ *              "transactions.amount": [2],
+ *          }
+ *      }
+ *  }
+*/
+func PopulateNamespaceMemos(typ reflect.Type, visited map[reflect.Type]bool) error {
+	if visited == nil {
+		visited = map[reflect.Type]bool{}
+	}
+	if typ.Kind() == reflect.Ptr || typ.Kind() == reflect.Slice {
+		return PopulateNamespaceMemos(typ.Elem(), visited)
+	} else if typ.Kind() == reflect.Struct && typ != reflect.TypeOf(time.Time{}) {
+		if visited[typ] {
+			return nil
+		}
+		visited[typ] = true
+		if _, err := NamespaceMemos.LoadOrStoreWithVisited(typ, visited); err != nil {
+			return errors.Wrap(err, "load-or-storing memo")
+		}
+	}
+	return nil
+}

--- a/internal/unmarshal.go
+++ b/internal/unmarshal.go
@@ -466,7 +466,7 @@ func GetReflectValue(value any, typ reflect.Type, allMemo *NamespaceMemosT) (*re
 			// This could be either a dataclass or a feature class.
 			memo, err := allMemo.LoadOrStore(structValue.Type())
 			if err != nil {
-				return nil, errors.Newf("loading memo for struct '%s'", structValue.Type().Name())
+				return nil, errors.Wrapf(err, "loading memo for struct '%s'", structValue.Type().Name())
 			}
 			if memo.ResolvedFieldNameToIndices == nil {
 				return nil, errors.Newf(
@@ -735,7 +735,7 @@ func InitRemoteFeatureMap(
 
 	memo, err := allMemo.LoadOrStore(structValue.Type())
 	if err != nil {
-		return errors.Newf("loading memo for struct '%s'", structName)
+		return errors.Wrapf(err, "loading memo for struct '%s'", structName)
 	}
 
 	var fieldNames []string
@@ -964,7 +964,7 @@ func UnmarshalTableInto(table arrow.Table, resultHolders any) (returnErr error) 
 		// single namespace unmarshalling
 		nsMemo, err := allMemo.LoadOrStore(sliceElemType)
 		if err != nil {
-			return errors.Newf("loading memo for type '%s'", sliceElemType.Name())
+			return errors.Wrapf(err, "loading memo for type '%s'", sliceElemType.Name())
 		}
 
 		rowToStruct = func(row map[string]any) (*reflect.Value, error) {
@@ -1023,7 +1023,7 @@ func UnmarshalTableInto(table arrow.Table, resultHolders any) (returnErr error) 
 
 			fieldMemo, err := allMemo.LoadOrStore(fieldMeta.Type)
 			if err != nil {
-				return errors.Newf("loading memo for type '%s'", fieldMeta.Type.Name())
+				return errors.Wrapf(err, "loading memo for type '%s'", fieldMeta.Type.Name())
 			}
 
 			namespaceMeta = append(namespaceMeta, namespaceMetaT{

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -102,7 +102,7 @@ func UnmarshalInto(resultHolder any, fqnToValue map[Fqn]any) (returnErr error) {
 
 		nsMemo, err := allMemo.LoadOrStore(holderValue.Elem().Type())
 		if err != nil {
-			return errors.Newf("loading memo for struct '%s'", structName)
+			return errors.Wrapf(err, "loading memo for struct '%s'", structName)
 		}
 
 		return internal.ThinUnmarshalInto(

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -148,8 +148,10 @@ func UnmarshalInto(resultHolder any, fqnToValue map[Fqn]any) (returnErr error) {
 
 		fieldNsMemo, err := allMemo.LoadOrStore(field.Type())
 		if err != nil {
-			return errors.Newf(
-				"loading memo for struct '%s' of field '%s'", field.Type().Name(), fieldMeta.Name,
+			return errors.Wrapf(
+				err,
+				"loading memo for struct '%s' of field '%s'",
+				field.Type().Name(), fieldMeta.Name,
 			)
 		}
 		if err := internal.ThinUnmarshalInto(

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -74,8 +74,8 @@ fields correspond to the FQNs. An illustration:
 To ensure fast unmarshals, see `WarmUpUnmarshaller`.
 */
 func UnmarshalInto(resultHolder any, fqnToValue map[Fqn]any) (returnErr error) {
-	allMemo := internal.AllNamespaceMemo
-	if err := internal.PopulateAllNamespaceMemo(reflect.ValueOf(resultHolder).Elem().Type(), nil); err != nil {
+	allMemo := internal.NamespaceMemos
+	if err := internal.PopulateNamespaceMemos(reflect.ValueOf(resultHolder).Elem().Type(), nil); err != nil {
 		return errors.Wrap(err, "building namespace memo")
 	}
 	scope, err := internal.BuildScope(colls.Keys(fqnToValue))
@@ -100,9 +100,9 @@ func UnmarshalInto(resultHolder any, fqnToValue map[Fqn]any) (returnErr error) {
 			)
 		}
 
-		nsMemo, ok := allMemo.Load(holderValue.Elem().Type())
-		if !ok {
-			return errors.Newf("namespace '%s' not found in memo", structName)
+		nsMemo, err := allMemo.LoadOrStore(holderValue.Elem().Type())
+		if err != nil {
+			return errors.Newf("loading memo for struct '%s'", structName)
 		}
 
 		return internal.ThinUnmarshalInto(
@@ -146,10 +146,10 @@ func UnmarshalInto(resultHolder any, fqnToValue map[Fqn]any) (returnErr error) {
 			)
 		}
 
-		fieldNsMemo, ok := allMemo.Load(field.Type())
-		if !ok {
+		fieldNsMemo, err := allMemo.LoadOrStore(field.Type())
+		if err != nil {
 			return errors.Newf(
-				"namespace for struct '%s' of field '%s' not found in memo", field.Type().Name(), fieldMeta.Name,
+				"loading memo for struct '%s' of field '%s'", field.Type().Name(), fieldMeta.Name,
 			)
 		}
 		if err := internal.ThinUnmarshalInto(

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -1291,12 +1291,12 @@ func TestWarmUpUnmarshaller(t *testing.T) {
 		LatLng      *unmarshalLatLNG
 	}
 	assert.NoError(t, WarmUpUnmarshaller(&rootFeatures))
-	_, ok := internal.AllNamespaceMemo.Load(reflect.TypeOf(unmarshalTransaction{}))
-	assert.True(t, ok)
-	_, ok = internal.AllNamespaceMemo.Load(reflect.TypeOf(unmarshalUSER{}))
-	assert.True(t, ok)
-	_, ok = internal.AllNamespaceMemo.Load(reflect.TypeOf(unmarshalLatLNG{}))
-	assert.True(t, ok)
+	_, err := internal.NamespaceMemos.LoadOrStore(reflect.TypeOf(unmarshalTransaction{}))
+	assert.NoError(t, err)
+	_, err = internal.NamespaceMemos.LoadOrStore(reflect.TypeOf(unmarshalUSER{}))
+	assert.NoError(t, err)
+	_, err = internal.NamespaceMemos.LoadOrStore(reflect.TypeOf(unmarshalLatLNG{}))
+	assert.NoError(t, err)
 }
 
 func TestWarmUpUnmarshallerConcurrent(t *testing.T) {
@@ -1329,32 +1329,32 @@ func TestWarmUpUnmarshallerConcurrent(t *testing.T) {
 			assert.NoError(t, WarmUpUnmarshaller(&rootFeatures))
 
 			// Check in reverse order of fields to more reliably catch race condition
-			_, ok := internal.AllNamespaceMemo.Load(reflect.TypeOf(fixtures.WindowedTimestampFeatures{}))
-			assert.True(t, ok)
-			_, ok = internal.AllNamespaceMemo.Load(reflect.TypeOf(fixtures.WindowedStringFeatures{}))
-			assert.True(t, ok)
-			_, ok = internal.AllNamespaceMemo.Load(reflect.TypeOf(fixtures.WindowedFloatFeatures{}))
-			assert.True(t, ok)
-			_, ok = internal.AllNamespaceMemo.Load(reflect.TypeOf(fixtures.WindowedIntFeatures{}))
-			assert.True(t, ok)
-			_, ok = internal.AllNamespaceMemo.Load(reflect.TypeOf(fixtures.WindowedBoolFeatures{}))
-			assert.True(t, ok)
-			_, ok = internal.AllNamespaceMemo.Load(reflect.TypeOf(fixtures.TimestampFeatures{}))
-			assert.True(t, ok)
-			_, ok = internal.AllNamespaceMemo.Load(reflect.TypeOf(fixtures.BoolFeatures{}))
-			assert.True(t, ok)
-			_, ok = internal.AllNamespaceMemo.Load(reflect.TypeOf(fixtures.IntFeatures{}))
-			assert.True(t, ok)
-			_, ok = internal.AllNamespaceMemo.Load(reflect.TypeOf(fixtures.FloatFeatures{}))
-			assert.True(t, ok)
-			_, ok = internal.AllNamespaceMemo.Load(reflect.TypeOf(fixtures.StringFeatures{}))
-			assert.True(t, ok)
-			_, ok = internal.AllNamespaceMemo.Load(reflect.TypeOf(unmarshalLatLNG{}))
-			assert.True(t, ok)
-			_, ok = internal.AllNamespaceMemo.Load(reflect.TypeOf(unmarshalUSER{}))
-			assert.True(t, ok)
-			_, ok = internal.AllNamespaceMemo.Load(reflect.TypeOf(unmarshalTransaction{}))
-			assert.True(t, ok)
+			_, err := internal.NamespaceMemos.LoadOrStore(reflect.TypeOf(fixtures.WindowedTimestampFeatures{}))
+			assert.NoError(t, err)
+			_, err = internal.NamespaceMemos.LoadOrStore(reflect.TypeOf(fixtures.WindowedStringFeatures{}))
+			assert.NoError(t, err)
+			_, err = internal.NamespaceMemos.LoadOrStore(reflect.TypeOf(fixtures.WindowedFloatFeatures{}))
+			assert.NoError(t, err)
+			_, err = internal.NamespaceMemos.LoadOrStore(reflect.TypeOf(fixtures.WindowedIntFeatures{}))
+			assert.NoError(t, err)
+			_, err = internal.NamespaceMemos.LoadOrStore(reflect.TypeOf(fixtures.WindowedBoolFeatures{}))
+			assert.NoError(t, err)
+			_, err = internal.NamespaceMemos.LoadOrStore(reflect.TypeOf(fixtures.TimestampFeatures{}))
+			assert.NoError(t, err)
+			_, err = internal.NamespaceMemos.LoadOrStore(reflect.TypeOf(fixtures.BoolFeatures{}))
+			assert.NoError(t, err)
+			_, err = internal.NamespaceMemos.LoadOrStore(reflect.TypeOf(fixtures.IntFeatures{}))
+			assert.NoError(t, err)
+			_, err = internal.NamespaceMemos.LoadOrStore(reflect.TypeOf(fixtures.FloatFeatures{}))
+			assert.NoError(t, err)
+			_, err = internal.NamespaceMemos.LoadOrStore(reflect.TypeOf(fixtures.StringFeatures{}))
+			assert.NoError(t, err)
+			_, err = internal.NamespaceMemos.LoadOrStore(reflect.TypeOf(unmarshalLatLNG{}))
+			assert.NoError(t, err)
+			_, err = internal.NamespaceMemos.LoadOrStore(reflect.TypeOf(unmarshalUSER{}))
+			assert.NoError(t, err)
+			_, err = internal.NamespaceMemos.LoadOrStore(reflect.TypeOf(unmarshalTransaction{}))
+			assert.NoError(t, err)
 		}()
 	}
 	wg.Wait()
@@ -1362,7 +1362,7 @@ func TestWarmUpUnmarshallerConcurrent(t *testing.T) {
 
 /*
  * TestUnmarshalConcurrently tests that unmarshalling the same data concurrently
- * works. Particularly the `internal.AllNamespaceMemo` object has to have thread-
+ * works. Particularly the `internal.NamespaceMemos` object has to have thread-
  * safe methods.
  */
 func TestUnmarshalConcurrently(t *testing.T) {


### PR DESCRIPTION
Replace `sync.Map + sync.RWMutex` implementation of namespace memos with `sync.Map + sync.Once`, because it has better (negligibly) performance according to benchmarks, but much simpler. 

This can be reused soon for caching codecs. 