### PR TITLE
Regen protos: add runtime field to CreateSandboxRequest

### DIFF
--- a/gen/chalk/sandbox/v1/service.pb.go
+++ b/gen/chalk/sandbox/v1/service.pb.go
@@ -1688,7 +1688,10 @@ type CreateSandboxRequest struct {
 	Volumes []*VolumeMount `protobuf:"bytes,6,rep,name=volumes,proto3" json:"volumes,omitempty"`
 	// Runtime backend for the sandbox container.
 	// Valid values: "" (server default), "kube", "local", "chalk_node".
-	Runtime       *string `protobuf:"bytes,7,opt,name=runtime,proto3,oneof" json:"runtime,omitempty"`
+	Runtime *string `protobuf:"bytes,7,opt,name=runtime,proto3,oneof" json:"runtime,omitempty"`
+	// Override the container entrypoint command (e.g. ["nginx", "-g", "daemon off;"]).
+	// When empty, the image's built-in entrypoint is used.
+	Entrypoint    []string `protobuf:"bytes,8,rep,name=entrypoint,proto3" json:"entrypoint,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1781,6 +1784,13 @@ func (x *CreateSandboxRequest) GetRuntime() string {
 		return *x.Runtime
 	}
 	return ""
+}
+
+func (x *CreateSandboxRequest) GetEntrypoint() []string {
+	if x != nil {
+		return x.Entrypoint
+	}
+	return nil
 }
 
 type isCreateSandboxRequest_ImageSource interface {
@@ -2743,7 +2753,7 @@ const file_chalk_sandbox_v1_service_proto_rawDesc = "" +
 	"\x04type\x18\x03 \x01(\tR\x04type\x12\"\n" +
 	"\n" +
 	"size_limit\x18\x04 \x01(\tH\x00R\tsizeLimit\x88\x01\x01B\r\n" +
-	"\v_size_limit\"\xe1\x03\n" +
+	"\v_size_limit\"\x81\x04\n" +
 	"\x14CreateSandboxRequest\x12\x16\n" +
 	"\x05image\x18\x01 \x01(\tH\x00R\x05image\x12<\n" +
 	"\n" +
@@ -2752,7 +2762,10 @@ const file_chalk_sandbox_v1_service_proto_rawDesc = "" +
 	"\x03env\x18\x03 \x03(\v2/.chalk.sandbox.v1.CreateSandboxRequest.EnvEntryR\x03env\x12\x17\n" +
 	"\x04name\x18\x04 \x01(\tH\x02R\x04name\x88\x01\x01\x127\n" +
 	"\avolumes\x18\x06 \x03(\v2\x1d.chalk.sandbox.v1.VolumeMountR\avolumes\x12\x1d\n" +
-	"\aruntime\x18\a \x01(\tH\x03R\aruntime\x88\x01\x01\x1a6\n" +
+	"\aruntime\x18\a \x01(\tH\x03R\aruntime\x88\x01\x01\x12\x1e\n" +
+	"\n" +
+	"entrypoint\x18\b \x03(\tR\n" +
+	"entrypoint\x1a6\n" +
 	"\bEnvEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x0e\n" +

--- a/gen/chalk/sandbox/v1/service.pb.go
+++ b/gen/chalk/sandbox/v1/service.pb.go
@@ -1685,7 +1685,10 @@ type CreateSandboxRequest struct {
 	// Optional name for the sandbox
 	Name *string `protobuf:"bytes,4,opt,name=name,proto3,oneof" json:"name,omitempty"`
 	// Optional volumes to mount into the sandbox
-	Volumes       []*VolumeMount `protobuf:"bytes,6,rep,name=volumes,proto3" json:"volumes,omitempty"`
+	Volumes []*VolumeMount `protobuf:"bytes,6,rep,name=volumes,proto3" json:"volumes,omitempty"`
+	// Runtime backend for the sandbox container.
+	// Valid values: "" (server default), "kube", "local", "chalk_node".
+	Runtime       *string `protobuf:"bytes,7,opt,name=runtime,proto3,oneof" json:"runtime,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1771,6 +1774,13 @@ func (x *CreateSandboxRequest) GetVolumes() []*VolumeMount {
 		return x.Volumes
 	}
 	return nil
+}
+
+func (x *CreateSandboxRequest) GetRuntime() string {
+	if x != nil && x.Runtime != nil {
+		return *x.Runtime
+	}
+	return ""
 }
 
 type isCreateSandboxRequest_ImageSource interface {
@@ -2733,7 +2743,7 @@ const file_chalk_sandbox_v1_service_proto_rawDesc = "" +
 	"\x04type\x18\x03 \x01(\tR\x04type\x12\"\n" +
 	"\n" +
 	"size_limit\x18\x04 \x01(\tH\x00R\tsizeLimit\x88\x01\x01B\r\n" +
-	"\v_size_limit\"\xb6\x03\n" +
+	"\v_size_limit\"\xe1\x03\n" +
 	"\x14CreateSandboxRequest\x12\x16\n" +
 	"\x05image\x18\x01 \x01(\tH\x00R\x05image\x12<\n" +
 	"\n" +
@@ -2741,13 +2751,16 @@ const file_chalk_sandbox_v1_service_proto_rawDesc = "" +
 	"\x0fresource_limits\x18\x02 \x01(\v2 .chalk.sandbox.v1.ResourceLimitsH\x01R\x0eresourceLimits\x88\x01\x01\x12A\n" +
 	"\x03env\x18\x03 \x03(\v2/.chalk.sandbox.v1.CreateSandboxRequest.EnvEntryR\x03env\x12\x17\n" +
 	"\x04name\x18\x04 \x01(\tH\x02R\x04name\x88\x01\x01\x127\n" +
-	"\avolumes\x18\x06 \x03(\v2\x1d.chalk.sandbox.v1.VolumeMountR\avolumes\x1a6\n" +
+	"\avolumes\x18\x06 \x03(\v2\x1d.chalk.sandbox.v1.VolumeMountR\avolumes\x12\x1d\n" +
+	"\aruntime\x18\a \x01(\tH\x03R\aruntime\x88\x01\x01\x1a6\n" +
 	"\bEnvEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x0e\n" +
 	"\fimage_sourceB\x12\n" +
 	"\x10_resource_limitsB\a\n" +
-	"\x05_name\"W\n" +
+	"\x05_nameB\n" +
+	"\n" +
+	"\b_runtime\"W\n" +
 	"\x0eResourceLimits\x12\x15\n" +
 	"\x03cpu\x18\x01 \x01(\tH\x00R\x03cpu\x88\x01\x01\x12\x1b\n" +
 	"\x06memory\x18\x02 \x01(\tH\x01R\x06memory\x88\x01\x01B\x06\n" +


### PR DESCRIPTION
## Summary
- Adds `optional string runtime` field (field 7) to `CreateSandboxRequest` proto
- Allows callers to select the container runtime backend (`kube`, `local`, `chalk_node`)

Part of a 3-repo change:
- **chalk-go** (this PR): generated proto code
- **chalk-private**: proto definition + go-api-server dispatcher factory
- **cli**: `--runtime` flag on `chalk sandbox create`

Claude session: 43e3ce4e-9ad3-455b-8e94-dab57cb27a80

## Test plan
- [ ] Generated code compiles