### PR TITLE
test(testserver): mocks for cluster, vpc, cloud-credentials, and team RPCs

### DIFF
--- a/testserver/cloud_components.go
+++ b/testserver/cloud_components.go
@@ -438,3 +438,25 @@ func (h *cloudComponentsServiceHandler) GetCloudComponentCluster(
 	}
 	return connect.NewResponse(resp.(*serverv1.GetCloudComponentClusterResponse)), nil
 }
+
+func (h *cloudComponentsServiceHandler) GetCloudComponentVpc(
+	ctx context.Context,
+	req *connect.Request[serverv1.GetCloudComponentVpcRequest],
+) (*connect.Response[serverv1.GetCloudComponentVpcResponse], error) {
+	h.registry.CaptureRequest("GetCloudComponentVpc", req.Msg)
+	if behavior := h.registry.GetBehavior("GetCloudComponentVpc"); behavior != nil {
+		resp, err := behavior(req.Msg)
+		if err != nil {
+			return nil, err
+		}
+		return connect.NewResponse(resp.(*serverv1.GetCloudComponentVpcResponse)), nil
+	}
+	if err := h.registry.GetError("GetCloudComponentVpc"); err != nil {
+		return nil, err
+	}
+	resp := h.registry.GetResponse("GetCloudComponentVpc")
+	if resp == nil {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("no mock response configured for GetCloudComponentVpc"))
+	}
+	return connect.NewResponse(resp.(*serverv1.GetCloudComponentVpcResponse)), nil
+}

--- a/testserver/cloud_components.go
+++ b/testserver/cloud_components.go
@@ -416,3 +416,25 @@ func (h *cloudComponentsServiceHandler) DeleteBindingEnvironmentBackgroundPersis
 	}
 	return connect.NewResponse(resp.(*serverv1.DeleteBindingEnvironmentBackgroundPersistenceDeploymentResponse)), nil
 }
+
+func (h *cloudComponentsServiceHandler) GetCloudComponentCluster(
+	ctx context.Context,
+	req *connect.Request[serverv1.GetCloudComponentClusterRequest],
+) (*connect.Response[serverv1.GetCloudComponentClusterResponse], error) {
+	h.registry.CaptureRequest("GetCloudComponentCluster", req.Msg)
+	if behavior := h.registry.GetBehavior("GetCloudComponentCluster"); behavior != nil {
+		resp, err := behavior(req.Msg)
+		if err != nil {
+			return nil, err
+		}
+		return connect.NewResponse(resp.(*serverv1.GetCloudComponentClusterResponse)), nil
+	}
+	if err := h.registry.GetError("GetCloudComponentCluster"); err != nil {
+		return nil, err
+	}
+	resp := h.registry.GetResponse("GetCloudComponentCluster")
+	if resp == nil {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("no mock response configured for GetCloudComponentCluster"))
+	}
+	return connect.NewResponse(resp.(*serverv1.GetCloudComponentClusterResponse)), nil
+}

