### PR TITLE
feat: Add duration suffix to windowed scalar feature names

### DIFF
--- a/graph/windowed.go
+++ b/graph/windowed.go
@@ -142,7 +142,10 @@ func (w *WindowedFeatureBuilder) ToProtos(fieldName string, namespace string) ([
 		if !ok {
 			return nil, fmt.Errorf("windowed features must be scalar")
 		}
-		f := scalarPtr.ToProto(fieldName, namespace)
+		// Add duration suffix to the scalar feature name
+		durationSeconds := int64(d.AsDuration().Seconds())
+		suffixedFieldName := fmt.Sprintf("%s__%d__", fieldName, durationSeconds)
+		f := scalarPtr.ToProto(suffixedFieldName, namespace)
 		f.Type.(*graphv1.FeatureType_Scalar).Scalar.WindowInfo = &graphv1.WindowInfo{
 			Duration: d,
 			Aggregation: &graphv1.WindowAggregation{


### PR DESCRIPTION
## Summary
- Updates `graph.Windowed` function to append duration suffixes to scalar feature names
- Scalar features created from windowed aggregates now include the window duration in seconds
- Format: `{name}__{duration_seconds}__`

## Changes
Modified the `ToProtos` method in `graph/windowed.go` to calculate the duration in seconds and append it as a suffix when creating scalar features from windowed types.

## Example
A windowed feature `recent_source_evals_day` with a window duration of `604800s` (7 days) will now create a scalar feature named `recent_source_evals_day__604800__`.

## Test plan
- [x] Existing tests pass (`go test ./graph/...`)
- [x] Windowed feature tests specifically verified

🤖 Generated with [Claude Code](https://claude.ai/code)