### PR TITLE
use x-chalk-server: go-api on branchQueryClient

### DIFF
--- a/grpc_client_branch_test.go
+++ b/grpc_client_branch_test.go
@@ -162,6 +162,11 @@ func TestGRPCBranchQueryRoutesToAPIServer(t *testing.T) {
 	h := apiCaptured.last()
 	assert.Equal(t, "my-branch", h.Get("X-Chalk-Branch-Id"))
 	assert.Equal(t, "branch-grpc", h.Get("X-Chalk-Deployment-Type"))
+	// Branch queries route through api.chalk.ai's Envoy, which dispatches
+	// based on x-chalk-server. It must be "go-api" — sending "engine" makes
+	// Envoy try to forward to the engine cluster and the upstream resets,
+	// surfacing as "reset reason: protocol error".
+	assert.Equal(t, "go-api", h.Get("X-Chalk-Server"))
 }
 
 func TestGRPCNoBranchQueryRoutesToEngine(t *testing.T) {
@@ -178,6 +183,8 @@ func TestGRPCNoBranchQueryRoutesToEngine(t *testing.T) {
 	h := engineCaptured.last()
 	assert.Equal(t, "", h.Get("X-Chalk-Branch-Id"))
 	assert.Equal(t, "engine-grpc", h.Get("X-Chalk-Deployment-Type"))
+	// Non-branch queries go directly to the engine.
+	assert.Equal(t, "engine", h.Get("X-Chalk-Server"))
 }
 
 func TestGRPCPerRequestBranchRoutesToAPIServer(t *testing.T) {

--- a/grpc_client_impl.go
+++ b/grpc_client_impl.go
@@ -138,44 +138,59 @@ func newGrpcClient(ctx context.Context, configs ...*GRPCClientConfig) (*grpcClie
 	}
 
 	clientBranch := cfg.Branch
-	engineInterceptor := func(next connect.UnaryFunc) connect.UnaryFunc {
-		return func(
-			ctx context.Context,
-			req connect.AnyRequest,
-		) (connect.AnyResponse, error) {
-			if timeout != nil {
-				if _, deadlineSet := ctx.Deadline(); !deadlineSet {
-					timeoutCtx, cancel := context.WithTimeout(ctx, *timeout)
-					ctx = timeoutCtx
-					defer cancel()
+	// makeEngineInterceptor builds a connect interceptor for QueryService
+	// requests. The serverHeader value is sent as x-chalk-server, which the
+	// upstream Envoy uses to route the request: "engine" goes to the engine
+	// cluster (used by queryClient, which talks directly to the resolved
+	// query server), while "go-api" goes to the API server's branch
+	// router (used by branchQueryClient, which talks to api.chalk.ai). This
+	// mirrors the Python SDK, where the API_SERVER channel is built with
+	// server="go-api" and the engine channel with server="engine".
+	makeEngineInterceptor := func(serverHeader string) func(connect.UnaryFunc) connect.UnaryFunc {
+		return func(next connect.UnaryFunc) connect.UnaryFunc {
+			return func(
+				ctx context.Context,
+				req connect.AnyRequest,
+			) (connect.AnyResponse, error) {
+				if timeout != nil {
+					if _, deadlineSet := ctx.Deadline(); !deadlineSet {
+						timeoutCtx, cancel := context.WithTimeout(ctx, *timeout)
+						ctx = timeoutCtx
+						defer cancel()
+					}
 				}
-			}
 
-			if req.Header().Get("x-chalk-branch-id") == "" && clientBranch != "" {
-				req.Header().Set("x-chalk-branch-id", clientBranch)
-			}
-			if req.Header().Get("x-chalk-branch-id") != "" {
-				req.Header().Set("x-chalk-deployment-type", "branch-grpc")
-			} else {
-				req.Header().Set("x-chalk-deployment-type", "engine-grpc")
-			}
-			req.Header().Set("x-chalk-server", "engine")
-			req.Header().Set("User-Agent", internal.UserAgent())
-			if cfg.DeploymentTag != "" {
-				req.Header().Set("x-chalk-deployment-tag", cfg.DeploymentTag)
-			}
+				if req.Header().Get("x-chalk-branch-id") == "" && clientBranch != "" {
+					req.Header().Set("x-chalk-branch-id", clientBranch)
+				}
+				if req.Header().Get("x-chalk-branch-id") != "" {
+					req.Header().Set("x-chalk-deployment-type", "branch-grpc")
+				} else {
+					req.Header().Set("x-chalk-deployment-type", "engine-grpc")
+				}
+				req.Header().Set("x-chalk-server", serverHeader)
+				req.Header().Set("User-Agent", internal.UserAgent())
+				if cfg.DeploymentTag != "" {
+					req.Header().Set("x-chalk-deployment-tag", cfg.DeploymentTag)
+				}
 
-			if envId := tokenManager.GetConfig().EnvironmentId.Value; envId != "" {
-				req.Header().Set("x-chalk-env-id", envId)
+				if envId := tokenManager.GetConfig().EnvironmentId.Value; envId != "" {
+					req.Header().Set("x-chalk-env-id", envId)
+				}
+				token, err := tokenManager.GetJWT(ctx, time.Now().Add(time.Minute))
+				if err != nil {
+					return nil, errors.Wrap(err, "error refreshing config")
+				}
+				req.Header().Set("Authorization", fmt.Sprintf("Bearer %s", token.AccessToken))
+				return next(ctx, req)
 			}
-			token, err := tokenManager.GetJWT(ctx, time.Now().Add(time.Minute))
-			if err != nil {
-				return nil, errors.Wrap(err, "error refreshing config")
-			}
-			req.Header().Set("Authorization", fmt.Sprintf("Bearer %s", token.AccessToken))
-			return next(ctx, req)
 		}
 	}
+
+	// engineInterceptor is retained on the client struct for callers of
+	// GetEngineServerInterceptor (which expect the engine routing).
+	engineInterceptor := makeEngineInterceptor("engine")
+	branchQueryInterceptor := makeEngineInterceptor("go-api")
 
 	queryClient := enginev1connect.NewQueryServiceClient(
 		cfg.HTTPClient,
@@ -190,7 +205,7 @@ func newGrpcClient(ctx context.Context, configs ...*GRPCClientConfig) (*grpcClie
 		cfg.HTTPClient,
 		apiServerURL,
 		connect.WithInterceptors(cfg.Interceptors...),
-		connect.WithInterceptors(connect.UnaryInterceptorFunc(engineInterceptor)),
+		connect.WithInterceptors(connect.UnaryInterceptorFunc(branchQueryInterceptor)),
 		connect.WithGRPC(),
 	)
 


### PR DESCRIPTION
may also need to enable the `branch_grpc_routing` flag for the environment