### PR TITLE
Add store_online to CreateAggregateBackfillJobRequest

### DIFF
--- a/gen/chalk/aggregate/v1/service.pb.go
+++ b/gen/chalk/aggregate/v1/service.pb.go
@@ -676,8 +676,12 @@ type CreateAggregateBackfillJobRequest struct {
 	StoreOffline        *bool                  `protobuf:"varint,10,opt,name=store_offline,json=storeOffline,proto3,oneof" json:"store_offline,omitempty"`
 	UseMetaplanner      *bool                  `protobuf:"varint,11,opt,name=use_metaplanner,json=useMetaplanner,proto3,oneof" json:"use_metaplanner,omitempty"`
 	AllowEmptyTiles     *bool                  `protobuf:"varint,12,opt,name=allow_empty_tiles,json=allowEmptyTiles,proto3,oneof" json:"allow_empty_tiles,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// If false, skip writing aggregate state to the online store and only
+	// compute aggregate tiles + emit the dataset parquet output. Defaults to
+	// true (write to the online store) when unset to preserve existing behavior.
+	StoreOnline   *bool `protobuf:"varint,13,opt,name=store_online,json=storeOnline,proto3,oneof" json:"store_online,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CreateAggregateBackfillJobRequest) Reset() {
@@ -794,6 +798,13 @@ func (x *CreateAggregateBackfillJobRequest) GetAllowEmptyTiles() bool {
 	return false
 }
 
+func (x *CreateAggregateBackfillJobRequest) GetStoreOnline() bool {
+	if x != nil && x.StoreOnline != nil {
+		return *x.StoreOnline
+	}
+	return false
+}
+
 type CreateAggregateBackfillJobResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	JobId         string                 `protobuf:"bytes,1,opt,name=job_id,json=jobId,proto3" json:"job_id,omitempty"`
@@ -895,7 +906,7 @@ const file_chalk_aggregate_v1_service_proto_rawDesc = "" +
 	"\n" +
 	"latest_job\x18\x02 \x01(\v2(.chalk.aggregate.v1.AggregateBackfillJobR\tlatestJob\"\x9b\x01\n" +
 	"'GetActiveCronAggregateBackfillsResponse\x12p\n" +
-	"\x18cron_aggregate_backfills\x18\x01 \x03(\v26.chalk.aggregate.v1.CronAggregateBackfillWithLatestRunR\x16cronAggregateBackfills\"\xf1\x05\n" +
+	"\x18cron_aggregate_backfills\x18\x01 \x03(\v26.chalk.aggregate.v1.CronAggregateBackfillWithLatestRunR\x16cronAggregateBackfills\"\xaa\x06\n" +
 	"!CreateAggregateBackfillJobRequest\x12\x1a\n" +
 	"\bfeatures\x18\x01 \x03(\tR\bfeatures\x12@\n" +
 	"\vlower_bound\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\n" +
@@ -912,7 +923,8 @@ const file_chalk_aggregate_v1_service_proto_rawDesc = "" +
 	"\rstore_offline\x18\n" +
 	" \x01(\bH\x06R\fstoreOffline\x88\x01\x01\x12,\n" +
 	"\x0fuse_metaplanner\x18\v \x01(\bH\aR\x0euseMetaplanner\x88\x01\x01\x12/\n" +
-	"\x11allow_empty_tiles\x18\f \x01(\bH\bR\x0fallowEmptyTiles\x88\x01\x01B\x0e\n" +
+	"\x11allow_empty_tiles\x18\f \x01(\bH\bR\x0fallowEmptyTiles\x88\x01\x01\x12&\n" +
+	"\fstore_online\x18\r \x01(\bH\tR\vstoreOnline\x88\x01\x01B\x0e\n" +
 	"\f_lower_boundB\x0e\n" +
 	"\f_upper_boundB\v\n" +
 	"\t_resolverB\x11\n" +
@@ -921,7 +933,8 @@ const file_chalk_aggregate_v1_service_proto_rawDesc = "" +
 	"\x0f_resource_groupB\x10\n" +
 	"\x0e_store_offlineB\x12\n" +
 	"\x10_use_metaplannerB\x14\n" +
-	"\x12_allow_empty_tiles\"\x8c\x01\n" +
+	"\x12_allow_empty_tilesB\x0f\n" +
+	"\r_store_online\"\x8c\x01\n" +
 	"\"CreateAggregateBackfillJobResponse\x12\x15\n" +
 	"\x06job_id\x18\x01 \x01(\tR\x05jobId\x12\x1a\n" +
 	"\bfeatures\x18\x02 \x03(\tR\bfeatures\x123\n" +


### PR DESCRIPTION
## Summary
- Regenerate Go protos for the new `store_online` field on `chalk.aggregate.v1.CreateAggregateBackfillJobRequest`
- Source proto change lives in chalk-private; this PR is the corresponding `chalk-go` regen so downstream Go consumers (CLI, etc.) can use the new field

The new field lets callers run `chalk aggregate backfill` with `--store-online=false` to compute aggregate tiles + emit the dataset parquet output while skipping the online-store write.