--- a/testserver/cloud_components_test.go
+++ b/testserver/cloud_components_test.go
@@ -1,0 +1,250 @@
+package testserver_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"connectrpc.com/connect"
+	serverv1 "github.com/chalk-ai/chalk-go/gen/chalk/server/v1"
+	"github.com/chalk-ai/chalk-go/gen/chalk/server/v1/serverv1connect"
+	"github.com/chalk-ai/chalk-go/testserver"
+	"google.golang.org/protobuf/proto"
+)
+
+// cloudComponentsClient returns a real CloudComponentsService client wired
+// against the mock server's HTTP endpoint.
+func cloudComponentsClient(server *testserver.MockServer) serverv1connect.CloudComponentsServiceClient {
+	return serverv1connect.NewCloudComponentsServiceClient(http.DefaultClient, server.URL)
+}
+
+func TestGetCloudComponentCluster(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Return", func(t *testing.T) {
+		t.Parallel()
+		server := testserver.NewMockBuilderServer(t)
+		t.Cleanup(func() { server.Close() })
+
+		want := &serverv1.GetCloudComponentClusterResponse{
+			Cluster: &serverv1.CloudComponentClusterResponse{Id: "cluster-id", Kind: "EKS_STANDARD"},
+		}
+		server.OnGetCloudComponentCluster().Return(want)
+
+		got, err := cloudComponentsClient(server).GetCloudComponentCluster(
+			context.Background(),
+			connect.NewRequest(&serverv1.GetCloudComponentClusterRequest{Id: "cluster-id"}),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Msg.Cluster.Id != "cluster-id" {
+			t.Errorf("Cluster.Id = %q, want %q", got.Msg.Cluster.Id, "cluster-id")
+		}
+		if got.Msg.Cluster.Kind != "EKS_STANDARD" {
+			t.Errorf("Cluster.Kind = %q, want %q", got.Msg.Cluster.Kind, "EKS_STANDARD")
+		}
+	})
+
+	t.Run("ReturnError", func(t *testing.T) {
+		t.Parallel()
+		server := testserver.NewMockBuilderServer(t)
+		t.Cleanup(func() { server.Close() })
+
+		server.OnGetCloudComponentCluster().ReturnError(
+			connect.NewError(connect.CodePermissionDenied, errors.New("nope")),
+		)
+
+		_, err := cloudComponentsClient(server).GetCloudComponentCluster(
+			context.Background(),
+			connect.NewRequest(&serverv1.GetCloudComponentClusterRequest{Id: "cluster-id"}),
+		)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if connect.CodeOf(err) != connect.CodePermissionDenied {
+			t.Errorf("error code = %v, want %v", connect.CodeOf(err), connect.CodePermissionDenied)
+		}
+	})
+
+	t.Run("NoMockConfigured", func(t *testing.T) {
+		t.Parallel()
+		server := testserver.NewMockBuilderServer(t)
+		t.Cleanup(func() { server.Close() })
+
+		_, err := cloudComponentsClient(server).GetCloudComponentCluster(
+			context.Background(),
+			connect.NewRequest(&serverv1.GetCloudComponentClusterRequest{Id: "cluster-id"}),
+		)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if connect.CodeOf(err) != connect.CodeNotFound {
+			t.Errorf("error code = %v, want %v", connect.CodeOf(err), connect.CodeNotFound)
+		}
+	})
+
+	t.Run("WithBehavior", func(t *testing.T) {
+		t.Parallel()
+		server := testserver.NewMockBuilderServer(t)
+		t.Cleanup(func() { server.Close() })
+
+		server.OnGetCloudComponentCluster().WithBehavior(func(req proto.Message) (proto.Message, error) {
+			r := req.(*serverv1.GetCloudComponentClusterRequest)
+			return &serverv1.GetCloudComponentClusterResponse{
+				Cluster: &serverv1.CloudComponentClusterResponse{Id: r.Id + "-echo"},
+			}, nil
+		})
+
+		got, err := cloudComponentsClient(server).GetCloudComponentCluster(
+			context.Background(),
+			connect.NewRequest(&serverv1.GetCloudComponentClusterRequest{Id: "abc"}),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Msg.Cluster.Id != "abc-echo" {
+			t.Errorf("Cluster.Id = %q, want %q", got.Msg.Cluster.Id, "abc-echo")
+		}
+	})
+
+	t.Run("CapturesRequests", func(t *testing.T) {
+		t.Parallel()
+		server := testserver.NewMockBuilderServer(t)
+		t.Cleanup(func() { server.Close() })
+
+		server.OnGetCloudComponentCluster().Return(&serverv1.GetCloudComponentClusterResponse{
+			Cluster: &serverv1.CloudComponentClusterResponse{Id: "x"},
+		})
+
+		_, err := cloudComponentsClient(server).GetCloudComponentCluster(
+			context.Background(),
+			connect.NewRequest(&serverv1.GetCloudComponentClusterRequest{Id: "captured-id"}),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		captured := server.GetCapturedRequests("GetCloudComponentCluster")
+		if len(captured) != 1 {
+			t.Fatalf("captured %d requests, want 1", len(captured))
+		}
+		req := captured[0].(*serverv1.GetCloudComponentClusterRequest)
+		if req.Id != "captured-id" {
+			t.Errorf("captured Id = %q, want %q", req.Id, "captured-id")
+		}
+	})
+}
+
+func TestGetCloudComponentVpc(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Return", func(t *testing.T) {
+		t.Parallel()
+		server := testserver.NewMockBuilderServer(t)
+		t.Cleanup(func() { server.Close() })
+
+		want := &serverv1.GetCloudComponentVpcResponse{
+			Vpc: &serverv1.CloudComponentVpcResponse{Id: "vpc-id", Kind: "aws"},
+		}
+		server.OnGetCloudComponentVpc().Return(want)
+
+		got, err := cloudComponentsClient(server).GetCloudComponentVpc(
+			context.Background(),
+			connect.NewRequest(&serverv1.GetCloudComponentVpcRequest{Id: "vpc-id"}),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Msg.Vpc.Id != "vpc-id" {
+			t.Errorf("Vpc.Id = %q, want %q", got.Msg.Vpc.Id, "vpc-id")
+		}
+		if got.Msg.Vpc.Kind != "aws" {
+			t.Errorf("Vpc.Kind = %q, want %q", got.Msg.Vpc.Kind, "aws")
+		}
+	})
+
+	t.Run("ReturnError", func(t *testing.T) {
+		t.Parallel()
+		server := testserver.NewMockBuilderServer(t)
+		t.Cleanup(func() { server.Close() })
+
+		server.OnGetCloudComponentVpc().ReturnError(
+			connect.NewError(connect.CodeInternal, errors.New("boom")),
+		)
+
+		_, err := cloudComponentsClient(server).GetCloudComponentVpc(
+			context.Background(),
+			connect.NewRequest(&serverv1.GetCloudComponentVpcRequest{Id: "vpc-id"}),
+		)
+		if connect.CodeOf(err) != connect.CodeInternal {
+			t.Errorf("error code = %v, want %v", connect.CodeOf(err), connect.CodeInternal)
+		}
+	})
+
+	t.Run("NoMockConfigured", func(t *testing.T) {
+		t.Parallel()
+		server := testserver.NewMockBuilderServer(t)
+		t.Cleanup(func() { server.Close() })
+
+		_, err := cloudComponentsClient(server).GetCloudComponentVpc(
+			context.Background(),
+			connect.NewRequest(&serverv1.GetCloudComponentVpcRequest{Id: "vpc-id"}),
+		)
+		if connect.CodeOf(err) != connect.CodeNotFound {
+			t.Errorf("error code = %v, want %v", connect.CodeOf(err), connect.CodeNotFound)
+		}
+	})
+
+	t.Run("WithBehavior", func(t *testing.T) {
+		t.Parallel()
+		server := testserver.NewMockBuilderServer(t)
+		t.Cleanup(func() { server.Close() })
+
+		server.OnGetCloudComponentVpc().WithBehavior(func(req proto.Message) (proto.Message, error) {
+			r := req.(*serverv1.GetCloudComponentVpcRequest)
+			return &serverv1.GetCloudComponentVpcResponse{
+				Vpc: &serverv1.CloudComponentVpcResponse{Id: r.Id + "-echo"},
+			}, nil
+		})
+
+		got, err := cloudComponentsClient(server).GetCloudComponentVpc(
+			context.Background(),
+			connect.NewRequest(&serverv1.GetCloudComponentVpcRequest{Id: "abc"}),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Msg.Vpc.Id != "abc-echo" {
+			t.Errorf("Vpc.Id = %q, want %q", got.Msg.Vpc.Id, "abc-echo")
+		}
+	})
+
+	t.Run("CapturesRequests", func(t *testing.T) {
+		t.Parallel()
+		server := testserver.NewMockBuilderServer(t)
+		t.Cleanup(func() { server.Close() })
+
+		server.OnGetCloudComponentVpc().Return(&serverv1.GetCloudComponentVpcResponse{
+			Vpc: &serverv1.CloudComponentVpcResponse{Id: "x"},
+		})
+
+		_, err := cloudComponentsClient(server).GetCloudComponentVpc(
+			context.Background(),
+			connect.NewRequest(&serverv1.GetCloudComponentVpcRequest{Id: "captured-vpc"}),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		captured := server.GetCapturedRequests("GetCloudComponentVpc")
+		if len(captured) != 1 {
+			t.Fatalf("captured %d requests, want 1", len(captured))
+		}
+		req := captured[0].(*serverv1.GetCloudComponentVpcRequest)
+		if req.Id != "captured-vpc" {
+			t.Errorf("captured Id = %q, want %q", req.Id, "captured-vpc")
+		}
+	})
+}

--- a/testserver/cloud_credentials.go
+++ b/testserver/cloud_credentials.go
@@ -1,0 +1,43 @@
+package testserver
+
+import (
+	"context"
+	"errors"
+
+	"connectrpc.com/connect"
+	serverv1 "github.com/chalk-ai/chalk-go/gen/chalk/server/v1"
+	"github.com/chalk-ai/chalk-go/gen/chalk/server/v1/serverv1connect"
+)
+
+// cloudAccountCredentialsServiceHandler implements the CloudAccountCredentialsService RPC
+// handler using a ResponseRegistry to provide configurable mock responses.
+type cloudAccountCredentialsServiceHandler struct {
+	serverv1connect.UnimplementedCloudAccountCredentialsServiceHandler
+	registry *ResponseRegistry
+}
+
+func newCloudAccountCredentialsServiceHandler(registry *ResponseRegistry) *cloudAccountCredentialsServiceHandler {
+	return &cloudAccountCredentialsServiceHandler{registry: registry}
+}
+
+func (h *cloudAccountCredentialsServiceHandler) GetCloudCredentials(
+	ctx context.Context,
+	req *connect.Request[serverv1.GetCloudCredentialsRequest],
+) (*connect.Response[serverv1.GetCloudCredentialsResponse], error) {
+	h.registry.CaptureRequest("GetCloudCredentials", req.Msg)
+	if behavior := h.registry.GetBehavior("GetCloudCredentials"); behavior != nil {
+		resp, err := behavior(req.Msg)
+		if err != nil {
+			return nil, err
+		}
+		return connect.NewResponse(resp.(*serverv1.GetCloudCredentialsResponse)), nil
+	}
+	if err := h.registry.GetError("GetCloudCredentials"); err != nil {
+		return nil, err
+	}
+	resp := h.registry.GetResponse("GetCloudCredentials")
+	if resp == nil {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("no mock response configured for GetCloudCredentials"))
+	}
+	return connect.NewResponse(resp.(*serverv1.GetCloudCredentialsResponse)), nil
+}

--- a/testserver/cloud_credentials_test.go
+++ b/testserver/cloud_credentials_test.go
@@ -1,0 +1,134 @@
+package testserver_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"connectrpc.com/connect"
+	serverv1 "github.com/chalk-ai/chalk-go/gen/chalk/server/v1"
+	"github.com/chalk-ai/chalk-go/gen/chalk/server/v1/serverv1connect"
+	"github.com/chalk-ai/chalk-go/testserver"
+	"google.golang.org/protobuf/proto"
+)
+
+func cloudCredentialsClient(server *testserver.MockServer) serverv1connect.CloudAccountCredentialsServiceClient {
+	return serverv1connect.NewCloudAccountCredentialsServiceClient(http.DefaultClient, server.URL)
+}
+
+// TestGetCloudCredentials covers the entire CloudAccountCredentialsService —
+// this service is registered on the mock mux in server.go alongside the others.
+// The "Return" subtest exercising a real client call against server.URL
+// implicitly verifies that mux registration is correct.
+func TestGetCloudCredentials(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Return", func(t *testing.T) {
+		t.Parallel()
+		server := testserver.NewMockBuilderServer(t)
+		t.Cleanup(func() { server.Close() })
+
+		want := &serverv1.GetCloudCredentialsResponse{
+			Credentials: &serverv1.CloudCredentialsResponse{Id: "cred-id", Name: "test", Kind: "aws"},
+		}
+		server.OnGetCloudCredentials().Return(want)
+
+		got, err := cloudCredentialsClient(server).GetCloudCredentials(
+			context.Background(),
+			connect.NewRequest(&serverv1.GetCloudCredentialsRequest{Id: "cred-id"}),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Msg.Credentials.Id != "cred-id" {
+			t.Errorf("Credentials.Id = %q, want %q", got.Msg.Credentials.Id, "cred-id")
+		}
+		if got.Msg.Credentials.Kind != "aws" {
+			t.Errorf("Credentials.Kind = %q, want %q", got.Msg.Credentials.Kind, "aws")
+		}
+	})
+
+	t.Run("ReturnError", func(t *testing.T) {
+		t.Parallel()
+		server := testserver.NewMockBuilderServer(t)
+		t.Cleanup(func() { server.Close() })
+
+		server.OnGetCloudCredentials().ReturnError(
+			connect.NewError(connect.CodeUnauthenticated, errors.New("token expired")),
+		)
+
+		_, err := cloudCredentialsClient(server).GetCloudCredentials(
+			context.Background(),
+			connect.NewRequest(&serverv1.GetCloudCredentialsRequest{Id: "cred-id"}),
+		)
+		if connect.CodeOf(err) != connect.CodeUnauthenticated {
+			t.Errorf("error code = %v, want %v", connect.CodeOf(err), connect.CodeUnauthenticated)
+		}
+	})
+
+	t.Run("NoMockConfigured", func(t *testing.T) {
+		t.Parallel()
+		server := testserver.NewMockBuilderServer(t)
+		t.Cleanup(func() { server.Close() })
+
+		_, err := cloudCredentialsClient(server).GetCloudCredentials(
+			context.Background(),
+			connect.NewRequest(&serverv1.GetCloudCredentialsRequest{Id: "cred-id"}),
+		)
+		if connect.CodeOf(err) != connect.CodeNotFound {
+			t.Errorf("error code = %v, want %v", connect.CodeOf(err), connect.CodeNotFound)
+		}
+	})
+
+	t.Run("WithBehavior", func(t *testing.T) {
+		t.Parallel()
+		server := testserver.NewMockBuilderServer(t)
+		t.Cleanup(func() { server.Close() })
+
+		server.OnGetCloudCredentials().WithBehavior(func(req proto.Message) (proto.Message, error) {
+			r := req.(*serverv1.GetCloudCredentialsRequest)
+			return &serverv1.GetCloudCredentialsResponse{
+				Credentials: &serverv1.CloudCredentialsResponse{Id: r.Id + "-echo"},
+			}, nil
+		})
+
+		got, err := cloudCredentialsClient(server).GetCloudCredentials(
+			context.Background(),
+			connect.NewRequest(&serverv1.GetCloudCredentialsRequest{Id: "abc"}),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Msg.Credentials.Id != "abc-echo" {
+			t.Errorf("Credentials.Id = %q, want %q", got.Msg.Credentials.Id, "abc-echo")
+		}
+	})
+
+	t.Run("CapturesRequests", func(t *testing.T) {
+		t.Parallel()
+		server := testserver.NewMockBuilderServer(t)
+		t.Cleanup(func() { server.Close() })
+
+		server.OnGetCloudCredentials().Return(&serverv1.GetCloudCredentialsResponse{
+			Credentials: &serverv1.CloudCredentialsResponse{Id: "x"},
+		})
+
+		_, err := cloudCredentialsClient(server).GetCloudCredentials(
+			context.Background(),
+			connect.NewRequest(&serverv1.GetCloudCredentialsRequest{Id: "captured-cred"}),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		captured := server.GetCapturedRequests("GetCloudCredentials")
+		if len(captured) != 1 {
+			t.Fatalf("captured %d requests, want 1", len(captured))
+		}
+		req := captured[0].(*serverv1.GetCloudCredentialsRequest)
+		if req.Id != "captured-cred" {
+			t.Errorf("captured Id = %q, want %q", req.Id, "captured-cred")
+		}
+	})
+}

--- a/testserver/server.go
+++ b/testserver/server.go
@@ -541,6 +541,14 @@ func (s *MockServer) OnGetCloudCredentials() *MethodConfigBuilder[*serverv1.GetC
 	}
 }
 
