### PR TITLE
[xs] make GRPCOnlineQueryResult.UnmarshalInto testable

### DIFF
--- a/grpc_client_impl.go
+++ b/grpc_client_impl.go
@@ -319,7 +319,11 @@ func (r *GRPCOnlineQueryBulkResult) GetErrors() ([]ServerError, error) {
 }
 
 func (r *GRPCOnlineQueryBulkResult) UnmarshalInto(resultHolders any) error {
-	scalars, err := internal.ConvertBytesToTable(r.RawResponse.GetScalarsData(), r.allocator)
+	allocator := r.allocator
+	if allocator == nil {
+		allocator = memory.DefaultAllocator
+	}
+	scalars, err := internal.ConvertBytesToTable(r.RawResponse.GetScalarsData(), allocator)
 	if err != nil {
 		return errors.Wrap(err, "deserializing scalars table")
 	}

--- a/internal/feather.go
+++ b/internal/feather.go
@@ -66,7 +66,7 @@ func TableToBytes(table arrow.Table, allocator memory.Allocator) ([]byte, error)
 	defer reader.Release()
 	for reader.Next() {
 		if err = fileWriter.Write(reader.Record()); err != nil {
-			return nil, errors.Wrap(err, "writing Arrow Table to request")
+			return nil, errors.Wrap(err, "writing Arrow Table to buffer")
 		}
 	}
 	if err = fileWriter.Close(); err != nil {

--- a/test_utils.go
+++ b/test_utils.go
@@ -8,6 +8,13 @@ import (
 	"github.com/chalk-ai/chalk-go/internal/tests/fixtures"
 )
 
+// CreateFeatureTable creates an Arrow table from a map of feature to values.
+// A feature can be either a string or a codegen'd feature reference.
+// The values should be a slice of the appropriate type for the feature.
+func CreateFeatureTable(featureToValues map[any]any) (arrow.Table, error) {
+	return buildTableFromFeatureToValuesMap(featureToValues)
+}
+
 // buildTableFromFeatureToValuesMap builds an Arrow record from a map of features to values.
 // The features should be codegen-ed `Feature` objects.
 func buildTableFromFeatureToValuesMap(featureToValues map[any]any) (arrow.Table, error) {

--- a/test_utils.go
+++ b/test_utils.go
@@ -36,9 +36,6 @@ type MakeFeatureTableOptions struct {
 // MakeFeatureTable creates an Arrow table from a map of feature to values.
 // A feature can be either a string or a codegen'd feature reference.
 // The values should be a slice of the appropriate type for the feature.
-// The first return value is the Arrow table, and the second return value
-// is the serialized Arrow table, which you can pass to raw response objects
-// such as GRPCOnlineQueryBulkResult.
 func MakeFeatureTable(featureToValues map[any]any, options ...MakeFeatureTableOptions) (*FeatureTable, error) {
 	allocator := memory.DefaultAllocator
 	if len(options) > 1 {
@@ -52,9 +49,9 @@ func MakeFeatureTable(featureToValues map[any]any, options ...MakeFeatureTableOp
 		return nil, errors.Wrap(err, "mapping features to FQN")
 	}
 
-	record, recordErr := internal.ColumnMapToRecord(fqnToValues, allocator)
-	if recordErr != nil {
-		return nil, fmt.Errorf("error converting a map of column values to an Arrow Record: %w", recordErr)
+	record, err := internal.ColumnMapToRecord(fqnToValues, allocator)
+	if err != nil {
+		return nil, errors.Wrap(err, "converting to record")
 	}
 	defer record.Release()
 	table := array.NewTableFromRecords(record.Schema(), []arrow.Record{record})

--- a/test_utils.go
+++ b/test_utils.go
@@ -11,7 +11,7 @@ import (
 )
 
 type FeatureTable struct {
-	Table arrow.Table
+	ArrowTable arrow.Table
 
 	allocator memory.Allocator
 }
@@ -21,11 +21,11 @@ func (f *FeatureTable) ToBytes() ([]byte, error) {
 	if allocator == nil {
 		allocator = memory.DefaultAllocator
 	}
-	return internal.TableToBytes(f.Table, allocator)
+	return internal.TableToBytes(f.ArrowTable, allocator)
 }
 
 func (f *FeatureTable) Release() {
-	f.Table.Release()
+	f.ArrowTable.Release()
 }
 
 type MakeFeatureTableOptions struct {
@@ -55,7 +55,7 @@ func MakeFeatureTable(featureToValues map[any]any, options ...MakeFeatureTableOp
 	}
 	defer record.Release()
 	table := array.NewTableFromRecords(record.Schema(), []arrow.Record{record})
-	return &FeatureTable{Table: table}, nil
+	return &FeatureTable{ArrowTable: table}, nil
 }
 
 func convertFeatureToValues(featureToValues map[any]any) (map[string]any, error) {

--- a/test_utils.go
+++ b/test_utils.go
@@ -4,27 +4,86 @@ import (
 	"fmt"
 	"github.com/apache/arrow/go/v16/arrow"
 	"github.com/apache/arrow/go/v16/arrow/array"
+	"github.com/apache/arrow/go/v16/arrow/memory"
 	"github.com/chalk-ai/chalk-go/internal"
 	"github.com/chalk-ai/chalk-go/internal/tests/fixtures"
+	"github.com/cockroachdb/errors"
 )
 
-// CreateFeatureTable creates an Arrow table from a map of feature to values.
+type FeatureTable struct {
+	Table arrow.Table
+
+	allocator memory.Allocator
+}
+
+func (f *FeatureTable) ToBytes() ([]byte, error) {
+	allocator := f.allocator
+	if allocator == nil {
+		allocator = memory.DefaultAllocator
+	}
+	return internal.TableToBytes(f.Table, allocator)
+}
+
+func (f *FeatureTable) Release() {
+	f.Table.Release()
+}
+
+type MakeFeatureTableOptions struct {
+	// Defaults to memory.DefaultAllocator
+	Allocator memory.Allocator
+}
+
+// MakeFeatureTable creates an Arrow table from a map of feature to values.
 // A feature can be either a string or a codegen'd feature reference.
 // The values should be a slice of the appropriate type for the feature.
-func CreateFeatureTable(featureToValues map[any]any) (arrow.Table, error) {
-	return buildTableFromFeatureToValuesMap(featureToValues)
+// The first return value is the Arrow table, and the second return value
+// is the serialized Arrow table, which you can pass to raw response objects
+// such as GRPCOnlineQueryBulkResult.
+func MakeFeatureTable(featureToValues map[any]any, options ...MakeFeatureTableOptions) (*FeatureTable, error) {
+	allocator := memory.DefaultAllocator
+	if len(options) > 1 {
+		return nil, errors.New("too many options provided")
+	} else if len(options) == 1 {
+		allocator = options[0].Allocator
+
+	}
+	fqnToValues, err := convertFeatureToValues(featureToValues)
+	if err != nil {
+		return nil, errors.Wrap(err, "mapping features to FQN")
+	}
+
+	record, recordErr := internal.ColumnMapToRecord(fqnToValues, allocator)
+	if recordErr != nil {
+		return nil, fmt.Errorf("error converting a map of column values to an Arrow Record: %w", recordErr)
+	}
+	defer record.Release()
+	table := array.NewTableFromRecords(record.Schema(), []arrow.Record{record})
+	return &FeatureTable{Table: table}, nil
+}
+
+func convertFeatureToValues(featureToValues map[any]any) (map[string]any, error) {
+	fqnToValues := make(map[string]any)
+	for featureRaw, values := range featureToValues {
+		if fqn, ok := featureRaw.(string); ok {
+			fqnToValues[fqn] = values
+		} else if feature, unwrapErr := UnwrapFeature(featureRaw); unwrapErr == nil {
+			fqnToValues[feature.Fqn] = values
+		} else {
+			return nil, errors.Newf(
+				"please pass either a string or a codegen'd feature reference as the key, got %T",
+				featureRaw,
+			)
+		}
+	}
+	return fqnToValues, nil
 }
 
 // buildTableFromFeatureToValuesMap builds an Arrow record from a map of features to values.
 // The features should be codegen-ed `Feature` objects.
 func buildTableFromFeatureToValuesMap(featureToValues map[any]any) (arrow.Table, error) {
-	fqnToValues := make(map[string]any)
-	for featureRaw, values := range featureToValues {
-		feature, unwrapErr := UnwrapFeature(featureRaw)
-		if unwrapErr != nil {
-			return nil, unwrapErr
-		}
-		fqnToValues[feature.Fqn] = values
+	fqnToValues, err := convertFeatureToValues(featureToValues)
+	if err != nil {
+		return nil, errors.Wrap(err, "mapping features to FQN")
 	}
 	return tableFromFqnToValues(fqnToValues)
 }

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -573,7 +573,7 @@ func TestUnmarshalOnlineQueryBulkResultPrimitives(t *testing.T) {
 			time.Date(2024, 5, 9, 22, 30, 0, 0, time.UTC),
 		},
 	}
-	scalarsTable, scalarsErr := buildTableFromFeatureToValuesMap(scalarsMap)
+	scalarsTable, scalarsErr := CreateFeatureTable(scalarsMap)
 	assert.Nil(t, scalarsErr)
 
 	bulkRes := OnlineQueryBulkResult{

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -574,12 +574,10 @@ func TestUnmarshalOnlineQueryBulkResultPrimitives(t *testing.T) {
 			time.Date(2024, 5, 9, 22, 30, 0, 0, time.UTC),
 		},
 	}
-	scalarsTable, scalarsErr := MakeFeatureTable(scalarsMap)
+	scalarsTable, scalarsErr := buildTableFromFeatureToValuesMap(scalarsMap)
 	assert.NoError(t, scalarsErr)
 
-	bulkRes := OnlineQueryBulkResult{
-		ScalarsTable: scalarsTable.Table,
-	}
+	bulkRes := OnlineQueryBulkResult{ScalarsTable: scalarsTable}
 	defer bulkRes.Release()
 
 	resultHolders := make([]fixtures.AllTypes, 0)


### PR DESCRIPTION
To help users test unmarshalling, we want to:
- [x] Expose a way to create a serialized Arrow table from a feature to values map
- [x] Make Unmarshal not error when response object is constructed externally. 