### PR TITLE
Add QueryMeta.MissedPlanCache reporting plan-cache participation

### DIFF
--- a/from_proto.go
+++ b/from_proto.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	commonv1 "github.com/chalk-ai/chalk-go/gen/chalk/common/v1"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func queryMetaFromProto(metaRaw *commonv1.OnlineQueryMetadata) *QueryMeta {
@@ -21,6 +22,15 @@ func queryMetaFromProto(metaRaw *commonv1.OnlineQueryMetadata) *QueryMeta {
 		queryTimestamp = new(qs.AsTime())
 	}
 
+	// The server reports plan-cache participation through the free-form additional
+	// metadata map; absence (or a non-bool value) means the server did not report it.
+	var missedPlanCache *bool
+	if v, ok := metaRaw.GetAdditionalMetadata()["missed_plan_cache"]; ok && v != nil {
+		if _, isBool := v.GetKind().(*structpb.Value_BoolValue); isBool {
+			missedPlanCache = new(v.GetBoolValue())
+		}
+	}
+
 	return &QueryMeta{
 		ExecutionDurationS: executionDuration,
 		DeploymentId:       metaRaw.DeploymentId,
@@ -29,6 +39,7 @@ func queryMetaFromProto(metaRaw *commonv1.OnlineQueryMetadata) *QueryMeta {
 		QueryId:            metaRaw.QueryId,
 		QueryTimestamp:     queryTimestamp,
 		QueryHash:          metaRaw.QueryHash,
+		MissedPlanCache:    missedPlanCache,
 	}
 }
 

--- a/from_proto_test.go
+++ b/from_proto_test.go
@@ -1,0 +1,66 @@
+package chalk
+
+import (
+	"testing"
+
+	commonv1 "github.com/chalk-ai/chalk-go/gen/chalk/common/v1"
+	assert "github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// TestQueryMetaFromProtoMissedPlanCache verifies that the plan-cache participation flag is
+// read from the free-form additional_metadata map, and that absent or non-bool values are
+// reported as nil (server did not report it).
+func TestQueryMetaFromProtoMissedPlanCache(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name     string
+		meta     *commonv1.OnlineQueryMetadata
+		expected *bool
+	}{
+		{
+			name: "missed",
+			meta: &commonv1.OnlineQueryMetadata{
+				AdditionalMetadata: map[string]*structpb.Value{
+					"missed_plan_cache": structpb.NewBoolValue(true),
+				},
+			},
+			expected: new(true),
+		},
+		{
+			name: "served from cache",
+			meta: &commonv1.OnlineQueryMetadata{
+				AdditionalMetadata: map[string]*structpb.Value{
+					"missed_plan_cache": structpb.NewBoolValue(false),
+				},
+			},
+			expected: new(false),
+		},
+		{
+			name:     "not reported",
+			meta:     &commonv1.OnlineQueryMetadata{},
+			expected: nil,
+		},
+		{
+			name: "non-bool value",
+			meta: &commonv1.OnlineQueryMetadata{
+				AdditionalMetadata: map[string]*structpb.Value{
+					"missed_plan_cache": structpb.NewStringValue("yes"),
+				},
+			},
+			expected: nil,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			converted := queryMetaFromProto(tt.meta)
+			assert.NotNil(t, converted)
+			if tt.expected == nil {
+				assert.Nil(t, converted.MissedPlanCache)
+			} else {
+				assert.NotNil(t, converted.MissedPlanCache)
+				assert.Equal(t, *tt.expected, *converted.MissedPlanCache)
+			}
+		})
+	}
+}

--- a/models.go
+++ b/models.go
@@ -349,6 +349,11 @@ type QueryMeta struct {
 	// input/output features will typically have the same hash; changes may be observed
 	// over time as we adjust implementation details.
 	QueryHash string `json:"query_hash"`
+
+	// True if this query's plan had to be computed by the planner rather than served
+	// from a plan cache. Nil when the server did not report plan-cache participation
+	// (e.g. older server versions).
+	MissedPlanCache *bool `json:"missed_plan_cache"`
 }
 
 // OnlineQueryBulkResult holds the result of a bulk online query.


### PR DESCRIPTION
## Summary

Chalk servers now report whether an online query's plan had to be computed by the planner rather than served from a plan cache (chalk-ai/chalk-private#37350). This PR surfaces that as a new `QueryMeta.MissedPlanCache *bool` so SDK users can observe plan-cache misses:

- **gRPC clients**: the server carries the flag in `OnlineQueryMetadata.additional_metadata["missed_plan_cache"]` (an existing free-form `map<string, google.protobuf.Value>` — no proto change); `queryMetaFromProto` now parses it.
- **HTTP/feather clients**: the servers include `missed_plan_cache` in the meta JSON, so the new `json:"missed_plan_cache"` tag picks it up on the existing unmarshal paths.

`MissedPlanCache` is `nil` when the server does not report it (e.g. older server versions) — distinguishing "not reported" from "served from cache".

## Testing

`TestQueryMetaFromProtoMissedPlanCache` covers true/false/absent/non-bool values in `additional_metadata`. `go build ./... && go test -run TestQueryMetaFromProtoMissedPlanCache ./` pass locally.