### PR TITLE
Add Named Error for External Usage

### DIFF
--- a/internal/unmarshal.go
+++ b/internal/unmarshal.go
@@ -6,6 +6,7 @@ import (
 	"github.com/apache/arrow/go/v16/arrow/array"
 	"github.com/chalk-ai/chalk-go/internal/colls"
 	"github.com/chalk-ai/chalk-go/internal/ptr"
+	chalkerrors "github.com/chalk-ai/chalk-go/pkg/errors"
 	"github.com/cockroachdb/errors"
 	"os"
 	"reflect"
@@ -657,7 +658,7 @@ func ConvertIfHasManyMap(value any) (any, error) {
 	}
 
 	if len(values) == 0 {
-		return nil, errors.New("values of has-many results is empty")
+		return nil, chalkerrors.ErrEmptyHasManyValues
 	}
 	numRows := len(values[0])
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,5 @@
+package errors
+
+import "github.com/cockroachdb/errors"
+
+var ErrEmptyHasManyValues = errors.New("values of has-many results is empty")

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/chalk-ai/chalk-go/internal"
 	"github.com/chalk-ai/chalk-go/internal/ptr"
 	"github.com/chalk-ai/chalk-go/internal/tests/fixtures"
+	"github.com/chalk-ai/chalk-go/pkg/errors"
 	assert "github.com/stretchr/testify/require"
 	"log"
 	"os"
@@ -558,6 +559,36 @@ func TestUnmarshalWrongType(t *testing.T) {
 		assert.Contains(t, unmarshalErr.Error(), internal.KindMismatchError(reflect.Int64, reflect.String).Error())
 		fmt.Println("We correctly surfaced an unmarshal type mismatch error - the error is: ", unmarshalErr)
 	}
+}
+
+func TestUnmarshalHasManyWithNoValues(t *testing.T) {
+	t.Parallel()
+	assert.Nil(t, initErr)
+	data := []FeatureResult{
+		{
+			Field:     "all_types.has_many",
+			Value:     map[string]any{"columns": []any{}, "values": []any{}},
+			Pkey:      "abc",
+			Timestamp: nil,
+			Meta:      nil,
+			Error:     nil,
+		},
+	}
+
+	result := OnlineQueryResult{
+		Data:     data,
+		Meta:     nil,
+		features: nil,
+	}
+
+	features := fixtures.AllTypes{}
+	unmarshalErr := result.UnmarshalInto(&features)
+	if unmarshalErr == nil {
+		t.Fatal("Expected an error when unmarshalling has-many with no values")
+	} else {
+		assert.ErrorIs(t, unmarshalErr, errors.ErrEmptyHasManyValues)
+	}
+
 }
 
 // Test primitives unmarshalling only.


### PR DESCRIPTION
This PR introduces the ability for external modules to consume specific error instances via named errors. In this case, it's knowing that a has-many result returned no values. Very similar to the `sql.ErrNoRows` named variable, this lets consuming code easily know that no data was found, instead of performing the same type-assertions + checks on the `Value` result that the unmarshal function does.

Example:
```go
var out MyStruct
_, err = s.chalkClient.OnlineQuery(<params>, <params>, &out)
if err != nil {
    if errors.Is(err, chalkerrors.ErrEmptyHasManyValues) {
        // handle knowing no data was found
    } else {
        // handle knowing something failed
}
```