### PR TITLE
Support FixedSizeList (vector/embedding) arrays in ConvertTableToRows

### DIFF
--- a/internal/feather_test.go
+++ b/internal/feather_test.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"github.com/apache/arrow/go/v16/arrow"
+	"github.com/apache/arrow/go/v16/arrow/array"
 	"github.com/chalk-ai/chalk-go/internal/tests/fixtures"
 	assert "github.com/stretchr/testify/require"
 	"reflect"
@@ -32,4 +34,37 @@ func TestColumnMapToRecordOptionalPrimitives(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestGetValueFromFixedSizeList(t *testing.T) {
+	t.Parallel()
+	// Vector / embedding features arrive over the wire as Arrow FixedSizeList
+	// columns (with float32 child values). Make sure we can read a row out of one.
+	builder := array.NewFixedSizeListBuilder(fixtures.TestAllocator, 3, arrow.PrimitiveTypes.Float32)
+	defer builder.Release()
+	valueBuilder := builder.ValueBuilder().(*array.Float32Builder)
+
+	// Row 0: [1.5, 2.5, 3.5]
+	builder.Append(true)
+	valueBuilder.AppendValues([]float32{1.5, 2.5, 3.5}, nil)
+	// Row 1: null (AppendNull appends the child nulls itself)
+	builder.AppendNull()
+	// Row 2: [4.5, 5.5, 6.5]
+	builder.Append(true)
+	valueBuilder.AppendValues([]float32{4.5, 5.5, 6.5}, nil)
+
+	arr := builder.NewArray()
+	defer arr.Release()
+
+	row0, err := GetValueFromArrowArray(arr, 0, false)
+	assert.Nil(t, err)
+	assert.Equal(t, []any{float32(1.5), float32(2.5), float32(3.5)}, row0)
+
+	row1, err := GetValueFromArrowArray(arr, 1, false)
+	assert.Nil(t, err)
+	assert.Nil(t, row1)
+
+	row2, err := GetValueFromArrowArray(arr, 2, false)
+	assert.Nil(t, err)
+	assert.Equal(t, []any{float32(4.5), float32(5.5), float32(6.5)}, row2)
 }

--- a/internal/unmarshal.go
+++ b/internal/unmarshal.go
@@ -120,6 +120,12 @@ func GetValueFromArrowArray(a arrow.Array, idx int, timeAsString bool) (any, err
 			o64[i] = int64(arr.Offsets()[i])
 		}
 		return getInnerSliceFromArray(arr.ListValues(), o64, idx, timeAsString)
+	case *array.FixedSizeList:
+		// Fixed-size lists (e.g. vector / embedding features) store their values
+		// contiguously in the child array; ValueOffsets gives the [start, end)
+		// slice for this row.
+		start, end := arr.ValueOffsets(idx)
+		return getInnerSliceFromArray(arr.ListValues(), []int64{start, end}, 0, timeAsString)
 	case *array.Struct:
 		newMap := map[string]any{}
 		structType, typeOk := arr.DataType().(*arrow.StructType)
@@ -148,11 +154,15 @@ func GetValueFromArrowArray(a arrow.Array, idx int, timeAsString bool) (any, err
 		return arr.Value(idx), nil
 	case *array.Uint64:
 		return arr.Value(idx), nil
+	case *array.Int8:
+		return arr.Value(idx), nil
 	case *array.Int16:
 		return arr.Value(idx), nil
 	case *array.Int32:
 		return arr.Value(idx), nil
 	case *array.Int64:
+		return arr.Value(idx), nil
+	case *array.Float32:
 		return arr.Value(idx), nil
 	case *array.Float64:
 		return arr.Value(idx), nil


### PR DESCRIPTION
## Problem

`chalk query --grpc` (and any `ConvertTableToRows` caller) fails when the result table contains a vector / embedding feature:

```
Error converting scalars table to rows.
converting table to rows: getting value from arrow array for feature
'user.member_level_fpf_embedding_features.embedding': unsupported array type: *array.FixedSizeList
```

`GetValueFromArrowArray` in `internal/unmarshal.go` had no `case` for `*array.FixedSizeList` — the Arrow type Chalk uses for fixed-size vector/embedding features — so it fell through to the `default` branch and errored.

## Fix

- Add a `*array.FixedSizeList` case that slices the child array via `ValueOffsets(idx)` and reuses the existing `getInnerSliceFromArray` helper.
- Add `*array.Float32` and `*array.Int8` cases. Embeddings are `float32` vectors, so without `Float32` the FixedSizeList case would just fail one level deeper on the child values; `Int8` added for completeness alongside the other integer widths.

## Test

Added `TestGetValueFromFixedSizeList` (3-wide `float32` fixed-size list including a null row). New + existing tests pass; `go build ./...`, `go vet`, and `gofmt` are clean.

## Downstream

The CLI pins `github.com/chalk-ai/chalk-go`, so after this merges it needs a new chalk-go release + a `go.mod` bump in `chalk-ai/cli` to take effect for `chalk query`.

---
🤖 Claude Code session: `d8c39df9-d252-4ad5-aa21-204c72e6f313`
