### PR TITLE
[xs] Add GRPCOnlineQueryBulkResult constructor

### DIFF
--- a/grpc_client_impl.go
+++ b/grpc_client_impl.go
@@ -255,7 +255,7 @@ type GRPCOnlineQueryBulkResult struct {
 }
 
 type NewGRPCOnlineQueryBulkResultOptions struct {
-	allocator memory.Allocator
+	Allocator memory.Allocator
 }
 
 // NewGRPCOnlineQueryBulkResult creates a GRPCOnlineQueryBulkResult
@@ -269,8 +269,8 @@ func NewGRPCOnlineQueryBulkResult(
 	allocator := memory.DefaultAllocator
 	if len(options) == 1 {
 		opt := options[0]
-		if opt.allocator != nil {
-			allocator = opt.allocator
+		if opt.Allocator != nil {
+			allocator = opt.Allocator
 		}
 	} else if len(options) > 1 {
 		return nil, errors.Newf("expected only one set of options, found %d", len(options))

--- a/grpc_client_impl.go
+++ b/grpc_client_impl.go
@@ -251,8 +251,34 @@ func (r *RowResult) GetFeatureValue(feature any) (any, error) {
 
 type GRPCOnlineQueryBulkResult struct {
 	RawResponse *commonv1.OnlineQueryBulkResponse
+	allocator   memory.Allocator
+}
 
+type NewGRPCOnlineQueryBulkResultOptions struct {
 	allocator memory.Allocator
+}
+
+// NewGRPCOnlineQueryBulkResult creates a GRPCOnlineQueryBulkResult
+// for testing. This function sets up a result object with Arrow
+// artifacts such as a `memory.Allocator` which is required during
+// unmarshalling operations.
+func NewGRPCOnlineQueryBulkResult(
+	response *commonv1.OnlineQueryBulkResponse,
+	options ...NewGRPCOnlineQueryBulkResultOptions,
+) (*GRPCOnlineQueryBulkResult, error) {
+	allocator := memory.DefaultAllocator
+	if len(options) == 1 {
+		opt := options[0]
+		if opt.allocator != nil {
+			allocator = opt.allocator
+		}
+	} else if len(options) > 1 {
+		return nil, errors.Newf("expected only one set of options, found %d", len(options))
+	}
+	return &GRPCOnlineQueryBulkResult{
+		RawResponse: response,
+		allocator:   allocator,
+	}, nil
 }
 
 func (r *GRPCOnlineQueryBulkResult) GetTable() (arrow.Table, error) {

--- a/serializers_test.go
+++ b/serializers_test.go
@@ -1,6 +1,7 @@
 package chalk
 
 import (
+	commonv1 "github.com/chalk-ai/chalk-go/gen/chalk/common/v1"
 	"github.com/chalk-ai/chalk-go/internal"
 	"github.com/chalk-ai/chalk-go/internal/ptr"
 	"github.com/chalk-ai/chalk-go/internal/tests/fixtures"
@@ -158,4 +159,20 @@ func TestSerializingDataclassNestedInFeaturesClass(t *testing.T) {
 	assert.Equal(t, 1, len(actualUser))
 	assert.Equal(t, transactions, *actualUser[0].Txns)
 
+}
+
+func TestGRPCOnlineQueryBulkResultConstructor(t *testing.T) {
+	table, err := MakeFeatureTable(map[any]any{
+		"user.id": []string{"1"},
+	})
+	assert.NoError(t, err)
+	tableBytes, err := table.ToBytes()
+	assert.NoError(t, err)
+	result, err := NewGRPCOnlineQueryBulkResult(&commonv1.OnlineQueryBulkResponse{
+		ScalarsData: tableBytes,
+	})
+	assert.NoError(t, err)
+	row, err := result.GetRow(0)
+	assert.NoError(t, err)
+	assert.Equal(t, "1", row.Features["user.id"].Value)
 }


### PR DESCRIPTION
To make it possible for users to add unit tests for all unmarshal methods in `GRPCOnlineQueryBulkResult`, we add a constructor such that an allocator is always set. 