+// OnGetTeam configures the GetTeam RPC method.
+func (s *MockServer) OnGetTeam() *MethodConfigBuilder[*serverv1.GetTeamResponse] {
+	return &MethodConfigBuilder[*serverv1.GetTeamResponse]{
+		methodName: "GetTeam",
+		registry:   s.registry,
+	}
+}
+
 // GetCapturedRequests returns all requests captured for the given method name.
 // This is useful for test assertions.
 func (s *MockServer) GetCapturedRequests(methodName string) []proto.Message {

--- a/testserver/server.go
+++ b/testserver/server.go
@@ -512,6 +512,14 @@ func (s *MockServer) OnTestOfflineStoreConnection() *MethodConfigBuilder[*server
 	}
 }
 
+// OnGetCloudComponentCluster configures the GetCloudComponentCluster RPC method.
+func (s *MockServer) OnGetCloudComponentCluster() *MethodConfigBuilder[*serverv1.GetCloudComponentClusterResponse] {
+	return &MethodConfigBuilder[*serverv1.GetCloudComponentClusterResponse]{
+		methodName: "GetCloudComponentCluster",
+		registry:   s.registry,
+	}
+}
+
 // GetCapturedRequests returns all requests captured for the given method name.
 // This is useful for test assertions.
 func (s *MockServer) GetCapturedRequests(methodName string) []proto.Message {

--- a/testserver/server.go
+++ b/testserver/server.go
@@ -85,6 +85,11 @@ func NewMockBuilderServer(t testing.TB) *MockServer {
 	scalingGroupPath, scalingGroupRPCHandler := scalinggroupv1connect.NewScalingGroupManagerServiceHandler(scalingGroupHandler)
 	mux.Handle(scalingGroupPath, scalingGroupRPCHandler)
 
+	// Register CloudAccountCredentialsService handler
+	cloudCredsHandler := newCloudAccountCredentialsServiceHandler(registry)
+	cloudCredsPath, cloudCredsRPCHandler := serverv1connect.NewCloudAccountCredentialsServiceHandler(cloudCredsHandler)
+	mux.Handle(cloudCredsPath, cloudCredsRPCHandler)
+
 	// Create httptest server
 	httpServer := httptest.NewServer(mux)
 
@@ -524,6 +529,14 @@ func (s *MockServer) OnGetCloudComponentCluster() *MethodConfigBuilder[*serverv1
 func (s *MockServer) OnGetCloudComponentVpc() *MethodConfigBuilder[*serverv1.GetCloudComponentVpcResponse] {
 	return &MethodConfigBuilder[*serverv1.GetCloudComponentVpcResponse]{
 		methodName: "GetCloudComponentVpc",
+		registry:   s.registry,
+	}
+}
+
+// OnGetCloudCredentials configures the GetCloudCredentials RPC method.
+func (s *MockServer) OnGetCloudCredentials() *MethodConfigBuilder[*serverv1.GetCloudCredentialsResponse] {
+	return &MethodConfigBuilder[*serverv1.GetCloudCredentialsResponse]{
+		methodName: "GetCloudCredentials",
 		registry:   s.registry,
 	}
 }

--- a/testserver/server.go
+++ b/testserver/server.go
@@ -520,6 +520,14 @@ func (s *MockServer) OnGetCloudComponentCluster() *MethodConfigBuilder[*serverv1
 	}
 }
 
+// OnGetCloudComponentVpc configures the GetCloudComponentVpc RPC method.
+func (s *MockServer) OnGetCloudComponentVpc() *MethodConfigBuilder[*serverv1.GetCloudComponentVpcResponse] {
+	return &MethodConfigBuilder[*serverv1.GetCloudComponentVpcResponse]{
+		methodName: "GetCloudComponentVpc",
+		registry:   s.registry,
+	}
+}
+
 // GetCapturedRequests returns all requests captured for the given method name.
 // This is useful for test assertions.
 func (s *MockServer) GetCapturedRequests(methodName string) []proto.Message {

--- a/testserver/team.go
+++ b/testserver/team.go
@@ -2,6 +2,7 @@ package testserver
 
 import (
 	"context"
+	"errors"
 
 	"connectrpc.com/connect"
 	serverv1 "github.com/chalk-ai/chalk-go/gen/chalk/server/v1"
@@ -55,4 +56,27 @@ func (h *teamServiceHandler) GetEnv(
 	}
 
 	return connect.NewResponse(resp.(*serverv1.GetEnvResponse)), nil
+}
+
+// GetTeam implements the GetTeam RPC method.
+func (h *teamServiceHandler) GetTeam(
+	ctx context.Context,
+	req *connect.Request[serverv1.GetTeamRequest],
+) (*connect.Response[serverv1.GetTeamResponse], error) {
+	h.registry.CaptureRequest("GetTeam", req.Msg)
+	if behavior := h.registry.GetBehavior("GetTeam"); behavior != nil {
+		resp, err := behavior(req.Msg)
+		if err != nil {
+			return nil, err
+		}
+		return connect.NewResponse(resp.(*serverv1.GetTeamResponse)), nil
+	}
+	if err := h.registry.GetError("GetTeam"); err != nil {
+		return nil, err
+	}
+	resp := h.registry.GetResponse("GetTeam")
+	if resp == nil {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("no mock response configured for GetTeam"))
+	}
+	return connect.NewResponse(resp.(*serverv1.GetTeamResponse)), nil
 }

--- a/testserver/team_test.go
+++ b/testserver/team_test.go
@@ -1,0 +1,134 @@
+package testserver_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"connectrpc.com/connect"
+	serverv1 "github.com/chalk-ai/chalk-go/gen/chalk/server/v1"
+	"github.com/chalk-ai/chalk-go/gen/chalk/server/v1/serverv1connect"
+	"github.com/chalk-ai/chalk-go/testserver"
+	"google.golang.org/protobuf/proto"
+)
+
+func teamClient(server *testserver.MockServer) serverv1connect.TeamServiceClient {
+	return serverv1connect.NewTeamServiceClient(http.DefaultClient, server.URL)
+}
+
+func TestGetTeam(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Return", func(t *testing.T) {
+		t.Parallel()
+		server := testserver.NewMockBuilderServer(t)
+		t.Cleanup(func() { server.Close() })
+
+		want := &serverv1.GetTeamResponse{
+			Team: &serverv1.Team{
+				Id: "team-id",
+				Projects: []*serverv1.Project{
+					{Id: "project-id", TeamId: "team-id", Name: "Features"},
+				},
+			},
+		}
+		server.OnGetTeam().Return(want)
+
+		got, err := teamClient(server).GetTeam(
+			context.Background(),
+			connect.NewRequest(&serverv1.GetTeamRequest{}),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Msg.Team.Id != "team-id" {
+			t.Errorf("Team.Id = %q, want %q", got.Msg.Team.Id, "team-id")
+		}
+		if len(got.Msg.Team.Projects) != 1 || got.Msg.Team.Projects[0].Id != "project-id" {
+			t.Errorf("Team.Projects = %+v, want one project with id 'project-id'", got.Msg.Team.Projects)
+		}
+	})
+
+	t.Run("ReturnError", func(t *testing.T) {
+		t.Parallel()
+		server := testserver.NewMockBuilderServer(t)
+		t.Cleanup(func() { server.Close() })
+
+		server.OnGetTeam().ReturnError(
+			connect.NewError(connect.CodeFailedPrecondition, errors.New("team archived")),
+		)
+
+		_, err := teamClient(server).GetTeam(
+			context.Background(),
+			connect.NewRequest(&serverv1.GetTeamRequest{}),
+		)
+		if connect.CodeOf(err) != connect.CodeFailedPrecondition {
+			t.Errorf("error code = %v, want %v", connect.CodeOf(err), connect.CodeFailedPrecondition)
+		}
+	})
+
+	t.Run("NoMockConfigured", func(t *testing.T) {
+		t.Parallel()
+		server := testserver.NewMockBuilderServer(t)
+		t.Cleanup(func() { server.Close() })
+
+		_, err := teamClient(server).GetTeam(
+			context.Background(),
+			connect.NewRequest(&serverv1.GetTeamRequest{}),
+		)
+		if connect.CodeOf(err) != connect.CodeNotFound {
+			t.Errorf("error code = %v, want %v", connect.CodeOf(err), connect.CodeNotFound)
+		}
+	})
+
+	t.Run("WithBehavior", func(t *testing.T) {
+		t.Parallel()
+		server := testserver.NewMockBuilderServer(t)
+		t.Cleanup(func() { server.Close() })
+
+		called := false
+		server.OnGetTeam().WithBehavior(func(req proto.Message) (proto.Message, error) {
+			called = true
+			return &serverv1.GetTeamResponse{Team: &serverv1.Team{Id: "from-behavior"}}, nil
+		})
+
+		got, err := teamClient(server).GetTeam(
+			context.Background(),
+			connect.NewRequest(&serverv1.GetTeamRequest{}),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !called {
+			t.Error("behavior callback was not invoked")
+		}
+		if got.Msg.Team.Id != "from-behavior" {
+			t.Errorf("Team.Id = %q, want %q", got.Msg.Team.Id, "from-behavior")
+		}
+	})
+
+	t.Run("CapturesRequests", func(t *testing.T) {
+		t.Parallel()
+		server := testserver.NewMockBuilderServer(t)
+		t.Cleanup(func() { server.Close() })
+
+		server.OnGetTeam().Return(&serverv1.GetTeamResponse{Team: &serverv1.Team{Id: "x"}})
+
+		_, err := teamClient(server).GetTeam(
+			context.Background(),
+			connect.NewRequest(&serverv1.GetTeamRequest{}),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		captured := server.GetCapturedRequests("GetTeam")
+		if len(captured) != 1 {
+			t.Fatalf("captured %d requests, want 1", len(captured))
+		}
+		if _, ok := captured[0].(*serverv1.GetTeamRequest); !ok {
+			t.Errorf("captured request type = %T, want *serverv1.GetTeamRequest", captured[0])
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds four new RPC mocks to the `testserver` package, plus the first round of tests for testserver itself. Driven by [terraform-provider-chalk#TBD](https://github.com/chalk-ai/terraform-provider-chalk/pull/new/daniel/add-data-objects), which needs these mocks to write integration tests for new Terraform data sources (`chalk_managed_cluster`, `chalk_managed_aws_vpc`, the AWS/GCP/Azure `*_cloud_credentials` family, `chalk_kubernetes_cluster`, `chalk_project`).

## What's added

### New mock handlers + builders (commits 1–4)

| RPC | Service | Used by provider data source |
|---|---|---|
| `GetCloudComponentCluster` | `CloudComponentsService` | `chalk_managed_cluster`, `chalk_kubernetes_cluster` |
| `GetCloudComponentVpc` | `CloudComponentsService` | `chalk_managed_aws_vpc` |
| `GetCloudCredentials` | `CloudAccountCredentialsService` *(new service mount on the mux)* | `chalk_aws_cloud_credentials`, `chalk_gcp_cloud_credentials`, `chalk_azure_cloud_credentials` |
| `GetTeam` | `TeamService` | `chalk_project` |

All four follow the existing `registry`-backed handler pattern in `cloud_components.go` / `team.go`. `GetCloudCredentials` additionally registers the `CloudAccountCredentialsService` handler on the mock mux in `server.go` — the service wasn't mounted before.

### Tests (commit 5)

First tests in the testserver package. Each new mock gets a top-level `Test*` function with five `t.Run` subtests covering the public surface of `MethodConfigBuilder` and the registry's capture path:

- **`Return`** — configured response reaches the client through the mux
- **`ReturnError`** — configured error reaches the client with the right `connect.Code`
- **`NoMockConfigured`** — un-configured calls return `CodeNotFound` with the documented "no mock response configured for X" message
- **`WithBehavior`** — custom callback is invoked and its result reaches the client
- **`CapturesRequests`** — `GetCapturedRequests(methodName)` returns the request payload

**20 subtests** total, all `t.Parallel()` with isolated `MockServer` instances, all green under `-race`.

These are black-box (`package testserver_test`) so they exercise only the public API external callers use.

## Why test what's basically boilerplate?

The primary correctness concern these catch is **method-name string drift** between the handler's `registry.CaptureRequest("X", …)` and the `MethodConfigBuilder.methodName` field — they're string literals in two different files and a typo (e.g. `"GetCloudCredentials"` vs `"GetCloudCredential"`) would silently break the mock with no compile error. The `CapturesRequests` subtests catch this immediately.

The `Return` + `CapturesRequests` subtests on `GetCloudCredentials` also implicitly verify the new mux registration in `server.go` — that's the only one of the four that's a brand-new service mount, not just a new handler on an existing service.

## Test plan

- [x] `go test ./testserver/... -count=1 -race` passes (20 subtests, ~1.7s)
- [x] `go vet ./testserver/...` clean
- [x] `gofmt -l testserver/` clean
- [x] No regressions in the rest of the repo (only testserver/ touched)
- [ ] Confirm terraform-provider-chalk's `daniel/add-data-objects` branch tests pass against this branch (via go.work locally — confirmed; CI will need this merged + tagged before the provider PR can merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)