### PR TITLE
feat: Add support for union types in offline query serialization

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -72,7 +72,7 @@ type OfflineQueryRequestSerialized struct {
 	ObservedAtUpperBound        *string                      `json:"observed_at_upper_bound"`
 	DatasetName                 *string                      `json:"dataset_name"`
 	Branch                      *string                      `json:"branch"`
-	RecomputeFeatures           bool                         `json:"recompute_features"`
+	RecomputeFeatures           interface{}                  `json:"recompute_features"`
 	SampleFeatures              *[]string                    `json:"sample_features"`
 	StorePlanStages             bool                         `json:"store_plan_stages"`
 	Explain                     bool                         `json:"explain"`

--- a/models.go
+++ b/models.go
@@ -579,6 +579,10 @@ type OfflineQueryParams struct {
 	// RecomputeFeatures forces recomputation of features instead of using cached values.
 	RecomputeFeatures bool
 
+	// RecomputeFeaturesList specifies a list of specific features to recompute.
+	// This is mutually exclusive with RecomputeFeatures - only one should be set.
+	RecomputeFeaturesList []string
+
 	// ObservedAtLowerBound specifies the lower bound for the observation time.
 	// Features will be queried as of this time or later.
 	ObservedAtLowerBound *time.Time

--- a/params_offline.go
+++ b/params_offline.go
@@ -188,6 +188,13 @@ func (p OfflineQueryParamsComplete) WithRecomputeFeatures(recomputeFeatures bool
 	return p
 }
 
+// WithRecomputeFeaturesList returns a copy of Offline Query parameters with specific features to recompute.
+// This is mutually exclusive with WithRecomputeFeatures - only one should be used.
+func (p OfflineQueryParamsComplete) WithRecomputeFeaturesList(features []string) OfflineQueryParamsComplete {
+	p.underlying.RecomputeFeaturesList = features
+	return p
+}
+
 // WithSampleFeatures returns a copy of Offline Query parameters with the specified sample features set.
 func (p OfflineQueryParamsComplete) WithSampleFeatures(sampleFeatures []string) OfflineQueryParamsComplete {
 	p.underlying.SampleFeatures = sampleFeatures

--- a/serializers.go
+++ b/serializers.go
@@ -158,6 +158,17 @@ func (c *ErrorCodeCategory) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// getRecomputeFeaturesValue returns the appropriate value for recompute_features field
+// based on whether RecomputeFeatures or RecomputeFeaturesList is set
+func getRecomputeFeaturesValue(p *OfflineQueryParams) interface{} {
+	// If RecomputeFeaturesList is set, use that
+	if len(p.RecomputeFeaturesList) > 0 {
+		return p.RecomputeFeaturesList
+	}
+	// Otherwise use the boolean value
+	return p.RecomputeFeatures
+}
+
 func serializeOfflineQueryParams(p *OfflineQueryParams, resolved *offlineQueryParamsResolved) ([]byte, error) {
 	var queryInput interface{}
 
@@ -302,7 +313,7 @@ func serializeOfflineQueryParams(p *OfflineQueryParams, resolved *offlineQueryPa
 		ObservedAtUpperBound:       upperBoundStr, // Using foreign branch's inline approach
 		DatasetName:                internal.StringOrNil(p.DatasetName),
 		Branch:                     internal.StringOrNil(p.Branch),
-		RecomputeFeatures:          p.RecomputeFeatures,
+		RecomputeFeatures:          getRecomputeFeaturesValue(p),
 		SampleFeatures:             sampleFeaturesPtr,
 		StorePlanStages:            p.StorePlanStages,
 		Explain:                    p.Explain,

--- a/validation.go
+++ b/validation.go
@@ -166,6 +166,12 @@ func (p *OfflineQueryParams) resolve() (*offlineQueryParamsResolved, error) {
 			)
 		}
 	}
+	
+	// Validate that only one of RecomputeFeatures or RecomputeFeaturesList is set
+	if p.RecomputeFeatures && len(p.RecomputeFeaturesList) > 0 {
+		return nil, errors.New("cannot set both RecomputeFeatures and RecomputeFeaturesList - use only one")
+	}
+	
 	return &offlineQueryParamsResolved{
 		inputs:          inputs,
 		outputs:         outputs,


### PR DESCRIPTION
This PR adds support for union types in offline query serialization to match the Python client