### PR TITLE
feat: add GetOfflineQueryStatus API and Dataset.Wait() method

### DIFF
--- a/client.go
+++ b/client.go
@@ -140,6 +140,10 @@ type Client interface {
 	// GetToken retrieves a token that can be used to authenticate requests to the Chalk API
 	// along with other using the client's credentials.
 	GetToken(ctx context.Context) (*TokenResult, error)
+
+	// GetOfflineQueryStatus retrieves the status of an offline query job.
+	// See https://docs.chalk.ai/docs/query-basics for more information.
+	GetOfflineQueryStatus(ctx context.Context, args GetOfflineQueryStatusParams) (GetOfflineQueryStatusResult, error)
 }
 
 type ClientConfig struct {

--- a/client_impl.go
+++ b/client_impl.go
@@ -73,6 +73,9 @@ func (c *clientImpl) OfflineQuery(ctx context.Context, params OfflineQueryParams
 		return Dataset{}, response.Errors
 	}
 
+	// Set the client reference for Wait() method
+	response.client = c
+
 	for idx := range response.Revisions {
 		response.Revisions[idx].client = c
 	}
@@ -626,6 +629,20 @@ func getHttpError(logger LeveledLogger, res http.Response, req http.Request) (*H
 	}
 
 	return &clientError, nil
+}
+
+func (c *clientImpl) GetOfflineQueryStatus(ctx context.Context, request GetOfflineQueryStatusParams) (GetOfflineQueryStatusResult, error) {
+	response := GetOfflineQueryStatusResult{}
+	err := c.sendRequest(
+		ctx,
+		&sendRequestParams{
+			Method:              "GET",
+			URL:                 fmt.Sprintf("v4/offline_query/%s/status", request.JobId),
+			Response:            &response,
+			PreviewDeploymentId: request.PreviewDeploymentId,
+		},
+	)
+	return response, errors.Wrap(err, "getting offline query status")
 }
 
 func newClientImpl(


### PR DESCRIPTION
## Summary
- Adds `GetOfflineQueryStatus` method to the client for querying offline job status
- Adds `Wait()` method to Dataset that polls job status until completion
- Adds required types: GetOfflineQueryStatusParams, BatchReport, GetOfflineQueryStatusResult

## Implementation Details
The implementation follows the same pattern as the CLI's `executeOfflineQuery` function:
- Polls `v4/offline_query/{jobId}/status` endpoint
- Continues polling every second until job reaches terminal state (COMPLETED or FAILED)
- Respects context cancellation
- Returns appropriate errors on failure

🤖 Generated with [Claude Code](https://claude.ai/code)