### PR TITLE
Add WithUseMetaplanner to offline query params

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -98,5 +98,6 @@ type OfflineQueryRequestSerialized struct {
 	CompletionDeadline         *string                     `json:"completion_deadline"`
 	MaxRetries                 *int                        `json:"max_retries"`
 	UseJobQueue                bool                        `json:"use_job_queue"`
+	UseMetaplanner             *bool                       `json:"use_metaplanner,omitempty"`
 	OverlayGraph               *string                     `json:"overlay_graph"`
 }

--- a/models.go
+++ b/models.go
@@ -602,6 +602,10 @@ type OfflineQueryParams struct {
 	// UseJobQueue specifies whether to use the job queue for processing.
 	UseJobQueue bool
 
+	// UseMetaplanner specifies whether to plan the query with the metaplanner.
+	// A nil value lets the server choose its own default.
+	UseMetaplanner *bool
+
 	// OverlayGraph specifies additional features and resolvers to be used to plan this specific query.
 	OverlayGraph string
 	/***************

--- a/params_offline.go
+++ b/params_offline.go
@@ -231,6 +231,12 @@ func (p OfflineQueryParamsComplete) WithUseJobQueue(useJobQueue bool) OfflineQue
 	return p
 }
 
+// WithUseMetaplanner returns a copy of Offline Query parameters with the specified use metaplanner setting.
+func (p OfflineQueryParamsComplete) WithUseMetaplanner(useMetaplanner bool) OfflineQueryParamsComplete {
+	p.underlying.UseMetaplanner = &useMetaplanner
+	return p
+}
+
 // WithOverlayGraph returns a copy of Offline Query parameters with the specified overlay graph set.
 func (p OfflineQueryParamsComplete) WithOverlayGraph(overlayGraph string) OfflineQueryParamsComplete {
 	p.underlying.OverlayGraph = overlayGraph

--- a/serializers.go
+++ b/serializers.go
@@ -366,6 +366,7 @@ func serializeOfflineQueryParams(p *OfflineQueryParams, resolved *offlineQueryPa
 		CompletionDeadline:         completionDeadlineStr,
 		MaxRetries:                 p.MaxRetries,
 		UseJobQueue:                p.UseJobQueue,
+		UseMetaplanner:             p.UseMetaplanner,
 		OverlayGraph:               nil,
 	}
 


### PR DESCRIPTION
## Summary
Adds support for the `use_metaplanner` field on offline query requests, mirroring the existing `use_job_queue` plumbing.

- `OfflineQueryParams.UseMetaplanner *bool` (nil ⇒ server chooses its own default)
- `WithUseMetaplanner(bool)` builder on `OfflineQueryParamsComplete`
- Serialized as `use_metaplanner` (omitempty) on the offline query request

This unblocks a `chalk query --offline --use-metaplanner` flag in the CLI, which needs this builder method.

JSON key + semantics match the Python SDK (`OfflineQueryRequest.use_metaplanner`, where `None` lets the server decide) and proto `use_metaplanner = 216`.

claude session: 9e6e0220-8160-43ae-ab86-507ac3086a08