### PR TITLE
Expose UpdateGraph and GetGraph methods on gRPC client

### DIFF
--- a/grpc_client.go
+++ b/grpc_client.go
@@ -123,6 +123,12 @@ type GRPCClient interface {
 	GetConfig() *GRPCClientConfig
 
 	GetMetadataServerInterceptor() []connect.ClientOption
+
+	// GetGraph retrieves the graph for a deployment.
+	GetGraph(ctx context.Context, deploymentId string) (*GRPCGetGraphResult, error)
+
+	// UpdateGraph updates the graph for a deployment.
+	UpdateGraph(ctx context.Context, req *serverv1.UpdateGraphRequest) (*GRPCUpdateGraphResult, error)
 }
 
 type GRPCClientConfig struct {

--- a/grpc_client_impl.go
+++ b/grpc_client_impl.go
@@ -16,6 +16,8 @@ import (
 	aggregatev1 "github.com/chalk-ai/chalk-go/gen/chalk/aggregate/v1"
 	commonv1 "github.com/chalk-ai/chalk-go/gen/chalk/common/v1"
 	"github.com/chalk-ai/chalk-go/gen/chalk/engine/v1/enginev1connect"
+	serverv1 "github.com/chalk-ai/chalk-go/gen/chalk/server/v1"
+	"github.com/chalk-ai/chalk-go/gen/chalk/server/v1/serverv1connect"
 	"github.com/chalk-ai/chalk-go/internal"
 	"github.com/chalk-ai/chalk-go/internal/ptr"
 	"github.com/cockroachdb/errors"
@@ -35,6 +37,7 @@ type grpcClientImpl struct {
 	timeout       *time.Duration
 
 	queryClient      enginev1connect.QueryServiceClient
+	graphClient      serverv1connect.GraphServiceClient
 	tokenInterceptor connect.UnaryInterceptorFunc
 	deploymentTag    string
 	tokenManager     *auth.TokenRefresher
@@ -121,6 +124,25 @@ func newGrpcClient(ctx context.Context, configs ...*GRPCClientConfig) (*grpcClie
 		connect.WithGRPC(),
 	)
 
+	// Create GraphServiceClient with API server endpoint
+	apiServerURL := c.ApiServer.Value
+	apiInterceptors := []connect.Interceptor{
+		tokenInterceptor,
+		headerInterceptor(map[string]string{
+			HeaderKeyServerType: serverTypeApi,
+		}),
+	}
+	if timeout != nil {
+		apiInterceptors = append(apiInterceptors, timeoutInterceptor(timeout))
+	}
+
+	graphClient := serverv1connect.NewGraphServiceClient(
+		cfg.HTTPClient,
+		apiServerURL,
+		connect.WithInterceptors(append(cfg.Interceptors, apiInterceptors...)...),
+		connect.WithGRPC(),
+	)
+
 	return &grpcClientImpl{
 		deploymentTag:    cfg.DeploymentTag,
 		branch:           cfg.Branch,
@@ -129,6 +151,7 @@ func newGrpcClient(ctx context.Context, configs ...*GRPCClientConfig) (*grpcClie
 		config:           c,
 		tokenManager:     tokenManager,
 		queryClient:      queryClient,
+		graphClient:      graphClient,
 		queryServer:      ptr.OrNil(cfg.QueryServer),
 		resourceGroup:    resourceGroup,
 		timeout:          timeout,
@@ -484,4 +507,36 @@ func (c *grpcClientImpl) GetToken(ctx context.Context) (*TokenResult, error) {
 		PrimaryEnvironment: c.tokenManager.GetEnvironmentId(ptr.OrZero(res.PrimaryEnvironment)),
 		Engines:            res.Engines,
 	}, nil
+}
+
+type GRPCGetGraphResult struct {
+	RawResponse *serverv1.GetGraphResponse
+}
+
+func (c *grpcClientImpl) GetGraph(ctx context.Context, deploymentId string) (*GRPCGetGraphResult, error) {
+	req := connect.NewRequest(&serverv1.GetGraphRequest{
+		DeploymentId: deploymentId,
+	})
+	
+	res, err := c.graphClient.GetGraph(ctx, req)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting graph")
+	}
+
+	return &GRPCGetGraphResult{RawResponse: res.Msg}, nil
+}
+
+type GRPCUpdateGraphResult struct {
+	RawResponse *serverv1.UpdateGraphResponse
+}
+
+func (c *grpcClientImpl) UpdateGraph(ctx context.Context, req *serverv1.UpdateGraphRequest) (*GRPCUpdateGraphResult, error) {
+	connectReq := connect.NewRequest(req)
+	
+	res, err := c.graphClient.UpdateGraph(ctx, connectReq)
+	if err != nil {
+		return nil, errors.Wrap(err, "updating graph")
+	}
+
+	return &GRPCUpdateGraphResult{RawResponse: res.Msg}, nil
 }


### PR DESCRIPTION
## Summary
- Added `GetGraph` and `UpdateGraph` methods to the `GRPCClient` interface
- Implemented both methods following the same pattern as existing gRPC methods
- These methods provide access to the graph service functionality for retrieving and updating deployment graphs

## Changes
- **grpc_client.go**: Added method signatures to the GRPCClient interface
- **grpc_client_impl.go**: 
  - Added GraphServiceClient to the struct
  - Initialized GraphServiceClient with API server configuration
  - Implemented GetGraph and UpdateGraph methods
  - Added result wrapper types

## Test Plan
- [x] Code compiles successfully (`go build ./...`)
- [x] All existing tests pass (`go test ./... -v -short`)
- [ ] Integration testing with actual graph service endpoints

🤖 Generated with [Claude Code](https://claude.ai/code)