### PR TITLE
[codex] CHA-8929 update generated protos for empty tiles

### DIFF
--- a/gen/chalk/aggregate/v1/service.pb.go
+++ b/gen/chalk/aggregate/v1/service.pb.go
@@ -674,6 +674,8 @@ type CreateAggregateBackfillJobRequest struct {
 	ResourceGroup       *string                `protobuf:"bytes,8,opt,name=resource_group,json=resourceGroup,proto3,oneof" json:"resource_group,omitempty"`
 	QueryTags           []string               `protobuf:"bytes,9,rep,name=query_tags,json=queryTags,proto3" json:"query_tags,omitempty"`
 	StoreOffline        *bool                  `protobuf:"varint,10,opt,name=store_offline,json=storeOffline,proto3,oneof" json:"store_offline,omitempty"`
+	UseMetaplanner      *bool                  `protobuf:"varint,11,opt,name=use_metaplanner,json=useMetaplanner,proto3,oneof" json:"use_metaplanner,omitempty"`
+	AllowEmptyTiles     *bool                  `protobuf:"varint,12,opt,name=allow_empty_tiles,json=allowEmptyTiles,proto3,oneof" json:"allow_empty_tiles,omitempty"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache
 }
@@ -774,6 +776,20 @@ func (x *CreateAggregateBackfillJobRequest) GetQueryTags() []string {
 func (x *CreateAggregateBackfillJobRequest) GetStoreOffline() bool {
 	if x != nil && x.StoreOffline != nil {
 		return *x.StoreOffline
+	}
+	return false
+}
+
+func (x *CreateAggregateBackfillJobRequest) GetUseMetaplanner() bool {
+	if x != nil && x.UseMetaplanner != nil {
+		return *x.UseMetaplanner
+	}
+	return false
+}
+
+func (x *CreateAggregateBackfillJobRequest) GetAllowEmptyTiles() bool {
+	if x != nil && x.AllowEmptyTiles != nil {
+		return *x.AllowEmptyTiles
 	}
 	return false
 }
@@ -879,7 +895,7 @@ const file_chalk_aggregate_v1_service_proto_rawDesc = "" +
 	"\n" +
 	"latest_job\x18\x02 \x01(\v2(.chalk.aggregate.v1.AggregateBackfillJobR\tlatestJob\"\x9b\x01\n" +
 	"'GetActiveCronAggregateBackfillsResponse\x12p\n" +
-	"\x18cron_aggregate_backfills\x18\x01 \x03(\v26.chalk.aggregate.v1.CronAggregateBackfillWithLatestRunR\x16cronAggregateBackfills\"\xe8\x04\n" +
+	"\x18cron_aggregate_backfills\x18\x01 \x03(\v26.chalk.aggregate.v1.CronAggregateBackfillWithLatestRunR\x16cronAggregateBackfills\"\xf1\x05\n" +
 	"!CreateAggregateBackfillJobRequest\x12\x1a\n" +
 	"\bfeatures\x18\x01 \x03(\tR\bfeatures\x12@\n" +
 	"\vlower_bound\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\n" +
@@ -894,14 +910,18 @@ const file_chalk_aggregate_v1_service_proto_rawDesc = "" +
 	"\n" +
 	"query_tags\x18\t \x03(\tR\tqueryTags\x12(\n" +
 	"\rstore_offline\x18\n" +
-	" \x01(\bH\x06R\fstoreOffline\x88\x01\x01B\x0e\n" +
+	" \x01(\bH\x06R\fstoreOffline\x88\x01\x01\x12,\n" +
+	"\x0fuse_metaplanner\x18\v \x01(\bH\aR\x0euseMetaplanner\x88\x01\x01\x12/\n" +
+	"\x11allow_empty_tiles\x18\f \x01(\bH\bR\x0fallowEmptyTiles\x88\x01\x01B\x0e\n" +
 	"\f_lower_boundB\x0e\n" +
 	"\f_upper_boundB\v\n" +
 	"\t_resolverB\x11\n" +
 	"\x0f_bucket_featureB\x18\n" +
 	"\x16_aggregate_backfill_idB\x11\n" +
 	"\x0f_resource_groupB\x10\n" +
-	"\x0e_store_offline\"\x8c\x01\n" +
+	"\x0e_store_offlineB\x12\n" +
+	"\x10_use_metaplannerB\x14\n" +
+	"\x12_allow_empty_tiles\"\x8c\x01\n" +
 	"\"CreateAggregateBackfillJobResponse\x12\x15\n" +
 	"\x06job_id\x18\x01 \x01(\tR\x05jobId\x12\x1a\n" +
 	"\bfeatures\x18\x02 \x03(\tR\bfeatures\x123\n" +

--- a/gen/chalk/artifacts/v1/cron_aggregate_backfill.pb.go
+++ b/gen/chalk/artifacts/v1/cron_aggregate_backfill.pb.go
@@ -72,19 +72,20 @@ func (CronAggregateBackfillTarget) EnumDescriptor() ([]byte, []int) {
 }
 
 type CronAggregateBackfill struct {
-	state         protoimpl.MessageState      `protogen:"open.v1"`
-	Name          string                      `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Schedule      string                      `protobuf:"bytes,2,opt,name=schedule,proto3" json:"schedule,omitempty"`
-	FileName      string                      `protobuf:"bytes,3,opt,name=file_name,json=fileName,proto3" json:"file_name,omitempty"`
-	Features      []string                    `protobuf:"bytes,4,rep,name=features,proto3" json:"features,omitempty"`
-	Resolvers     []string                    `protobuf:"bytes,5,rep,name=resolvers,proto3" json:"resolvers,omitempty"`
-	QueryTags     []string                    `protobuf:"bytes,6,rep,name=query_tags,json=queryTags,proto3" json:"query_tags,omitempty"`
-	Target        CronAggregateBackfillTarget `protobuf:"varint,7,opt,name=target,proto3,enum=chalk.artifacts.v1.CronAggregateBackfillTarget" json:"target,omitempty"`
-	ResourceGroup *string                     `protobuf:"bytes,8,opt,name=resource_group,json=resourceGroup,proto3,oneof" json:"resource_group,omitempty"`
-	LowerBound    *timestamppb.Timestamp      `protobuf:"bytes,9,opt,name=lower_bound,json=lowerBound,proto3" json:"lower_bound,omitempty"`
-	UpperBound    *timestamppb.Timestamp      `protobuf:"bytes,10,opt,name=upper_bound,json=upperBound,proto3" json:"upper_bound,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state           protoimpl.MessageState      `protogen:"open.v1"`
+	Name            string                      `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Schedule        string                      `protobuf:"bytes,2,opt,name=schedule,proto3" json:"schedule,omitempty"`
+	FileName        string                      `protobuf:"bytes,3,opt,name=file_name,json=fileName,proto3" json:"file_name,omitempty"`
+	Features        []string                    `protobuf:"bytes,4,rep,name=features,proto3" json:"features,omitempty"`
+	Resolvers       []string                    `protobuf:"bytes,5,rep,name=resolvers,proto3" json:"resolvers,omitempty"`
+	QueryTags       []string                    `protobuf:"bytes,6,rep,name=query_tags,json=queryTags,proto3" json:"query_tags,omitempty"`
+	Target          CronAggregateBackfillTarget `protobuf:"varint,7,opt,name=target,proto3,enum=chalk.artifacts.v1.CronAggregateBackfillTarget" json:"target,omitempty"`
+	ResourceGroup   *string                     `protobuf:"bytes,8,opt,name=resource_group,json=resourceGroup,proto3,oneof" json:"resource_group,omitempty"`
+	LowerBound      *timestamppb.Timestamp      `protobuf:"bytes,9,opt,name=lower_bound,json=lowerBound,proto3" json:"lower_bound,omitempty"`
+	UpperBound      *timestamppb.Timestamp      `protobuf:"bytes,10,opt,name=upper_bound,json=upperBound,proto3" json:"upper_bound,omitempty"`
+	AllowEmptyTiles *bool                       `protobuf:"varint,11,opt,name=allow_empty_tiles,json=allowEmptyTiles,proto3,oneof" json:"allow_empty_tiles,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *CronAggregateBackfill) Reset() {
@@ -187,11 +188,18 @@ func (x *CronAggregateBackfill) GetUpperBound() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *CronAggregateBackfill) GetAllowEmptyTiles() bool {
+	if x != nil && x.AllowEmptyTiles != nil {
+		return *x.AllowEmptyTiles
+	}
+	return false
+}
+
 var File_chalk_artifacts_v1_cron_aggregate_backfill_proto protoreflect.FileDescriptor
 
 const file_chalk_artifacts_v1_cron_aggregate_backfill_proto_rawDesc = "" +
 	"\n" +
-	"0chalk/artifacts/v1/cron_aggregate_backfill.proto\x12\x12chalk.artifacts.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xbf\x03\n" +
+	"0chalk/artifacts/v1/cron_aggregate_backfill.proto\x12\x12chalk.artifacts.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x86\x04\n" +
 	"\x15CronAggregateBackfill\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1a\n" +
 	"\bschedule\x18\x02 \x01(\tR\bschedule\x12\x1b\n" +
@@ -206,8 +214,10 @@ const file_chalk_artifacts_v1_cron_aggregate_backfill_proto_rawDesc = "" +
 	"lowerBound\x12;\n" +
 	"\vupper_bound\x18\n" +
 	" \x01(\v2\x1a.google.protobuf.TimestampR\n" +
-	"upperBoundB\x11\n" +
-	"\x0f_resource_group*\xa4\x01\n" +
+	"upperBound\x12/\n" +
+	"\x11allow_empty_tiles\x18\v \x01(\bH\x01R\x0fallowEmptyTiles\x88\x01\x01B\x11\n" +
+	"\x0f_resource_groupB\x14\n" +
+	"\x12_allow_empty_tiles*\xa4\x01\n" +
 	"\x1bCronAggregateBackfillTarget\x12.\n" +
 	"*CRON_AGGREGATE_BACKFILL_TARGET_UNSPECIFIED\x10\x00\x12)\n" +
 	"%CRON_AGGREGATE_BACKFILL_TARGET_ONLINE\x10\x01\x12*\n" +

--- a/gen/chalk/common/v1/offline_query.pb.go
+++ b/gen/chalk/common/v1/offline_query.pb.go
@@ -488,6 +488,7 @@ type ResourceRequests struct {
 	Memory *string `protobuf:"bytes,2,opt,name=memory,proto3,oneof" json:"memory,omitempty"`
 	// *
 	// Chalk can use this for spilling intermediate state of some large computations, i.e. joins, aggregations, and sorting.
+	//
 	// Default unit is bytes, i.e. 1000000000 is 1 gigabyte of memory.
 	// You can also specify a suffix such as K, M, or G for kilobytes, megabytes, and gigabytes, respectively.
 	// It's also possible to use the power of two equivalents, such as Ki, Mi, and Gi.

--- a/gen/chalk/server/v1/serverv1connect/sso.connect.go
+++ b/gen/chalk/server/v1/serverv1connect/sso.connect.go
@@ -60,6 +60,9 @@ const (
 	// SsoServiceDeleteSignOnProviderConfigurationProcedure is the fully-qualified name of the
 	// SsoService's DeleteSignOnProviderConfiguration RPC.
 	SsoServiceDeleteSignOnProviderConfigurationProcedure = "/chalk.server.v1.SsoService/DeleteSignOnProviderConfiguration"
+	// SsoServiceGetSignOnProvidersForEmailProcedure is the fully-qualified name of the SsoService's
+	// GetSignOnProvidersForEmail RPC.
+	SsoServiceGetSignOnProvidersForEmailProcedure = "/chalk.server.v1.SsoService/GetSignOnProvidersForEmail"
 	// SsoServiceGetSamlConfigurationByIssuerProcedure is the fully-qualified name of the SsoService's
 	// GetSamlConfigurationByIssuer RPC.
 	SsoServiceGetSamlConfigurationByIssuerProcedure = "/chalk.server.v1.SsoService/GetSamlConfigurationByIssuer"
@@ -77,6 +80,7 @@ type SsoServiceClient interface {
 	CreateSignOnProviderConfiguration(context.Context, *connect.Request[v1.CreateSignOnProviderConfigurationRequest]) (*connect.Response[v1.CreateSignOnProviderConfigurationResponse], error)
 	UpdateSignOnProviderConfiguration(context.Context, *connect.Request[v1.UpdateSignOnProviderConfigurationRequest]) (*connect.Response[v1.UpdateSignOnProviderConfigurationResponse], error)
 	DeleteSignOnProviderConfiguration(context.Context, *connect.Request[v1.DeleteSignOnProviderConfigurationRequest]) (*connect.Response[v1.DeleteSignOnProviderConfigurationResponse], error)
+	GetSignOnProvidersForEmail(context.Context, *connect.Request[v1.GetSignOnProvidersForEmailRequest]) (*connect.Response[v1.GetSignOnProvidersForEmailResponse], error)
 	GetSamlConfigurationByIssuer(context.Context, *connect.Request[v1.GetSamlConfigurationByIssuerRequest]) (*connect.Response[v1.GetSamlConfigurationByIssuerResponse], error)
 }
 
@@ -150,6 +154,13 @@ func NewSsoServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...
 			connect.WithSchema(ssoServiceMethods.ByName("DeleteSignOnProviderConfiguration")),
 			connect.WithClientOptions(opts...),
 		),
+		getSignOnProvidersForEmail: connect.NewClient[v1.GetSignOnProvidersForEmailRequest, v1.GetSignOnProvidersForEmailResponse](
+			httpClient,
+			baseURL+SsoServiceGetSignOnProvidersForEmailProcedure,
+			connect.WithSchema(ssoServiceMethods.ByName("GetSignOnProvidersForEmail")),
+			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
+			connect.WithClientOptions(opts...),
+		),
 		getSamlConfigurationByIssuer: connect.NewClient[v1.GetSamlConfigurationByIssuerRequest, v1.GetSamlConfigurationByIssuerResponse](
 			httpClient,
 			baseURL+SsoServiceGetSamlConfigurationByIssuerProcedure,
@@ -171,6 +182,7 @@ type ssoServiceClient struct {
 	createSignOnProviderConfiguration *connect.Client[v1.CreateSignOnProviderConfigurationRequest, v1.CreateSignOnProviderConfigurationResponse]
 	updateSignOnProviderConfiguration *connect.Client[v1.UpdateSignOnProviderConfigurationRequest, v1.UpdateSignOnProviderConfigurationResponse]
 	deleteSignOnProviderConfiguration *connect.Client[v1.DeleteSignOnProviderConfigurationRequest, v1.DeleteSignOnProviderConfigurationResponse]
+	getSignOnProvidersForEmail        *connect.Client[v1.GetSignOnProvidersForEmailRequest, v1.GetSignOnProvidersForEmailResponse]
 	getSamlConfigurationByIssuer      *connect.Client[v1.GetSamlConfigurationByIssuerRequest, v1.GetSamlConfigurationByIssuerResponse]
 }
 
@@ -223,6 +235,11 @@ func (c *ssoServiceClient) DeleteSignOnProviderConfiguration(ctx context.Context
 	return c.deleteSignOnProviderConfiguration.CallUnary(ctx, req)
 }
 
+// GetSignOnProvidersForEmail calls chalk.server.v1.SsoService.GetSignOnProvidersForEmail.
+func (c *ssoServiceClient) GetSignOnProvidersForEmail(ctx context.Context, req *connect.Request[v1.GetSignOnProvidersForEmailRequest]) (*connect.Response[v1.GetSignOnProvidersForEmailResponse], error) {
+	return c.getSignOnProvidersForEmail.CallUnary(ctx, req)
+}
+
 // GetSamlConfigurationByIssuer calls chalk.server.v1.SsoService.GetSamlConfigurationByIssuer.
 func (c *ssoServiceClient) GetSamlConfigurationByIssuer(ctx context.Context, req *connect.Request[v1.GetSamlConfigurationByIssuerRequest]) (*connect.Response[v1.GetSamlConfigurationByIssuerResponse], error) {
 	return c.getSamlConfigurationByIssuer.CallUnary(ctx, req)
@@ -240,6 +257,7 @@ type SsoServiceHandler interface {
 	CreateSignOnProviderConfiguration(context.Context, *connect.Request[v1.CreateSignOnProviderConfigurationRequest]) (*connect.Response[v1.CreateSignOnProviderConfigurationResponse], error)
 	UpdateSignOnProviderConfiguration(context.Context, *connect.Request[v1.UpdateSignOnProviderConfigurationRequest]) (*connect.Response[v1.UpdateSignOnProviderConfigurationResponse], error)
 	DeleteSignOnProviderConfiguration(context.Context, *connect.Request[v1.DeleteSignOnProviderConfigurationRequest]) (*connect.Response[v1.DeleteSignOnProviderConfigurationResponse], error)
+	GetSignOnProvidersForEmail(context.Context, *connect.Request[v1.GetSignOnProvidersForEmailRequest]) (*connect.Response[v1.GetSignOnProvidersForEmailResponse], error)
 	GetSamlConfigurationByIssuer(context.Context, *connect.Request[v1.GetSamlConfigurationByIssuerRequest]) (*connect.Response[v1.GetSamlConfigurationByIssuerResponse], error)
 }
 
@@ -309,6 +327,13 @@ func NewSsoServiceHandler(svc SsoServiceHandler, opts ...connect.HandlerOption) 
 		connect.WithSchema(ssoServiceMethods.ByName("DeleteSignOnProviderConfiguration")),
 		connect.WithHandlerOptions(opts...),
 	)
+	ssoServiceGetSignOnProvidersForEmailHandler := connect.NewUnaryHandler(
+		SsoServiceGetSignOnProvidersForEmailProcedure,
+		svc.GetSignOnProvidersForEmail,
+		connect.WithSchema(ssoServiceMethods.ByName("GetSignOnProvidersForEmail")),
+		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
+		connect.WithHandlerOptions(opts...),
+	)
 	ssoServiceGetSamlConfigurationByIssuerHandler := connect.NewUnaryHandler(
 		SsoServiceGetSamlConfigurationByIssuerProcedure,
 		svc.GetSamlConfigurationByIssuer,
@@ -336,6 +361,8 @@ func NewSsoServiceHandler(svc SsoServiceHandler, opts ...connect.HandlerOption) 
 			ssoServiceUpdateSignOnProviderConfigurationHandler.ServeHTTP(w, r)
 		case SsoServiceDeleteSignOnProviderConfigurationProcedure:
 			ssoServiceDeleteSignOnProviderConfigurationHandler.ServeHTTP(w, r)
+		case SsoServiceGetSignOnProvidersForEmailProcedure:
+			ssoServiceGetSignOnProvidersForEmailHandler.ServeHTTP(w, r)
 		case SsoServiceGetSamlConfigurationByIssuerProcedure:
 			ssoServiceGetSamlConfigurationByIssuerHandler.ServeHTTP(w, r)
 		default:
@@ -381,6 +408,10 @@ func (UnimplementedSsoServiceHandler) UpdateSignOnProviderConfiguration(context.
 
 func (UnimplementedSsoServiceHandler) DeleteSignOnProviderConfiguration(context.Context, *connect.Request[v1.DeleteSignOnProviderConfigurationRequest]) (*connect.Response[v1.DeleteSignOnProviderConfigurationResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("chalk.server.v1.SsoService.DeleteSignOnProviderConfiguration is not implemented"))
+}
+
+func (UnimplementedSsoServiceHandler) GetSignOnProvidersForEmail(context.Context, *connect.Request[v1.GetSignOnProvidersForEmailRequest]) (*connect.Response[v1.GetSignOnProvidersForEmailResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("chalk.server.v1.SsoService.GetSignOnProvidersForEmail is not implemented"))
 }
 
 func (UnimplementedSsoServiceHandler) GetSamlConfigurationByIssuer(context.Context, *connect.Request[v1.GetSamlConfigurationByIssuerRequest]) (*connect.Response[v1.GetSamlConfigurationByIssuerResponse], error) {

--- a/gen/chalk/server/v1/sso.pb.go
+++ b/gen/chalk/server/v1/sso.pb.go
@@ -647,6 +647,7 @@ type SignOnProviderConfiguration struct {
 	Name    string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	Id      string                 `protobuf:"bytes,2,opt,name=id,proto3" json:"id,omitempty"`
 	IdpType string                 `protobuf:"bytes,3,opt,name=idp_type,json=idpType,proto3" json:"idp_type,omitempty"`
+	TeamId  string                 `protobuf:"bytes,6,opt,name=team_id,json=teamId,proto3" json:"team_id,omitempty"`
 	// Types that are valid to be assigned to ProviderConfig:
 	//
 	//	*SignOnProviderConfiguration_SamlConfig
@@ -703,6 +704,13 @@ func (x *SignOnProviderConfiguration) GetId() string {
 func (x *SignOnProviderConfiguration) GetIdpType() string {
 	if x != nil {
 		return x.IdpType
+	}
+	return ""
+}
+
+func (x *SignOnProviderConfiguration) GetTeamId() string {
+	if x != nil {
+		return x.TeamId
 	}
 	return ""
 }
@@ -1084,6 +1092,94 @@ func (*DeleteSignOnProviderConfigurationResponse) Descriptor() ([]byte, []int) {
 	return file_chalk_server_v1_sso_proto_rawDescGZIP(), []int{21}
 }
 
+type GetSignOnProvidersForEmailRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Email         string                 `protobuf:"bytes,1,opt,name=email,proto3" json:"email,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSignOnProvidersForEmailRequest) Reset() {
+	*x = GetSignOnProvidersForEmailRequest{}
+	mi := &file_chalk_server_v1_sso_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSignOnProvidersForEmailRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSignOnProvidersForEmailRequest) ProtoMessage() {}
+
+func (x *GetSignOnProvidersForEmailRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_chalk_server_v1_sso_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSignOnProvidersForEmailRequest.ProtoReflect.Descriptor instead.
+func (*GetSignOnProvidersForEmailRequest) Descriptor() ([]byte, []int) {
+	return file_chalk_server_v1_sso_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *GetSignOnProvidersForEmailRequest) GetEmail() string {
+	if x != nil {
+		return x.Email
+	}
+	return ""
+}
+
+type GetSignOnProvidersForEmailResponse struct {
+	state         protoimpl.MessageState         `protogen:"open.v1"`
+	Providers     []*SignOnProviderConfiguration `protobuf:"bytes,1,rep,name=providers,proto3" json:"providers,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSignOnProvidersForEmailResponse) Reset() {
+	*x = GetSignOnProvidersForEmailResponse{}
+	mi := &file_chalk_server_v1_sso_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSignOnProvidersForEmailResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSignOnProvidersForEmailResponse) ProtoMessage() {}
+
+func (x *GetSignOnProvidersForEmailResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_chalk_server_v1_sso_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSignOnProvidersForEmailResponse.ProtoReflect.Descriptor instead.
+func (*GetSignOnProvidersForEmailResponse) Descriptor() ([]byte, []int) {
+	return file_chalk_server_v1_sso_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *GetSignOnProvidersForEmailResponse) GetProviders() []*SignOnProviderConfiguration {
+	if x != nil {
+		return x.Providers
+	}
+	return nil
+}
+
 type GetSamlConfigurationByIssuerRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Issuer        string                 `protobuf:"bytes,1,opt,name=issuer,proto3" json:"issuer,omitempty"`
@@ -1093,7 +1189,7 @@ type GetSamlConfigurationByIssuerRequest struct {
 
 func (x *GetSamlConfigurationByIssuerRequest) Reset() {
 	*x = GetSamlConfigurationByIssuerRequest{}
-	mi := &file_chalk_server_v1_sso_proto_msgTypes[22]
+	mi := &file_chalk_server_v1_sso_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1105,7 +1201,7 @@ func (x *GetSamlConfigurationByIssuerRequest) String() string {
 func (*GetSamlConfigurationByIssuerRequest) ProtoMessage() {}
 
 func (x *GetSamlConfigurationByIssuerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chalk_server_v1_sso_proto_msgTypes[22]
+	mi := &file_chalk_server_v1_sso_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1118,7 +1214,7 @@ func (x *GetSamlConfigurationByIssuerRequest) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use GetSamlConfigurationByIssuerRequest.ProtoReflect.Descriptor instead.
 func (*GetSamlConfigurationByIssuerRequest) Descriptor() ([]byte, []int) {
-	return file_chalk_server_v1_sso_proto_rawDescGZIP(), []int{22}
+	return file_chalk_server_v1_sso_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *GetSamlConfigurationByIssuerRequest) GetIssuer() string {
@@ -1138,7 +1234,7 @@ type GetSamlConfigurationByIssuerResponse struct {
 
 func (x *GetSamlConfigurationByIssuerResponse) Reset() {
 	*x = GetSamlConfigurationByIssuerResponse{}
-	mi := &file_chalk_server_v1_sso_proto_msgTypes[23]
+	mi := &file_chalk_server_v1_sso_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1150,7 +1246,7 @@ func (x *GetSamlConfigurationByIssuerResponse) String() string {
 func (*GetSamlConfigurationByIssuerResponse) ProtoMessage() {}
 
 func (x *GetSamlConfigurationByIssuerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chalk_server_v1_sso_proto_msgTypes[23]
+	mi := &file_chalk_server_v1_sso_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1163,7 +1259,7 @@ func (x *GetSamlConfigurationByIssuerResponse) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use GetSamlConfigurationByIssuerResponse.ProtoReflect.Descriptor instead.
 func (*GetSamlConfigurationByIssuerResponse) Descriptor() ([]byte, []int) {
-	return file_chalk_server_v1_sso_proto_rawDescGZIP(), []int{23}
+	return file_chalk_server_v1_sso_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *GetSamlConfigurationByIssuerResponse) GetConfiguration() *SignOnProviderSamlConfig {
@@ -1218,11 +1314,12 @@ const file_chalk_server_v1_sso_proto_rawDesc = "" +
 	"\x16_is_primary_sso_config\"\\\n" +
 	"\x18SignOnProviderOidcConfig\x12\x1b\n" +
 	"\tclient_id\x18\x01 \x01(\tR\bclientId\x12#\n" +
-	"\rclient_secret\x18\x02 \x01(\tR\fclientSecret\"\x8b\x02\n" +
+	"\rclient_secret\x18\x02 \x01(\tR\fclientSecret\"\xa4\x02\n" +
 	"\x1bSignOnProviderConfiguration\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\tR\x02id\x12\x19\n" +
-	"\bidp_type\x18\x03 \x01(\tR\aidpType\x12L\n" +
+	"\bidp_type\x18\x03 \x01(\tR\aidpType\x12\x17\n" +
+	"\ateam_id\x18\x06 \x01(\tR\x06teamId\x12L\n" +
 	"\vsaml_config\x18\x04 \x01(\v2).chalk.server.v1.SignOnProviderSamlConfigH\x00R\n" +
 	"samlConfig\x12L\n" +
 	"\voidc_config\x18\x05 \x01(\v2).chalk.server.v1.SignOnProviderOidcConfigH\x00R\n" +
@@ -1241,12 +1338,16 @@ const file_chalk_server_v1_sso_proto_rawDesc = "" +
 	"\rconfiguration\x18\x01 \x01(\v2,.chalk.server.v1.SignOnProviderConfigurationR\rconfiguration\":\n" +
 	"(DeleteSignOnProviderConfigurationRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\"+\n" +
-	")DeleteSignOnProviderConfigurationResponse\"=\n" +
+	")DeleteSignOnProviderConfigurationResponse\"9\n" +
+	"!GetSignOnProvidersForEmailRequest\x12\x14\n" +
+	"\x05email\x18\x01 \x01(\tR\x05email\"p\n" +
+	"\"GetSignOnProvidersForEmailResponse\x12J\n" +
+	"\tproviders\x18\x01 \x03(\v2,.chalk.server.v1.SignOnProviderConfigurationR\tproviders\"=\n" +
 	"#GetSamlConfigurationByIssuerRequest\x12\x16\n" +
 	"\x06issuer\x18\x01 \x01(\tR\x06issuer\"\x90\x01\n" +
 	"$GetSamlConfigurationByIssuerResponse\x12O\n" +
 	"\rconfiguration\x18\x01 \x01(\v2).chalk.server.v1.SignOnProviderSamlConfigR\rconfiguration\x12\x17\n" +
-	"\ateam_id\x18\x02 \x01(\tR\x06teamId2\x91\r\n" +
+	"\ateam_id\x18\x02 \x01(\tR\x06teamId2\xa1\x0e\n" +
 	"\n" +
 	"SsoService\x12l\n" +
 	"\x0fCreateScimToken\x12'.chalk.server.v1.CreateScimTokenRequest\x1a(.chalk.server.v1.CreateScimTokenResponse\"\x06\x80}\a\x90\x02\x02\x12x\n" +
@@ -1265,7 +1366,8 @@ const file_chalk_server_v1_sso_proto_rawDesc = "" +
 	"!UpdateSignOnProviderConfiguration\x129.chalk.server.v1.UpdateSignOnProviderConfigurationRequest\x1a:.chalk.server.v1.UpdateSignOnProviderConfigurationResponse\"8\x80}\n" +
 	"\x8a\xd3\x0e1\b\x02\x12-Updated a SAML sign-on provider configuration\x12\xd4\x01\n" +
 	"!DeleteSignOnProviderConfiguration\x129.chalk.server.v1.DeleteSignOnProviderConfigurationRequest\x1a:.chalk.server.v1.DeleteSignOnProviderConfigurationResponse\"8\x80}\n" +
-	"\x8a\xd3\x0e1\b\x02\x12-Deleted a SAML sign-on provider configuration\x12\x93\x01\n" +
+	"\x8a\xd3\x0e1\b\x02\x12-Deleted a SAML sign-on provider configuration\x12\x8d\x01\n" +
+	"\x1aGetSignOnProvidersForEmail\x122.chalk.server.v1.GetSignOnProvidersForEmailRequest\x1a3.chalk.server.v1.GetSignOnProvidersForEmailResponse\"\x06\x80}\x01\x90\x02\x01\x12\x93\x01\n" +
 	"\x1cGetSamlConfigurationByIssuer\x124.chalk.server.v1.GetSamlConfigurationByIssuerRequest\x1a5.chalk.server.v1.GetSamlConfigurationByIssuerResponse\"\x06\x80}\x1d\x90\x02\x01B\xb8\x01\n" +
 	"\x13com.chalk.server.v1B\bSsoProtoP\x01Z9github.com/chalk-ai/chalk-go/gen/chalk/server/v1;serverv1\xa2\x02\x03CSX\xaa\x02\x0fChalk.Server.V1\xca\x02\x0fChalk\\Server\\V1\xe2\x02\x1bChalk\\Server\\V1\\GPBMetadata\xea\x02\x11Chalk::Server::V1b\x06proto3"
 
@@ -1281,7 +1383,7 @@ func file_chalk_server_v1_sso_proto_rawDescGZIP() []byte {
 	return file_chalk_server_v1_sso_proto_rawDescData
 }
 
-var file_chalk_server_v1_sso_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
+var file_chalk_server_v1_sso_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
 var file_chalk_server_v1_sso_proto_goTypes = []any{
 	(*CreateScimTokenRequest)(nil),                    // 0: chalk.server.v1.CreateScimTokenRequest
 	(*CreateScimTokenResponse)(nil),                   // 1: chalk.server.v1.CreateScimTokenResponse
@@ -1305,8 +1407,10 @@ var file_chalk_server_v1_sso_proto_goTypes = []any{
 	(*UpdateSignOnProviderConfigurationResponse)(nil), // 19: chalk.server.v1.UpdateSignOnProviderConfigurationResponse
 	(*DeleteSignOnProviderConfigurationRequest)(nil),  // 20: chalk.server.v1.DeleteSignOnProviderConfigurationRequest
 	(*DeleteSignOnProviderConfigurationResponse)(nil), // 21: chalk.server.v1.DeleteSignOnProviderConfigurationResponse
-	(*GetSamlConfigurationByIssuerRequest)(nil),       // 22: chalk.server.v1.GetSamlConfigurationByIssuerRequest
-	(*GetSamlConfigurationByIssuerResponse)(nil),      // 23: chalk.server.v1.GetSamlConfigurationByIssuerResponse
+	(*GetSignOnProvidersForEmailRequest)(nil),         // 22: chalk.server.v1.GetSignOnProvidersForEmailRequest
+	(*GetSignOnProvidersForEmailResponse)(nil),        // 23: chalk.server.v1.GetSignOnProvidersForEmailResponse
+	(*GetSamlConfigurationByIssuerRequest)(nil),       // 24: chalk.server.v1.GetSamlConfigurationByIssuerRequest
+	(*GetSamlConfigurationByIssuerResponse)(nil),      // 25: chalk.server.v1.GetSamlConfigurationByIssuerResponse
 }
 var file_chalk_server_v1_sso_proto_depIdxs = []int32{
 	2,  // 0: chalk.server.v1.ListSsoEmailDomainsResponse.email_domains:type_name -> chalk.server.v1.SsoEmailDomain
@@ -1321,32 +1425,35 @@ var file_chalk_server_v1_sso_proto_depIdxs = []int32{
 	13, // 9: chalk.server.v1.CreateSignOnProviderConfigurationResponse.configuration:type_name -> chalk.server.v1.SignOnProviderConfiguration
 	13, // 10: chalk.server.v1.UpdateSignOnProviderConfigurationRequest.configuration:type_name -> chalk.server.v1.SignOnProviderConfiguration
 	13, // 11: chalk.server.v1.UpdateSignOnProviderConfigurationResponse.configuration:type_name -> chalk.server.v1.SignOnProviderConfiguration
-	11, // 12: chalk.server.v1.GetSamlConfigurationByIssuerResponse.configuration:type_name -> chalk.server.v1.SignOnProviderSamlConfig
-	0,  // 13: chalk.server.v1.SsoService.CreateScimToken:input_type -> chalk.server.v1.CreateScimTokenRequest
-	3,  // 14: chalk.server.v1.SsoService.ListSsoEmailDomains:input_type -> chalk.server.v1.ListSsoEmailDomainsRequest
-	5,  // 15: chalk.server.v1.SsoService.CreateSsoEmailDomain:input_type -> chalk.server.v1.CreateSsoEmailDomainRequest
-	7,  // 16: chalk.server.v1.SsoService.UpdateSsoEmailDomain:input_type -> chalk.server.v1.UpdateSsoEmailDomainRequest
-	9,  // 17: chalk.server.v1.SsoService.DeleteSsoEmailDomain:input_type -> chalk.server.v1.DeleteSsoEmailDomainRequest
-	14, // 18: chalk.server.v1.SsoService.ListSignOnProviderConfigurations:input_type -> chalk.server.v1.ListSignOnProviderConfigurationsRequest
-	16, // 19: chalk.server.v1.SsoService.CreateSignOnProviderConfiguration:input_type -> chalk.server.v1.CreateSignOnProviderConfigurationRequest
-	18, // 20: chalk.server.v1.SsoService.UpdateSignOnProviderConfiguration:input_type -> chalk.server.v1.UpdateSignOnProviderConfigurationRequest
-	20, // 21: chalk.server.v1.SsoService.DeleteSignOnProviderConfiguration:input_type -> chalk.server.v1.DeleteSignOnProviderConfigurationRequest
-	22, // 22: chalk.server.v1.SsoService.GetSamlConfigurationByIssuer:input_type -> chalk.server.v1.GetSamlConfigurationByIssuerRequest
-	1,  // 23: chalk.server.v1.SsoService.CreateScimToken:output_type -> chalk.server.v1.CreateScimTokenResponse
-	4,  // 24: chalk.server.v1.SsoService.ListSsoEmailDomains:output_type -> chalk.server.v1.ListSsoEmailDomainsResponse
-	6,  // 25: chalk.server.v1.SsoService.CreateSsoEmailDomain:output_type -> chalk.server.v1.CreateSsoEmailDomainResponse
-	8,  // 26: chalk.server.v1.SsoService.UpdateSsoEmailDomain:output_type -> chalk.server.v1.UpdateSsoEmailDomainResponse
-	10, // 27: chalk.server.v1.SsoService.DeleteSsoEmailDomain:output_type -> chalk.server.v1.DeleteSsoEmailDomainResponse
-	15, // 28: chalk.server.v1.SsoService.ListSignOnProviderConfigurations:output_type -> chalk.server.v1.ListSignOnProviderConfigurationsResponse
-	17, // 29: chalk.server.v1.SsoService.CreateSignOnProviderConfiguration:output_type -> chalk.server.v1.CreateSignOnProviderConfigurationResponse
-	19, // 30: chalk.server.v1.SsoService.UpdateSignOnProviderConfiguration:output_type -> chalk.server.v1.UpdateSignOnProviderConfigurationResponse
-	21, // 31: chalk.server.v1.SsoService.DeleteSignOnProviderConfiguration:output_type -> chalk.server.v1.DeleteSignOnProviderConfigurationResponse
-	23, // 32: chalk.server.v1.SsoService.GetSamlConfigurationByIssuer:output_type -> chalk.server.v1.GetSamlConfigurationByIssuerResponse
-	23, // [23:33] is the sub-list for method output_type
-	13, // [13:23] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	13, // 12: chalk.server.v1.GetSignOnProvidersForEmailResponse.providers:type_name -> chalk.server.v1.SignOnProviderConfiguration
+	11, // 13: chalk.server.v1.GetSamlConfigurationByIssuerResponse.configuration:type_name -> chalk.server.v1.SignOnProviderSamlConfig
+	0,  // 14: chalk.server.v1.SsoService.CreateScimToken:input_type -> chalk.server.v1.CreateScimTokenRequest
+	3,  // 15: chalk.server.v1.SsoService.ListSsoEmailDomains:input_type -> chalk.server.v1.ListSsoEmailDomainsRequest
+	5,  // 16: chalk.server.v1.SsoService.CreateSsoEmailDomain:input_type -> chalk.server.v1.CreateSsoEmailDomainRequest
+	7,  // 17: chalk.server.v1.SsoService.UpdateSsoEmailDomain:input_type -> chalk.server.v1.UpdateSsoEmailDomainRequest
+	9,  // 18: chalk.server.v1.SsoService.DeleteSsoEmailDomain:input_type -> chalk.server.v1.DeleteSsoEmailDomainRequest
+	14, // 19: chalk.server.v1.SsoService.ListSignOnProviderConfigurations:input_type -> chalk.server.v1.ListSignOnProviderConfigurationsRequest
+	16, // 20: chalk.server.v1.SsoService.CreateSignOnProviderConfiguration:input_type -> chalk.server.v1.CreateSignOnProviderConfigurationRequest
+	18, // 21: chalk.server.v1.SsoService.UpdateSignOnProviderConfiguration:input_type -> chalk.server.v1.UpdateSignOnProviderConfigurationRequest
+	20, // 22: chalk.server.v1.SsoService.DeleteSignOnProviderConfiguration:input_type -> chalk.server.v1.DeleteSignOnProviderConfigurationRequest
+	22, // 23: chalk.server.v1.SsoService.GetSignOnProvidersForEmail:input_type -> chalk.server.v1.GetSignOnProvidersForEmailRequest
+	24, // 24: chalk.server.v1.SsoService.GetSamlConfigurationByIssuer:input_type -> chalk.server.v1.GetSamlConfigurationByIssuerRequest
+	1,  // 25: chalk.server.v1.SsoService.CreateScimToken:output_type -> chalk.server.v1.CreateScimTokenResponse
+	4,  // 26: chalk.server.v1.SsoService.ListSsoEmailDomains:output_type -> chalk.server.v1.ListSsoEmailDomainsResponse
+	6,  // 27: chalk.server.v1.SsoService.CreateSsoEmailDomain:output_type -> chalk.server.v1.CreateSsoEmailDomainResponse
+	8,  // 28: chalk.server.v1.SsoService.UpdateSsoEmailDomain:output_type -> chalk.server.v1.UpdateSsoEmailDomainResponse
+	10, // 29: chalk.server.v1.SsoService.DeleteSsoEmailDomain:output_type -> chalk.server.v1.DeleteSsoEmailDomainResponse
+	15, // 30: chalk.server.v1.SsoService.ListSignOnProviderConfigurations:output_type -> chalk.server.v1.ListSignOnProviderConfigurationsResponse
+	17, // 31: chalk.server.v1.SsoService.CreateSignOnProviderConfiguration:output_type -> chalk.server.v1.CreateSignOnProviderConfigurationResponse
+	19, // 32: chalk.server.v1.SsoService.UpdateSignOnProviderConfiguration:output_type -> chalk.server.v1.UpdateSignOnProviderConfigurationResponse
+	21, // 33: chalk.server.v1.SsoService.DeleteSignOnProviderConfiguration:output_type -> chalk.server.v1.DeleteSignOnProviderConfigurationResponse
+	23, // 34: chalk.server.v1.SsoService.GetSignOnProvidersForEmail:output_type -> chalk.server.v1.GetSignOnProvidersForEmailResponse
+	25, // 35: chalk.server.v1.SsoService.GetSamlConfigurationByIssuer:output_type -> chalk.server.v1.GetSamlConfigurationByIssuerResponse
+	25, // [25:36] is the sub-list for method output_type
+	14, // [14:25] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_chalk_server_v1_sso_proto_init() }
@@ -1365,7 +1472,7 @@ func file_chalk_server_v1_sso_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chalk_server_v1_sso_proto_rawDesc), len(file_chalk_server_v1_sso_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   24,
+			NumMessages:   26,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/chalk/streaming/v1/debug_service.pb.go
+++ b/gen/chalk/streaming/v1/debug_service.pb.go
@@ -7,8 +7,9 @@
 package streamingv1
 
 import (
+	v1 "github.com/chalk-ai/chalk-go/gen/chalk/arrow/v1"
 	_ "github.com/chalk-ai/chalk-go/gen/chalk/auth/v1"
-	v1 "github.com/chalk-ai/chalk-go/gen/chalk/common/v1"
+	v11 "github.com/chalk-ai/chalk-go/gen/chalk/common/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
@@ -495,6 +496,425 @@ func (x *GetDebugMessagesResponse) GetError() string {
 	return ""
 }
 
+// Same shape as GetDebugMessagesRequest. Kept as a distinct message so v1 and
+// v2 can evolve independently.
+type GetDebugMessagesV2Request struct {
+	state                   protoimpl.MessageState `protogen:"open.v1"`
+	ResolverFqn             string                 `protobuf:"bytes,1,opt,name=resolver_fqn,json=resolverFqn,proto3" json:"resolver_fqn,omitempty"`
+	StartTimestampInclusive *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=start_timestamp_inclusive,json=startTimestampInclusive,proto3,oneof" json:"start_timestamp_inclusive,omitempty"`
+	EndTimestampExclusive   *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=end_timestamp_exclusive,json=endTimestampExclusive,proto3,oneof" json:"end_timestamp_exclusive,omitempty"`
+	MaxMessages             *int32                 `protobuf:"varint,4,opt,name=max_messages,json=maxMessages,proto3,oneof" json:"max_messages,omitempty"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
+}
+
+func (x *GetDebugMessagesV2Request) Reset() {
+	*x = GetDebugMessagesV2Request{}
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetDebugMessagesV2Request) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetDebugMessagesV2Request) ProtoMessage() {}
+
+func (x *GetDebugMessagesV2Request) ProtoReflect() protoreflect.Message {
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetDebugMessagesV2Request.ProtoReflect.Descriptor instead.
+func (*GetDebugMessagesV2Request) Descriptor() ([]byte, []int) {
+	return file_chalk_streaming_v1_debug_service_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *GetDebugMessagesV2Request) GetResolverFqn() string {
+	if x != nil {
+		return x.ResolverFqn
+	}
+	return ""
+}
+
+func (x *GetDebugMessagesV2Request) GetStartTimestampInclusive() *timestamppb.Timestamp {
+	if x != nil {
+		return x.StartTimestampInclusive
+	}
+	return nil
+}
+
+func (x *GetDebugMessagesV2Request) GetEndTimestampExclusive() *timestamppb.Timestamp {
+	if x != nil {
+		return x.EndTimestampExclusive
+	}
+	return nil
+}
+
+func (x *GetDebugMessagesV2Request) GetMaxMessages() int32 {
+	if x != nil && x.MaxMessages != nil {
+		return *x.MaxMessages
+	}
+	return 0
+}
+
+// Structured debug response. One entry per stream message ingested in the
+// requested window, plus aggregate counts and a description of how each
+// output feature is computed by the resolver.
+type GetDebugMessagesV2Response struct {
+	state    protoimpl.MessageState   `protogen:"open.v1"`
+	Messages []*StreamingDebugMessage `protobuf:"bytes,1,rep,name=messages,proto3" json:"messages,omitempty"`
+	// STREAMING_MESSAGE_STATUS_SUCCESS rows in `messages`.
+	SuccessCount int64 `protobuf:"varint,2,opt,name=success_count,json=successCount,proto3" json:"success_count,omitempty"`
+	// STREAMING_MESSAGE_STATUS_FAILED rows in `messages`. Note: PARSE_FAILED is
+	// counted under skipped_count, not here — a parse error is treated as an
+	// unprocessable input, not a system fault.
+	FailedCount int64 `protobuf:"varint,3,opt,name=failed_count,json=failedCount,proto3" json:"failed_count,omitempty"`
+	// PARSE_FAILED + PARSE_SKIPPED + DUPLICATE_SKIPPED rows in `messages`.
+	SkippedCount int64 `protobuf:"varint,4,opt,name=skipped_count,json=skippedCount,proto3" json:"skipped_count,omitempty"`
+	// How each output feature is computed by this resolver. Constant across
+	// every returned message, so we surface it once at the top level. Keys are
+	// feature FQNs and match the keys of StreamingDebugMessage.features.
+	FeatureExpressions map[string]*StreamingFeatureExpression `protobuf:"bytes,5,rep,name=feature_expressions,json=featureExpressions,proto3" json:"feature_expressions,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *GetDebugMessagesV2Response) Reset() {
+	*x = GetDebugMessagesV2Response{}
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetDebugMessagesV2Response) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetDebugMessagesV2Response) ProtoMessage() {}
+
+func (x *GetDebugMessagesV2Response) ProtoReflect() protoreflect.Message {
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetDebugMessagesV2Response.ProtoReflect.Descriptor instead.
+func (*GetDebugMessagesV2Response) Descriptor() ([]byte, []int) {
+	return file_chalk_streaming_v1_debug_service_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *GetDebugMessagesV2Response) GetMessages() []*StreamingDebugMessage {
+	if x != nil {
+		return x.Messages
+	}
+	return nil
+}
+
+func (x *GetDebugMessagesV2Response) GetSuccessCount() int64 {
+	if x != nil {
+		return x.SuccessCount
+	}
+	return 0
+}
+
+func (x *GetDebugMessagesV2Response) GetFailedCount() int64 {
+	if x != nil {
+		return x.FailedCount
+	}
+	return 0
+}
+
+func (x *GetDebugMessagesV2Response) GetSkippedCount() int64 {
+	if x != nil {
+		return x.SkippedCount
+	}
+	return 0
+}
+
+func (x *GetDebugMessagesV2Response) GetFeatureExpressions() map[string]*StreamingFeatureExpression {
+	if x != nil {
+		return x.FeatureExpressions
+	}
+	return nil
+}
+
+type StreamingDebugMessage struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Stream-assigned message ID.
+	MessageId string `protobuf:"bytes,1,opt,name=message_id,json=messageId,proto3" json:"message_id,omitempty"`
+	// Raw message payload bytes.
+	MessageData []byte `protobuf:"bytes,2,opt,name=message_data,json=messageData,proto3" json:"message_data,omitempty"`
+	// Optional message key (e.g., Kafka key).
+	MessageKey *string `protobuf:"bytes,3,opt,name=message_key,json=messageKey,proto3,oneof" json:"message_key,omitempty"`
+	// Stream-level headers (e.g., Kafka headers). Empty when the source has no
+	// headers or when libchalk's writer didn't produce the optional column.
+	// libchalk emits these as Arrow map<large_utf8, large_binary>.
+	MessageHeaders map[string][]byte `protobuf:"bytes,4,rep,name=message_headers,json=messageHeaders,proto3" json:"message_headers,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// When the upstream stream produced the message.
+	PublishTimestamp *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=publish_timestamp,json=publishTimestamp,proto3" json:"publish_timestamp,omitempty"`
+	// When this debug row was created (used for filtering by time range).
+	IngestTimestamp *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=ingest_timestamp,json=ingestTimestamp,proto3" json:"ingest_timestamp,omitempty"`
+	Status          StreamingMessageStatus `protobuf:"varint,7,opt,name=status,proto3,enum=chalk.streaming.v1.StreamingMessageStatus" json:"status,omitempty"`
+	// Resolver outputs for this message. Keys are feature FQNs.
+	// Populated only when status == STREAMING_MESSAGE_STATUS_SUCCESS;
+	// empty otherwise.
+	Features map[string]*v1.ScalarValue `protobuf:"bytes,8,rep,name=features,proto3" json:"features,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// Populated only when status is not STREAMING_MESSAGE_STATUS_SUCCESS.
+	Error         *StreamingDebugMessageError `protobuf:"bytes,9,opt,name=error,proto3,oneof" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StreamingDebugMessage) Reset() {
+	*x = StreamingDebugMessage{}
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StreamingDebugMessage) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StreamingDebugMessage) ProtoMessage() {}
+
+func (x *StreamingDebugMessage) ProtoReflect() protoreflect.Message {
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StreamingDebugMessage.ProtoReflect.Descriptor instead.
+func (*StreamingDebugMessage) Descriptor() ([]byte, []int) {
+	return file_chalk_streaming_v1_debug_service_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *StreamingDebugMessage) GetMessageId() string {
+	if x != nil {
+		return x.MessageId
+	}
+	return ""
+}
+
+func (x *StreamingDebugMessage) GetMessageData() []byte {
+	if x != nil {
+		return x.MessageData
+	}
+	return nil
+}
+
+func (x *StreamingDebugMessage) GetMessageKey() string {
+	if x != nil && x.MessageKey != nil {
+		return *x.MessageKey
+	}
+	return ""
+}
+
+func (x *StreamingDebugMessage) GetMessageHeaders() map[string][]byte {
+	if x != nil {
+		return x.MessageHeaders
+	}
+	return nil
+}
+
+func (x *StreamingDebugMessage) GetPublishTimestamp() *timestamppb.Timestamp {
+	if x != nil {
+		return x.PublishTimestamp
+	}
+	return nil
+}
+
+func (x *StreamingDebugMessage) GetIngestTimestamp() *timestamppb.Timestamp {
+	if x != nil {
+		return x.IngestTimestamp
+	}
+	return nil
+}
+
+func (x *StreamingDebugMessage) GetStatus() StreamingMessageStatus {
+	if x != nil {
+		return x.Status
+	}
+	return StreamingMessageStatus_STREAMING_MESSAGE_STATUS_UNSPECIFIED
+}
+
+func (x *StreamingDebugMessage) GetFeatures() map[string]*v1.ScalarValue {
+	if x != nil {
+		return x.Features
+	}
+	return nil
+}
+
+func (x *StreamingDebugMessage) GetError() *StreamingDebugMessageError {
+	if x != nil {
+		return x.Error
+	}
+	return nil
+}
+
+type StreamingDebugMessageError struct {
+	state               protoimpl.MessageState `protogen:"open.v1"`
+	Phase               ExecutionPhase         `protobuf:"varint,1,opt,name=phase,proto3,enum=chalk.streaming.v1.ExecutionPhase" json:"phase,omitempty"`
+	Message             string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	Code                string                 `protobuf:"bytes,3,opt,name=code,proto3" json:"code,omitempty"`
+	ExceptionKind       *string                `protobuf:"bytes,4,opt,name=exception_kind,json=exceptionKind,proto3,oneof" json:"exception_kind,omitempty"`
+	ExceptionStacktrace *string                `protobuf:"bytes,5,opt,name=exception_stacktrace,json=exceptionStacktrace,proto3,oneof" json:"exception_stacktrace,omitempty"`
+	// Feature FQN if the error is feature-specific.
+	Feature       *string `protobuf:"bytes,6,opt,name=feature,proto3,oneof" json:"feature,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StreamingDebugMessageError) Reset() {
+	*x = StreamingDebugMessageError{}
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StreamingDebugMessageError) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StreamingDebugMessageError) ProtoMessage() {}
+
+func (x *StreamingDebugMessageError) ProtoReflect() protoreflect.Message {
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StreamingDebugMessageError.ProtoReflect.Descriptor instead.
+func (*StreamingDebugMessageError) Descriptor() ([]byte, []int) {
+	return file_chalk_streaming_v1_debug_service_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *StreamingDebugMessageError) GetPhase() ExecutionPhase {
+	if x != nil {
+		return x.Phase
+	}
+	return ExecutionPhase_EXECUTION_PHASE_UNSPECIFIED
+}
+
+func (x *StreamingDebugMessageError) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *StreamingDebugMessageError) GetCode() string {
+	if x != nil {
+		return x.Code
+	}
+	return ""
+}
+
+func (x *StreamingDebugMessageError) GetExceptionKind() string {
+	if x != nil && x.ExceptionKind != nil {
+		return *x.ExceptionKind
+	}
+	return ""
+}
+
+func (x *StreamingDebugMessageError) GetExceptionStacktrace() string {
+	if x != nil && x.ExceptionStacktrace != nil {
+		return *x.ExceptionStacktrace
+	}
+	return ""
+}
+
+func (x *StreamingDebugMessageError) GetFeature() string {
+	if x != nil && x.Feature != nil {
+		return *x.Feature
+	}
+	return ""
+}
+
+type StreamingFeatureExpression struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Pretty-printed expression as the user wrote it in `output_features={...}`,
+	// e.g. "json_value(_.payload, '$.contents.merchant.state')". Always set.
+	Expression string `protobuf:"bytes,1,opt,name=expression,proto3" json:"expression,omitempty"`
+	// Set only when `expression` is a trivial top-level
+	// F.json_value(_.payload, "$path") extraction. Lets the UI render the path
+	// inline next to the value without re-parsing the expression.
+	JsonPath      *string `protobuf:"bytes,2,opt,name=json_path,json=jsonPath,proto3,oneof" json:"json_path,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StreamingFeatureExpression) Reset() {
+	*x = StreamingFeatureExpression{}
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StreamingFeatureExpression) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StreamingFeatureExpression) ProtoMessage() {}
+
+func (x *StreamingFeatureExpression) ProtoReflect() protoreflect.Message {
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StreamingFeatureExpression.ProtoReflect.Descriptor instead.
+func (*StreamingFeatureExpression) Descriptor() ([]byte, []int) {
+	return file_chalk_streaming_v1_debug_service_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *StreamingFeatureExpression) GetExpression() string {
+	if x != nil {
+		return x.Expression
+	}
+	return ""
+}
+
+func (x *StreamingFeatureExpression) GetJsonPath() string {
+	if x != nil && x.JsonPath != nil {
+		return *x.JsonPath
+	}
+	return ""
+}
+
 // Request to watch for new debug files from a streaming resolver in cloud storage
 type WatchDebugStreamRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -510,7 +930,7 @@ type WatchDebugStreamRequest struct {
 
 func (x *WatchDebugStreamRequest) Reset() {
 	*x = WatchDebugStreamRequest{}
-	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[8]
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -522,7 +942,7 @@ func (x *WatchDebugStreamRequest) String() string {
 func (*WatchDebugStreamRequest) ProtoMessage() {}
 
 func (x *WatchDebugStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[8]
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -535,7 +955,7 @@ func (x *WatchDebugStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchDebugStreamRequest.ProtoReflect.Descriptor instead.
 func (*WatchDebugStreamRequest) Descriptor() ([]byte, []int) {
-	return file_chalk_streaming_v1_debug_service_proto_rawDescGZIP(), []int{8}
+	return file_chalk_streaming_v1_debug_service_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *WatchDebugStreamRequest) GetBaseUri() string {
@@ -574,7 +994,7 @@ type WatchDebugStreamResponse struct {
 
 func (x *WatchDebugStreamResponse) Reset() {
 	*x = WatchDebugStreamResponse{}
-	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[9]
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -586,7 +1006,7 @@ func (x *WatchDebugStreamResponse) String() string {
 func (*WatchDebugStreamResponse) ProtoMessage() {}
 
 func (x *WatchDebugStreamResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[9]
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -599,7 +1019,7 @@ func (x *WatchDebugStreamResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchDebugStreamResponse.ProtoReflect.Descriptor instead.
 func (*WatchDebugStreamResponse) Descriptor() ([]byte, []int) {
-	return file_chalk_streaming_v1_debug_service_proto_rawDescGZIP(), []int{9}
+	return file_chalk_streaming_v1_debug_service_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *WatchDebugStreamResponse) GetFilePath() string {
@@ -637,7 +1057,7 @@ type PushTopicRequest struct {
 
 func (x *PushTopicRequest) Reset() {
 	*x = PushTopicRequest{}
-	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[10]
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -649,7 +1069,7 @@ func (x *PushTopicRequest) String() string {
 func (*PushTopicRequest) ProtoMessage() {}
 
 func (x *PushTopicRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[10]
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -662,7 +1082,7 @@ func (x *PushTopicRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PushTopicRequest.ProtoReflect.Descriptor instead.
 func (*PushTopicRequest) Descriptor() ([]byte, []int) {
-	return file_chalk_streaming_v1_debug_service_proto_rawDescGZIP(), []int{10}
+	return file_chalk_streaming_v1_debug_service_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *PushTopicRequest) GetTopic() string {
@@ -712,14 +1132,14 @@ type PushTopicResponse struct {
 	Status        string                 `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
 	Topic         *string                `protobuf:"bytes,2,opt,name=topic,proto3,oneof" json:"topic,omitempty"`
 	Integration   *string                `protobuf:"bytes,3,opt,name=integration,proto3,oneof" json:"integration,omitempty"`
-	Error         *v1.ChalkError         `protobuf:"bytes,4,opt,name=error,proto3,oneof" json:"error,omitempty"`
+	Error         *v11.ChalkError        `protobuf:"bytes,4,opt,name=error,proto3,oneof" json:"error,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *PushTopicResponse) Reset() {
 	*x = PushTopicResponse{}
-	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[11]
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -731,7 +1151,7 @@ func (x *PushTopicResponse) String() string {
 func (*PushTopicResponse) ProtoMessage() {}
 
 func (x *PushTopicResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[11]
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -744,7 +1164,7 @@ func (x *PushTopicResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PushTopicResponse.ProtoReflect.Descriptor instead.
 func (*PushTopicResponse) Descriptor() ([]byte, []int) {
-	return file_chalk_streaming_v1_debug_service_proto_rawDescGZIP(), []int{11}
+	return file_chalk_streaming_v1_debug_service_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *PushTopicResponse) GetStatus() string {
@@ -768,7 +1188,7 @@ func (x *PushTopicResponse) GetIntegration() string {
 	return ""
 }
 
-func (x *PushTopicResponse) GetError() *v1.ChalkError {
+func (x *PushTopicResponse) GetError() *v11.ChalkError {
 	if x != nil {
 		return x.Error
 	}
@@ -789,7 +1209,7 @@ type SetStreamingDebugConfigRequest struct {
 
 func (x *SetStreamingDebugConfigRequest) Reset() {
 	*x = SetStreamingDebugConfigRequest{}
-	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[12]
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -801,7 +1221,7 @@ func (x *SetStreamingDebugConfigRequest) String() string {
 func (*SetStreamingDebugConfigRequest) ProtoMessage() {}
 
 func (x *SetStreamingDebugConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[12]
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -814,7 +1234,7 @@ func (x *SetStreamingDebugConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetStreamingDebugConfigRequest.ProtoReflect.Descriptor instead.
 func (*SetStreamingDebugConfigRequest) Descriptor() ([]byte, []int) {
-	return file_chalk_streaming_v1_debug_service_proto_rawDescGZIP(), []int{12}
+	return file_chalk_streaming_v1_debug_service_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *SetStreamingDebugConfigRequest) GetResolverFqn() string {
@@ -847,7 +1267,7 @@ type SetStreamingDebugConfigResponse struct {
 
 func (x *SetStreamingDebugConfigResponse) Reset() {
 	*x = SetStreamingDebugConfigResponse{}
-	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[13]
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -859,7 +1279,7 @@ func (x *SetStreamingDebugConfigResponse) String() string {
 func (*SetStreamingDebugConfigResponse) ProtoMessage() {}
 
 func (x *SetStreamingDebugConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[13]
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -872,7 +1292,7 @@ func (x *SetStreamingDebugConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetStreamingDebugConfigResponse.ProtoReflect.Descriptor instead.
 func (*SetStreamingDebugConfigResponse) Descriptor() ([]byte, []int) {
-	return file_chalk_streaming_v1_debug_service_proto_rawDescGZIP(), []int{13}
+	return file_chalk_streaming_v1_debug_service_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *SetStreamingDebugConfigResponse) GetLoggerConfig() *StreamingLoggerConfig {
@@ -892,7 +1312,7 @@ type GetStreamingDebugConfigRequest struct {
 
 func (x *GetStreamingDebugConfigRequest) Reset() {
 	*x = GetStreamingDebugConfigRequest{}
-	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[14]
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -904,7 +1324,7 @@ func (x *GetStreamingDebugConfigRequest) String() string {
 func (*GetStreamingDebugConfigRequest) ProtoMessage() {}
 
 func (x *GetStreamingDebugConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[14]
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -917,7 +1337,7 @@ func (x *GetStreamingDebugConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetStreamingDebugConfigRequest.ProtoReflect.Descriptor instead.
 func (*GetStreamingDebugConfigRequest) Descriptor() ([]byte, []int) {
-	return file_chalk_streaming_v1_debug_service_proto_rawDescGZIP(), []int{14}
+	return file_chalk_streaming_v1_debug_service_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *GetStreamingDebugConfigRequest) GetResolverFqn() string {
@@ -938,7 +1358,7 @@ type GetStreamingDebugConfigResponse struct {
 
 func (x *GetStreamingDebugConfigResponse) Reset() {
 	*x = GetStreamingDebugConfigResponse{}
-	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[15]
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -950,7 +1370,7 @@ func (x *GetStreamingDebugConfigResponse) String() string {
 func (*GetStreamingDebugConfigResponse) ProtoMessage() {}
 
 func (x *GetStreamingDebugConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[15]
+	mi := &file_chalk_streaming_v1_debug_service_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -963,7 +1383,7 @@ func (x *GetStreamingDebugConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetStreamingDebugConfigResponse.ProtoReflect.Descriptor instead.
 func (*GetStreamingDebugConfigResponse) Descriptor() ([]byte, []int) {
-	return file_chalk_streaming_v1_debug_service_proto_rawDescGZIP(), []int{15}
+	return file_chalk_streaming_v1_debug_service_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *GetStreamingDebugConfigResponse) GetLoggerConfig() *StreamingLoggerConfig {
@@ -991,7 +1411,7 @@ var File_chalk_streaming_v1_debug_service_proto protoreflect.FileDescriptor
 
 const file_chalk_streaming_v1_debug_service_proto_rawDesc = "" +
 	"\n" +
-	"&chalk/streaming/v1/debug_service.proto\x12\x12chalk.streaming.v1\x1a\x1fchalk/auth/v1/permissions.proto\x1a!chalk/common/v1/chalk_error.proto\x1a1chalk/streaming/v1/simple_streaming_service.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xc7\x01\n" +
+	"&chalk/streaming/v1/debug_service.proto\x12\x12chalk.streaming.v1\x1a\x1achalk/arrow/v1/arrow.proto\x1a\x1fchalk/auth/v1/permissions.proto\x1a!chalk/common/v1/chalk_error.proto\x1a1chalk/streaming/v1/simple_streaming_service.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xc7\x01\n" +
 	"\x16EnableDebugModeRequest\x12!\n" +
 	"\fresolver_fqn\x18\x01 \x01(\tR\vresolverFqn\x12#\n" +
 	"\rdeployment_id\x18\x02 \x01(\tR\fdeploymentId\x12S\n" +
@@ -1028,7 +1448,62 @@ const file_chalk_streaming_v1_debug_service_proto_rawDesc = "" +
 	"\x18GetDebugMessagesResponse\x12\x18\n" +
 	"\aparquet\x18\x01 \x01(\fR\aparquet\x12\x19\n" +
 	"\x05error\x18\x02 \x01(\tH\x00R\x05error\x88\x01\x01B\b\n" +
-	"\x06_error\"\xaa\x01\n" +
+	"\x06_error\"\xe7\x02\n" +
+	"\x19GetDebugMessagesV2Request\x12!\n" +
+	"\fresolver_fqn\x18\x01 \x01(\tR\vresolverFqn\x12[\n" +
+	"\x19start_timestamp_inclusive\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\x17startTimestampInclusive\x88\x01\x01\x12W\n" +
+	"\x17end_timestamp_exclusive\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampH\x01R\x15endTimestampExclusive\x88\x01\x01\x12&\n" +
+	"\fmax_messages\x18\x04 \x01(\x05H\x02R\vmaxMessages\x88\x01\x01B\x1c\n" +
+	"\x1a_start_timestamp_inclusiveB\x1a\n" +
+	"\x18_end_timestamp_exclusiveB\x0f\n" +
+	"\r_max_messages\"\xc0\x03\n" +
+	"\x1aGetDebugMessagesV2Response\x12E\n" +
+	"\bmessages\x18\x01 \x03(\v2).chalk.streaming.v1.StreamingDebugMessageR\bmessages\x12#\n" +
+	"\rsuccess_count\x18\x02 \x01(\x03R\fsuccessCount\x12!\n" +
+	"\ffailed_count\x18\x03 \x01(\x03R\vfailedCount\x12#\n" +
+	"\rskipped_count\x18\x04 \x01(\x03R\fskippedCount\x12w\n" +
+	"\x13feature_expressions\x18\x05 \x03(\v2F.chalk.streaming.v1.GetDebugMessagesV2Response.FeatureExpressionsEntryR\x12featureExpressions\x1au\n" +
+	"\x17FeatureExpressionsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12D\n" +
+	"\x05value\x18\x02 \x01(\v2..chalk.streaming.v1.StreamingFeatureExpressionR\x05value:\x028\x01\"\x92\x06\n" +
+	"\x15StreamingDebugMessage\x12\x1d\n" +
+	"\n" +
+	"message_id\x18\x01 \x01(\tR\tmessageId\x12!\n" +
+	"\fmessage_data\x18\x02 \x01(\fR\vmessageData\x12$\n" +
+	"\vmessage_key\x18\x03 \x01(\tH\x00R\n" +
+	"messageKey\x88\x01\x01\x12f\n" +
+	"\x0fmessage_headers\x18\x04 \x03(\v2=.chalk.streaming.v1.StreamingDebugMessage.MessageHeadersEntryR\x0emessageHeaders\x12G\n" +
+	"\x11publish_timestamp\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\x10publishTimestamp\x12E\n" +
+	"\x10ingest_timestamp\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x0fingestTimestamp\x12B\n" +
+	"\x06status\x18\a \x01(\x0e2*.chalk.streaming.v1.StreamingMessageStatusR\x06status\x12S\n" +
+	"\bfeatures\x18\b \x03(\v27.chalk.streaming.v1.StreamingDebugMessage.FeaturesEntryR\bfeatures\x12I\n" +
+	"\x05error\x18\t \x01(\v2..chalk.streaming.v1.StreamingDebugMessageErrorH\x01R\x05error\x88\x01\x01\x1aA\n" +
+	"\x13MessageHeadersEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x01\x1aX\n" +
+	"\rFeaturesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x121\n" +
+	"\x05value\x18\x02 \x01(\v2\x1b.chalk.arrow.v1.ScalarValueR\x05value:\x028\x01B\x0e\n" +
+	"\f_message_keyB\b\n" +
+	"\x06_error\"\xbf\x02\n" +
+	"\x1aStreamingDebugMessageError\x128\n" +
+	"\x05phase\x18\x01 \x01(\x0e2\".chalk.streaming.v1.ExecutionPhaseR\x05phase\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\x12\x12\n" +
+	"\x04code\x18\x03 \x01(\tR\x04code\x12*\n" +
+	"\x0eexception_kind\x18\x04 \x01(\tH\x00R\rexceptionKind\x88\x01\x01\x126\n" +
+	"\x14exception_stacktrace\x18\x05 \x01(\tH\x01R\x13exceptionStacktrace\x88\x01\x01\x12\x1d\n" +
+	"\afeature\x18\x06 \x01(\tH\x02R\afeature\x88\x01\x01B\x11\n" +
+	"\x0f_exception_kindB\x17\n" +
+	"\x15_exception_stacktraceB\n" +
+	"\n" +
+	"\b_feature\"l\n" +
+	"\x1aStreamingFeatureExpression\x12\x1e\n" +
+	"\n" +
+	"expression\x18\x01 \x01(\tR\n" +
+	"expression\x12 \n" +
+	"\tjson_path\x18\x02 \x01(\tH\x00R\bjsonPath\x88\x01\x01B\f\n" +
+	"\n" +
+	"_json_path\"\xaa\x01\n" +
 	"\x17WatchDebugStreamRequest\x12\x19\n" +
 	"\bbase_uri\x18\x01 \x01(\tR\abaseUri\x12!\n" +
 	"\fresolver_fqn\x18\x02 \x01(\tR\vresolverFqn\x127\n" +
@@ -1075,14 +1550,15 @@ const file_chalk_streaming_v1_debug_service_proto_rawDesc = "" +
 	"\vstorage_uri\x18\x03 \x01(\tR\n" +
 	"storageUriB\x10\n" +
 	"\x0e_logger_configB\x10\n" +
-	"\x0e_deployment_id2\xdc\a\n" +
+	"\x0e_deployment_id2\xd9\b\n" +
 	"\x15StreamingDebugService\x12\x87\x01\n" +
 	"\x17SetStreamingDebugConfig\x122.chalk.streaming.v1.SetStreamingDebugConfigRequest\x1a3.chalk.streaming.v1.SetStreamingDebugConfigResponse\"\x03\x80}\f\x12\x8a\x01\n" +
 	"\x17GetStreamingDebugConfig\x122.chalk.streaming.v1.GetStreamingDebugConfigRequest\x1a3.chalk.streaming.v1.GetStreamingDebugConfigResponse\"\x06\x80}\v\x90\x02\x01\x12o\n" +
 	"\x0fEnableDebugMode\x12*.chalk.streaming.v1.EnableDebugModeRequest\x1a+.chalk.streaming.v1.EnableDebugModeResponse\"\x03\x80}\f\x12r\n" +
 	"\x10DisableDebugMode\x12+.chalk.streaming.v1.DisableDebugModeRequest\x1a,.chalk.streaming.v1.DisableDebugModeResponse\"\x03\x80}\f\x12{\n" +
 	"\x12GetDebugModeStatus\x12-.chalk.streaming.v1.GetDebugModeStatusRequest\x1a..chalk.streaming.v1.GetDebugModeStatusResponse\"\x06\x80}\v\x90\x02\x01\x12u\n" +
-	"\x10GetDebugMessages\x12+.chalk.streaming.v1.GetDebugMessagesRequest\x1a,.chalk.streaming.v1.GetDebugMessagesResponse\"\x06\x80}\v\x90\x02\x01\x12t\n" +
+	"\x10GetDebugMessages\x12+.chalk.streaming.v1.GetDebugMessagesRequest\x1a,.chalk.streaming.v1.GetDebugMessagesResponse\"\x06\x80}\v\x90\x02\x01\x12{\n" +
+	"\x12GetDebugMessagesV2\x12-.chalk.streaming.v1.GetDebugMessagesV2Request\x1a..chalk.streaming.v1.GetDebugMessagesV2Response\"\x06\x80}\v\x90\x02\x01\x12t\n" +
 	"\x10WatchDebugStream\x12+.chalk.streaming.v1.WatchDebugStreamRequest\x1a,.chalk.streaming.v1.WatchDebugStreamResponse\"\x03\x80}\v0\x01\x12]\n" +
 	"\tPushTopic\x12$.chalk.streaming.v1.PushTopicRequest\x1a%.chalk.streaming.v1.PushTopicResponse\"\x03\x80}\x03B\xd6\x01\n" +
 	"\x16com.chalk.streaming.v1B\x11DebugServiceProtoP\x01Z?github.com/chalk-ai/chalk-go/gen/chalk/streaming/v1;streamingv1\xa2\x02\x03CSX\xaa\x02\x12Chalk.Streaming.V1\xca\x02\x12Chalk\\Streaming\\V1\xe2\x02\x1eChalk\\Streaming\\V1\\GPBMetadata\xea\x02\x14Chalk::Streaming::V1b\x06proto3"
@@ -1099,7 +1575,7 @@ func file_chalk_streaming_v1_debug_service_proto_rawDescGZIP() []byte {
 	return file_chalk_streaming_v1_debug_service_proto_rawDescData
 }
 
-var file_chalk_streaming_v1_debug_service_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
+var file_chalk_streaming_v1_debug_service_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
 var file_chalk_streaming_v1_debug_service_proto_goTypes = []any{
 	(*EnableDebugModeRequest)(nil),          // 0: chalk.streaming.v1.EnableDebugModeRequest
 	(*EnableDebugModeResponse)(nil),         // 1: chalk.streaming.v1.EnableDebugModeResponse
@@ -1109,50 +1585,76 @@ var file_chalk_streaming_v1_debug_service_proto_goTypes = []any{
 	(*GetDebugModeStatusResponse)(nil),      // 5: chalk.streaming.v1.GetDebugModeStatusResponse
 	(*GetDebugMessagesRequest)(nil),         // 6: chalk.streaming.v1.GetDebugMessagesRequest
 	(*GetDebugMessagesResponse)(nil),        // 7: chalk.streaming.v1.GetDebugMessagesResponse
-	(*WatchDebugStreamRequest)(nil),         // 8: chalk.streaming.v1.WatchDebugStreamRequest
-	(*WatchDebugStreamResponse)(nil),        // 9: chalk.streaming.v1.WatchDebugStreamResponse
-	(*PushTopicRequest)(nil),                // 10: chalk.streaming.v1.PushTopicRequest
-	(*PushTopicResponse)(nil),               // 11: chalk.streaming.v1.PushTopicResponse
-	(*SetStreamingDebugConfigRequest)(nil),  // 12: chalk.streaming.v1.SetStreamingDebugConfigRequest
-	(*SetStreamingDebugConfigResponse)(nil), // 13: chalk.streaming.v1.SetStreamingDebugConfigResponse
-	(*GetStreamingDebugConfigRequest)(nil),  // 14: chalk.streaming.v1.GetStreamingDebugConfigRequest
-	(*GetStreamingDebugConfigResponse)(nil), // 15: chalk.streaming.v1.GetStreamingDebugConfigResponse
-	(*StreamingLoggerConfig)(nil),           // 16: chalk.streaming.v1.StreamingLoggerConfig
-	(*timestamppb.Timestamp)(nil),           // 17: google.protobuf.Timestamp
-	(*v1.ChalkError)(nil),                   // 18: chalk.common.v1.ChalkError
+	(*GetDebugMessagesV2Request)(nil),       // 8: chalk.streaming.v1.GetDebugMessagesV2Request
+	(*GetDebugMessagesV2Response)(nil),      // 9: chalk.streaming.v1.GetDebugMessagesV2Response
+	(*StreamingDebugMessage)(nil),           // 10: chalk.streaming.v1.StreamingDebugMessage
+	(*StreamingDebugMessageError)(nil),      // 11: chalk.streaming.v1.StreamingDebugMessageError
+	(*StreamingFeatureExpression)(nil),      // 12: chalk.streaming.v1.StreamingFeatureExpression
+	(*WatchDebugStreamRequest)(nil),         // 13: chalk.streaming.v1.WatchDebugStreamRequest
+	(*WatchDebugStreamResponse)(nil),        // 14: chalk.streaming.v1.WatchDebugStreamResponse
+	(*PushTopicRequest)(nil),                // 15: chalk.streaming.v1.PushTopicRequest
+	(*PushTopicResponse)(nil),               // 16: chalk.streaming.v1.PushTopicResponse
+	(*SetStreamingDebugConfigRequest)(nil),  // 17: chalk.streaming.v1.SetStreamingDebugConfigRequest
+	(*SetStreamingDebugConfigResponse)(nil), // 18: chalk.streaming.v1.SetStreamingDebugConfigResponse
+	(*GetStreamingDebugConfigRequest)(nil),  // 19: chalk.streaming.v1.GetStreamingDebugConfigRequest
+	(*GetStreamingDebugConfigResponse)(nil), // 20: chalk.streaming.v1.GetStreamingDebugConfigResponse
+	nil,                                     // 21: chalk.streaming.v1.GetDebugMessagesV2Response.FeatureExpressionsEntry
+	nil,                                     // 22: chalk.streaming.v1.StreamingDebugMessage.MessageHeadersEntry
+	nil,                                     // 23: chalk.streaming.v1.StreamingDebugMessage.FeaturesEntry
+	(*StreamingLoggerConfig)(nil),           // 24: chalk.streaming.v1.StreamingLoggerConfig
+	(*timestamppb.Timestamp)(nil),           // 25: google.protobuf.Timestamp
+	(StreamingMessageStatus)(0),             // 26: chalk.streaming.v1.StreamingMessageStatus
+	(ExecutionPhase)(0),                     // 27: chalk.streaming.v1.ExecutionPhase
+	(*v11.ChalkError)(nil),                  // 28: chalk.common.v1.ChalkError
+	(*v1.ScalarValue)(nil),                  // 29: chalk.arrow.v1.ScalarValue
 }
 var file_chalk_streaming_v1_debug_service_proto_depIdxs = []int32{
-	16, // 0: chalk.streaming.v1.EnableDebugModeRequest.logger_config:type_name -> chalk.streaming.v1.StreamingLoggerConfig
-	17, // 1: chalk.streaming.v1.EnableDebugModeResponse.enabled_at:type_name -> google.protobuf.Timestamp
-	17, // 2: chalk.streaming.v1.GetDebugModeStatusResponse.enabled_at:type_name -> google.protobuf.Timestamp
-	16, // 3: chalk.streaming.v1.GetDebugModeStatusResponse.logger_config:type_name -> chalk.streaming.v1.StreamingLoggerConfig
-	17, // 4: chalk.streaming.v1.GetDebugMessagesRequest.start_timestamp_inclusive:type_name -> google.protobuf.Timestamp
-	17, // 5: chalk.streaming.v1.GetDebugMessagesRequest.end_timestamp_exclusive:type_name -> google.protobuf.Timestamp
-	18, // 6: chalk.streaming.v1.PushTopicResponse.error:type_name -> chalk.common.v1.ChalkError
-	16, // 7: chalk.streaming.v1.SetStreamingDebugConfigRequest.logger_config:type_name -> chalk.streaming.v1.StreamingLoggerConfig
-	16, // 8: chalk.streaming.v1.SetStreamingDebugConfigResponse.logger_config:type_name -> chalk.streaming.v1.StreamingLoggerConfig
-	16, // 9: chalk.streaming.v1.GetStreamingDebugConfigResponse.logger_config:type_name -> chalk.streaming.v1.StreamingLoggerConfig
-	12, // 10: chalk.streaming.v1.StreamingDebugService.SetStreamingDebugConfig:input_type -> chalk.streaming.v1.SetStreamingDebugConfigRequest
-	14, // 11: chalk.streaming.v1.StreamingDebugService.GetStreamingDebugConfig:input_type -> chalk.streaming.v1.GetStreamingDebugConfigRequest
-	0,  // 12: chalk.streaming.v1.StreamingDebugService.EnableDebugMode:input_type -> chalk.streaming.v1.EnableDebugModeRequest
-	2,  // 13: chalk.streaming.v1.StreamingDebugService.DisableDebugMode:input_type -> chalk.streaming.v1.DisableDebugModeRequest
-	4,  // 14: chalk.streaming.v1.StreamingDebugService.GetDebugModeStatus:input_type -> chalk.streaming.v1.GetDebugModeStatusRequest
-	6,  // 15: chalk.streaming.v1.StreamingDebugService.GetDebugMessages:input_type -> chalk.streaming.v1.GetDebugMessagesRequest
-	8,  // 16: chalk.streaming.v1.StreamingDebugService.WatchDebugStream:input_type -> chalk.streaming.v1.WatchDebugStreamRequest
-	10, // 17: chalk.streaming.v1.StreamingDebugService.PushTopic:input_type -> chalk.streaming.v1.PushTopicRequest
-	13, // 18: chalk.streaming.v1.StreamingDebugService.SetStreamingDebugConfig:output_type -> chalk.streaming.v1.SetStreamingDebugConfigResponse
-	15, // 19: chalk.streaming.v1.StreamingDebugService.GetStreamingDebugConfig:output_type -> chalk.streaming.v1.GetStreamingDebugConfigResponse
-	1,  // 20: chalk.streaming.v1.StreamingDebugService.EnableDebugMode:output_type -> chalk.streaming.v1.EnableDebugModeResponse
-	3,  // 21: chalk.streaming.v1.StreamingDebugService.DisableDebugMode:output_type -> chalk.streaming.v1.DisableDebugModeResponse
-	5,  // 22: chalk.streaming.v1.StreamingDebugService.GetDebugModeStatus:output_type -> chalk.streaming.v1.GetDebugModeStatusResponse
-	7,  // 23: chalk.streaming.v1.StreamingDebugService.GetDebugMessages:output_type -> chalk.streaming.v1.GetDebugMessagesResponse
-	9,  // 24: chalk.streaming.v1.StreamingDebugService.WatchDebugStream:output_type -> chalk.streaming.v1.WatchDebugStreamResponse
-	11, // 25: chalk.streaming.v1.StreamingDebugService.PushTopic:output_type -> chalk.streaming.v1.PushTopicResponse
-	18, // [18:26] is the sub-list for method output_type
-	10, // [10:18] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	24, // 0: chalk.streaming.v1.EnableDebugModeRequest.logger_config:type_name -> chalk.streaming.v1.StreamingLoggerConfig
+	25, // 1: chalk.streaming.v1.EnableDebugModeResponse.enabled_at:type_name -> google.protobuf.Timestamp
+	25, // 2: chalk.streaming.v1.GetDebugModeStatusResponse.enabled_at:type_name -> google.protobuf.Timestamp
+	24, // 3: chalk.streaming.v1.GetDebugModeStatusResponse.logger_config:type_name -> chalk.streaming.v1.StreamingLoggerConfig
+	25, // 4: chalk.streaming.v1.GetDebugMessagesRequest.start_timestamp_inclusive:type_name -> google.protobuf.Timestamp
+	25, // 5: chalk.streaming.v1.GetDebugMessagesRequest.end_timestamp_exclusive:type_name -> google.protobuf.Timestamp
+	25, // 6: chalk.streaming.v1.GetDebugMessagesV2Request.start_timestamp_inclusive:type_name -> google.protobuf.Timestamp
+	25, // 7: chalk.streaming.v1.GetDebugMessagesV2Request.end_timestamp_exclusive:type_name -> google.protobuf.Timestamp
+	10, // 8: chalk.streaming.v1.GetDebugMessagesV2Response.messages:type_name -> chalk.streaming.v1.StreamingDebugMessage
+	21, // 9: chalk.streaming.v1.GetDebugMessagesV2Response.feature_expressions:type_name -> chalk.streaming.v1.GetDebugMessagesV2Response.FeatureExpressionsEntry
+	22, // 10: chalk.streaming.v1.StreamingDebugMessage.message_headers:type_name -> chalk.streaming.v1.StreamingDebugMessage.MessageHeadersEntry
+	25, // 11: chalk.streaming.v1.StreamingDebugMessage.publish_timestamp:type_name -> google.protobuf.Timestamp
+	25, // 12: chalk.streaming.v1.StreamingDebugMessage.ingest_timestamp:type_name -> google.protobuf.Timestamp
+	26, // 13: chalk.streaming.v1.StreamingDebugMessage.status:type_name -> chalk.streaming.v1.StreamingMessageStatus
+	23, // 14: chalk.streaming.v1.StreamingDebugMessage.features:type_name -> chalk.streaming.v1.StreamingDebugMessage.FeaturesEntry
+	11, // 15: chalk.streaming.v1.StreamingDebugMessage.error:type_name -> chalk.streaming.v1.StreamingDebugMessageError
+	27, // 16: chalk.streaming.v1.StreamingDebugMessageError.phase:type_name -> chalk.streaming.v1.ExecutionPhase
+	28, // 17: chalk.streaming.v1.PushTopicResponse.error:type_name -> chalk.common.v1.ChalkError
+	24, // 18: chalk.streaming.v1.SetStreamingDebugConfigRequest.logger_config:type_name -> chalk.streaming.v1.StreamingLoggerConfig
+	24, // 19: chalk.streaming.v1.SetStreamingDebugConfigResponse.logger_config:type_name -> chalk.streaming.v1.StreamingLoggerConfig
+	24, // 20: chalk.streaming.v1.GetStreamingDebugConfigResponse.logger_config:type_name -> chalk.streaming.v1.StreamingLoggerConfig
+	12, // 21: chalk.streaming.v1.GetDebugMessagesV2Response.FeatureExpressionsEntry.value:type_name -> chalk.streaming.v1.StreamingFeatureExpression
+	29, // 22: chalk.streaming.v1.StreamingDebugMessage.FeaturesEntry.value:type_name -> chalk.arrow.v1.ScalarValue
+	17, // 23: chalk.streaming.v1.StreamingDebugService.SetStreamingDebugConfig:input_type -> chalk.streaming.v1.SetStreamingDebugConfigRequest
+	19, // 24: chalk.streaming.v1.StreamingDebugService.GetStreamingDebugConfig:input_type -> chalk.streaming.v1.GetStreamingDebugConfigRequest
+	0,  // 25: chalk.streaming.v1.StreamingDebugService.EnableDebugMode:input_type -> chalk.streaming.v1.EnableDebugModeRequest
+	2,  // 26: chalk.streaming.v1.StreamingDebugService.DisableDebugMode:input_type -> chalk.streaming.v1.DisableDebugModeRequest
+	4,  // 27: chalk.streaming.v1.StreamingDebugService.GetDebugModeStatus:input_type -> chalk.streaming.v1.GetDebugModeStatusRequest
+	6,  // 28: chalk.streaming.v1.StreamingDebugService.GetDebugMessages:input_type -> chalk.streaming.v1.GetDebugMessagesRequest
+	8,  // 29: chalk.streaming.v1.StreamingDebugService.GetDebugMessagesV2:input_type -> chalk.streaming.v1.GetDebugMessagesV2Request
+	13, // 30: chalk.streaming.v1.StreamingDebugService.WatchDebugStream:input_type -> chalk.streaming.v1.WatchDebugStreamRequest
+	15, // 31: chalk.streaming.v1.StreamingDebugService.PushTopic:input_type -> chalk.streaming.v1.PushTopicRequest
+	18, // 32: chalk.streaming.v1.StreamingDebugService.SetStreamingDebugConfig:output_type -> chalk.streaming.v1.SetStreamingDebugConfigResponse
+	20, // 33: chalk.streaming.v1.StreamingDebugService.GetStreamingDebugConfig:output_type -> chalk.streaming.v1.GetStreamingDebugConfigResponse
+	1,  // 34: chalk.streaming.v1.StreamingDebugService.EnableDebugMode:output_type -> chalk.streaming.v1.EnableDebugModeResponse
+	3,  // 35: chalk.streaming.v1.StreamingDebugService.DisableDebugMode:output_type -> chalk.streaming.v1.DisableDebugModeResponse
+	5,  // 36: chalk.streaming.v1.StreamingDebugService.GetDebugModeStatus:output_type -> chalk.streaming.v1.GetDebugModeStatusResponse
+	7,  // 37: chalk.streaming.v1.StreamingDebugService.GetDebugMessages:output_type -> chalk.streaming.v1.GetDebugMessagesResponse
+	9,  // 38: chalk.streaming.v1.StreamingDebugService.GetDebugMessagesV2:output_type -> chalk.streaming.v1.GetDebugMessagesV2Response
+	14, // 39: chalk.streaming.v1.StreamingDebugService.WatchDebugStream:output_type -> chalk.streaming.v1.WatchDebugStreamResponse
+	16, // 40: chalk.streaming.v1.StreamingDebugService.PushTopic:output_type -> chalk.streaming.v1.PushTopicResponse
+	32, // [32:41] is the sub-list for method output_type
+	23, // [23:32] is the sub-list for method input_type
+	23, // [23:23] is the sub-list for extension type_name
+	23, // [23:23] is the sub-list for extension extendee
+	0,  // [0:23] is the sub-list for field type_name
 }
 
 func init() { file_chalk_streaming_v1_debug_service_proto_init() }
@@ -1171,13 +1673,17 @@ func file_chalk_streaming_v1_debug_service_proto_init() {
 	file_chalk_streaming_v1_debug_service_proto_msgTypes[12].OneofWrappers = []any{}
 	file_chalk_streaming_v1_debug_service_proto_msgTypes[13].OneofWrappers = []any{}
 	file_chalk_streaming_v1_debug_service_proto_msgTypes[15].OneofWrappers = []any{}
+	file_chalk_streaming_v1_debug_service_proto_msgTypes[16].OneofWrappers = []any{}
+	file_chalk_streaming_v1_debug_service_proto_msgTypes[17].OneofWrappers = []any{}
+	file_chalk_streaming_v1_debug_service_proto_msgTypes[18].OneofWrappers = []any{}
+	file_chalk_streaming_v1_debug_service_proto_msgTypes[20].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chalk_streaming_v1_debug_service_proto_rawDesc), len(file_chalk_streaming_v1_debug_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   16,
+			NumMessages:   24,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/chalk/streaming/v1/streamingv1connect/debug_service.connect.go
+++ b/gen/chalk/streaming/v1/streamingv1connect/debug_service.connect.go
@@ -51,6 +51,9 @@ const (
 	// StreamingDebugServiceGetDebugMessagesProcedure is the fully-qualified name of the
 	// StreamingDebugService's GetDebugMessages RPC.
 	StreamingDebugServiceGetDebugMessagesProcedure = "/chalk.streaming.v1.StreamingDebugService/GetDebugMessages"
+	// StreamingDebugServiceGetDebugMessagesV2Procedure is the fully-qualified name of the
+	// StreamingDebugService's GetDebugMessagesV2 RPC.
+	StreamingDebugServiceGetDebugMessagesV2Procedure = "/chalk.streaming.v1.StreamingDebugService/GetDebugMessagesV2"
 	// StreamingDebugServiceWatchDebugStreamProcedure is the fully-qualified name of the
 	// StreamingDebugService's WatchDebugStream RPC.
 	StreamingDebugServiceWatchDebugStreamProcedure = "/chalk.streaming.v1.StreamingDebugService/WatchDebugStream"
@@ -73,6 +76,10 @@ type StreamingDebugServiceClient interface {
 	GetDebugModeStatus(context.Context, *connect.Request[v1.GetDebugModeStatusRequest]) (*connect.Response[v1.GetDebugModeStatusResponse], error)
 	// Get recent debug messages as parquet
 	GetDebugMessages(context.Context, *connect.Request[v1.GetDebugMessagesRequest]) (*connect.Response[v1.GetDebugMessagesResponse], error)
+	// Get recent debug messages as a structured response with per-feature
+	// values, error details, aggregate counts, and the expression each output
+	// feature is bound to in the resolver.
+	GetDebugMessagesV2(context.Context, *connect.Request[v1.GetDebugMessagesV2Request]) (*connect.Response[v1.GetDebugMessagesV2Response], error)
 	// Watch for new debug files in cloud storage and stream them back
 	WatchDebugStream(context.Context, *connect.Request[v1.WatchDebugStreamRequest]) (*connect.ServerStreamForClient[v1.WatchDebugStreamResponse], error)
 	// Push a message to a streaming topic
@@ -129,6 +136,13 @@ func NewStreamingDebugServiceClient(httpClient connect.HTTPClient, baseURL strin
 			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 			connect.WithClientOptions(opts...),
 		),
+		getDebugMessagesV2: connect.NewClient[v1.GetDebugMessagesV2Request, v1.GetDebugMessagesV2Response](
+			httpClient,
+			baseURL+StreamingDebugServiceGetDebugMessagesV2Procedure,
+			connect.WithSchema(streamingDebugServiceMethods.ByName("GetDebugMessagesV2")),
+			connect.WithIdempotency(connect.IdempotencyNoSideEffects),
+			connect.WithClientOptions(opts...),
+		),
 		watchDebugStream: connect.NewClient[v1.WatchDebugStreamRequest, v1.WatchDebugStreamResponse](
 			httpClient,
 			baseURL+StreamingDebugServiceWatchDebugStreamProcedure,
@@ -152,6 +166,7 @@ type streamingDebugServiceClient struct {
 	disableDebugMode        *connect.Client[v1.DisableDebugModeRequest, v1.DisableDebugModeResponse]
 	getDebugModeStatus      *connect.Client[v1.GetDebugModeStatusRequest, v1.GetDebugModeStatusResponse]
 	getDebugMessages        *connect.Client[v1.GetDebugMessagesRequest, v1.GetDebugMessagesResponse]
+	getDebugMessagesV2      *connect.Client[v1.GetDebugMessagesV2Request, v1.GetDebugMessagesV2Response]
 	watchDebugStream        *connect.Client[v1.WatchDebugStreamRequest, v1.WatchDebugStreamResponse]
 	pushTopic               *connect.Client[v1.PushTopicRequest, v1.PushTopicResponse]
 }
@@ -186,6 +201,11 @@ func (c *streamingDebugServiceClient) GetDebugMessages(ctx context.Context, req 
 	return c.getDebugMessages.CallUnary(ctx, req)
 }
 
+// GetDebugMessagesV2 calls chalk.streaming.v1.StreamingDebugService.GetDebugMessagesV2.
+func (c *streamingDebugServiceClient) GetDebugMessagesV2(ctx context.Context, req *connect.Request[v1.GetDebugMessagesV2Request]) (*connect.Response[v1.GetDebugMessagesV2Response], error) {
+	return c.getDebugMessagesV2.CallUnary(ctx, req)
+}
+
 // WatchDebugStream calls chalk.streaming.v1.StreamingDebugService.WatchDebugStream.
 func (c *streamingDebugServiceClient) WatchDebugStream(ctx context.Context, req *connect.Request[v1.WatchDebugStreamRequest]) (*connect.ServerStreamForClient[v1.WatchDebugStreamResponse], error) {
 	return c.watchDebugStream.CallServerStream(ctx, req)
@@ -211,6 +231,10 @@ type StreamingDebugServiceHandler interface {
 	GetDebugModeStatus(context.Context, *connect.Request[v1.GetDebugModeStatusRequest]) (*connect.Response[v1.GetDebugModeStatusResponse], error)
 	// Get recent debug messages as parquet
 	GetDebugMessages(context.Context, *connect.Request[v1.GetDebugMessagesRequest]) (*connect.Response[v1.GetDebugMessagesResponse], error)
+	// Get recent debug messages as a structured response with per-feature
+	// values, error details, aggregate counts, and the expression each output
+	// feature is bound to in the resolver.
+	GetDebugMessagesV2(context.Context, *connect.Request[v1.GetDebugMessagesV2Request]) (*connect.Response[v1.GetDebugMessagesV2Response], error)
 	// Watch for new debug files in cloud storage and stream them back
 	WatchDebugStream(context.Context, *connect.Request[v1.WatchDebugStreamRequest], *connect.ServerStream[v1.WatchDebugStreamResponse]) error
 	// Push a message to a streaming topic
@@ -263,6 +287,13 @@ func NewStreamingDebugServiceHandler(svc StreamingDebugServiceHandler, opts ...c
 		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
 		connect.WithHandlerOptions(opts...),
 	)
+	streamingDebugServiceGetDebugMessagesV2Handler := connect.NewUnaryHandler(
+		StreamingDebugServiceGetDebugMessagesV2Procedure,
+		svc.GetDebugMessagesV2,
+		connect.WithSchema(streamingDebugServiceMethods.ByName("GetDebugMessagesV2")),
+		connect.WithIdempotency(connect.IdempotencyNoSideEffects),
+		connect.WithHandlerOptions(opts...),
+	)
 	streamingDebugServiceWatchDebugStreamHandler := connect.NewServerStreamHandler(
 		StreamingDebugServiceWatchDebugStreamProcedure,
 		svc.WatchDebugStream,
@@ -289,6 +320,8 @@ func NewStreamingDebugServiceHandler(svc StreamingDebugServiceHandler, opts ...c
 			streamingDebugServiceGetDebugModeStatusHandler.ServeHTTP(w, r)
 		case StreamingDebugServiceGetDebugMessagesProcedure:
 			streamingDebugServiceGetDebugMessagesHandler.ServeHTTP(w, r)
+		case StreamingDebugServiceGetDebugMessagesV2Procedure:
+			streamingDebugServiceGetDebugMessagesV2Handler.ServeHTTP(w, r)
 		case StreamingDebugServiceWatchDebugStreamProcedure:
 			streamingDebugServiceWatchDebugStreamHandler.ServeHTTP(w, r)
 		case StreamingDebugServicePushTopicProcedure:
@@ -324,6 +357,10 @@ func (UnimplementedStreamingDebugServiceHandler) GetDebugModeStatus(context.Cont
 
 func (UnimplementedStreamingDebugServiceHandler) GetDebugMessages(context.Context, *connect.Request[v1.GetDebugMessagesRequest]) (*connect.Response[v1.GetDebugMessagesResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("chalk.streaming.v1.StreamingDebugService.GetDebugMessages is not implemented"))
+}
+
+func (UnimplementedStreamingDebugServiceHandler) GetDebugMessagesV2(context.Context, *connect.Request[v1.GetDebugMessagesV2Request]) (*connect.Response[v1.GetDebugMessagesV2Response], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("chalk.streaming.v1.StreamingDebugService.GetDebugMessagesV2 is not implemented"))
 }
 
 func (UnimplementedStreamingDebugServiceHandler) WatchDebugStream(context.Context, *connect.Request[v1.WatchDebugStreamRequest], *connect.ServerStream[v1.WatchDebugStreamResponse]) error {


### PR DESCRIPTION
Linear: https://linear.app/chalk-ai/issue/CHA-8929/write-scheduledaggregationbackfill-and-cli-flag-to-allow-empty-tiles

Labels: chalk-go, generated protos, bugfix

Updates the generated Go protobuf bindings from the current source protos.

This exposes `allow_empty_tiles` on scheduled aggregate backfill artifacts and aggregate backfill job requests so SDK callers can pass the new empty-tile opt-in flag. The generated snapshot also includes the current source-proto churn for related SSO, streaming, and offline query definitions.

Validated with `go test ./...`.