### PR TITLE
Expose UploadFeatures and DeleteFeatures on GRPCClient

### DIFF
--- a/grpc_client.go
+++ b/grpc_client.go
@@ -79,6 +79,14 @@ type GRPCClient interface {
 	GetOnlineQueryBulkRequest(ctx context.Context, params OnlineQueryParamsComplete) (*connect.Request[commonv1.OnlineQueryBulkRequest], error)
 	GetQueryEndpoint() string
 
+	// UploadFeatures synchronously persists feature values to the online and offline
+	// stores. This method delegates to Chalk's HTTP API.
+	UploadFeatures(ctx context.Context, params UploadFeaturesParams) (UploadFeaturesResult, error)
+
+	// DeleteFeatures targets feature observation values for deletion in the online and
+	// offline stores. This method delegates to Chalk's HTTP API.
+	DeleteFeatures(ctx context.Context, params DeleteFeaturesParams) (DeleteFeaturesResult, error)
+
 	// UpdateAggregates synchronously persists feature values that back windowed aggregations,
 	// while updating the corresponding aggregate values themselves.
 	// The `Inputs` parameter should be a map of features to values. The features should either

--- a/grpc_client.go
+++ b/grpc_client.go
@@ -79,12 +79,10 @@ type GRPCClient interface {
 	GetOnlineQueryBulkRequest(ctx context.Context, params OnlineQueryParamsComplete) (*connect.Request[commonv1.OnlineQueryBulkRequest], error)
 	GetQueryEndpoint() string
 
-	// UploadFeatures synchronously persists feature values to the online and offline
-	// stores. This method delegates to Chalk's HTTP API.
+	// UploadFeatures synchronously persists feature values to the online and offline stores.
 	UploadFeatures(ctx context.Context, params UploadFeaturesParams) (UploadFeaturesResult, error)
 
-	// DeleteFeatures targets feature observation values for deletion in the online and
-	// offline stores. This method delegates to Chalk's HTTP API.
+	// DeleteFeatures targets feature observation values for deletion in the online and offline stores.
 	DeleteFeatures(ctx context.Context, params DeleteFeaturesParams) (DeleteFeaturesResult, error)
 
 	// UpdateAggregates synchronously persists feature values that back windowed aggregations,

--- a/grpc_client_feature_writes_test.go
+++ b/grpc_client_feature_writes_test.go
@@ -1,0 +1,184 @@
+package chalk
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow/go/v16/arrow/memory"
+	serverv1 "github.com/chalk-ai/chalk-go/gen/chalk/server/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type fakeFeatureWriteClient struct {
+	uploadParams UploadFeaturesParams
+	deleteParams DeleteFeaturesParams
+	uploadResult UploadFeaturesResult
+	deleteResult DeleteFeaturesResult
+	uploadErr    error
+	deleteErr    error
+}
+
+type recordingConnectHTTPClient struct {
+	requests []*http.Request
+}
+
+func (c *recordingConnectHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	c.requests = append(c.requests, req)
+	body := `{"errors":[]}`
+	if req.URL.Path == "/v1/upload_features/multi" {
+		body = `{"operation_id":"operation-id"}`
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}, nil
+}
+
+func (c *fakeFeatureWriteClient) UploadFeatures(
+	_ context.Context,
+	params UploadFeaturesParams,
+) (UploadFeaturesResult, error) {
+	c.uploadParams = params
+	return c.uploadResult, c.uploadErr
+}
+
+func (c *fakeFeatureWriteClient) DeleteFeatures(
+	_ context.Context,
+	params DeleteFeaturesParams,
+) (DeleteFeaturesResult, error) {
+	c.deleteParams = params
+	return c.deleteResult, c.deleteErr
+}
+
+func TestGRPCClientUploadFeaturesDelegatesToHTTPClient(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("upload failed")
+	delegate := &fakeFeatureWriteClient{
+		uploadResult: UploadFeaturesResult{OperationId: "operation-id"},
+		uploadErr:    expectedErr,
+	}
+	client := &grpcClientImpl{featureWriteClient: delegate}
+	params := UploadFeaturesParams{
+		Inputs: map[any]any{"user.email": []string{"user@example.com"}},
+	}
+
+	result, err := client.UploadFeatures(context.Background(), params)
+
+	assert.Equal(t, params, delegate.uploadParams)
+	assert.Equal(t, delegate.uploadResult, result)
+	require.ErrorIs(t, err, expectedErr)
+}
+
+func TestGRPCClientDeleteFeaturesDelegatesToHTTPClient(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("delete failed")
+	delegate := &fakeFeatureWriteClient{
+		deleteResult: DeleteFeaturesResult{
+			Errors: ServerErrors{{Message: "partial deletion"}},
+		},
+		deleteErr: expectedErr,
+	}
+	client := &grpcClientImpl{featureWriteClient: delegate}
+	params := DeleteFeaturesParams{
+		Namespace:   "user",
+		Features:    []string{"email"},
+		PrimaryKeys: []string{"user-1"},
+	}
+
+	result, err := client.DeleteFeatures(context.Background(), params)
+
+	assert.Equal(t, params, delegate.deleteParams)
+	assert.Equal(t, delegate.deleteResult, result)
+	require.ErrorIs(t, err, expectedErr)
+}
+
+func TestNewGRPCClientSharesStateWithHTTPFeatureWriteClient(t *testing.T) {
+	t.Parallel()
+
+	allocator := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	client, err := newGrpcClient(context.Background(), &GRPCClientConfig{
+		ClientId:                   "client-id",
+		ClientSecret:               "client-secret",
+		ApiServer:                  "https://api.example.com",
+		QueryServer:                "https://query.example.com",
+		EnvironmentId:              "environment-id",
+		Branch:                     "branch-id",
+		DeploymentTag:              "deployment-tag",
+		ResourceGroup:              "resource-group",
+		HTTPClient:                 http.DefaultClient,
+		Allocator:                  allocator,
+		SkipEnvironmentNameMapping: true,
+		SkipEngineMapping:          true,
+		JWT: &serverv1.GetTokenResponse{
+			AccessToken: "token",
+			ExpiresAt:   timestamppb.New(time.Now().Add(time.Hour)),
+		},
+	})
+	require.NoError(t, err)
+
+	delegate, ok := client.featureWriteClient.(*clientImpl)
+	require.True(t, ok)
+	assert.Same(t, client.config, delegate.config)
+	assert.Same(t, client.tokenManager, delegate.tokenManager)
+	assert.Same(t, allocator, delegate.allocator)
+	assert.Same(t, http.DefaultClient, delegate.httpClient)
+	assert.Equal(t, client.branch, delegate.Branch)
+	assert.Equal(t, client.deploymentTag, delegate.DeploymentTag)
+	assert.Equal(t, client.resourceGroup, delegate.resourceGroup)
+}
+
+func TestGRPCClientFeatureWritesUseHTTPAPI(t *testing.T) {
+	httpClient := &recordingConnectHTTPClient{}
+	client, err := NewGRPCClient(context.Background(), &GRPCClientConfig{
+		ClientId:                   "client-id",
+		ClientSecret:               "client-secret",
+		ApiServer:                  "https://api.example.com",
+		QueryServer:                "https://grpc-query.example.com",
+		EnvironmentId:              "environment-id",
+		HTTPClient:                 httpClient,
+		SkipEnvironmentNameMapping: true,
+		JWT: &serverv1.GetTokenResponse{
+			AccessToken: "token",
+			ExpiresAt:   timestamppb.New(time.Now().Add(time.Hour)),
+			Engines: map[string]string{
+				"environment-id": "https://http-query.example.com",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	uploadResult, err := client.UploadFeatures(context.Background(), UploadFeaturesParams{
+		Inputs: map[any]any{"user.email": []string{"user@example.com"}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "operation-id", uploadResult.OperationId)
+
+	deleteResult, err := client.DeleteFeatures(context.Background(), DeleteFeaturesParams{
+		Namespace:   "user",
+		Features:    []string{"email"},
+		PrimaryKeys: []string{"user-1"},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, deleteResult.Errors)
+
+	require.Len(t, httpClient.requests, 2)
+	assert.Equal(t, http.MethodPost, httpClient.requests[0].Method)
+	assert.Equal(t, "https://http-query.example.com/v1/upload_features/multi", httpClient.requests[0].URL.String())
+	assert.Equal(t, http.MethodDelete, httpClient.requests[1].Method)
+	assert.Equal(t, "https://api.example.com/v1/features/rows", httpClient.requests[1].URL.String())
+	for _, req := range httpClient.requests {
+		assert.Equal(t, "Bearer token", req.Header.Get("Authorization"))
+		assert.Equal(t, "environment-id", req.Header.Get("X-Chalk-Env-Id"))
+	}
+}

--- a/grpc_client_impl.go
+++ b/grpc_client_impl.go
@@ -37,6 +37,7 @@ type grpcClientImpl struct {
 	httpClient    connect.HTTPClient
 	timeout       *time.Duration
 
+	featureWriteClient    featureWriteClient
 	queryClient           enginev1connect.QueryServiceClient
 	branchQueryClient     enginev1connect.QueryServiceClient
 	graphClient           serverv1connect.GraphServiceClient
@@ -45,6 +46,30 @@ type grpcClientImpl struct {
 	tokenManager          *auth.Manager
 	metadataInterceptor   connect.UnaryInterceptorFunc
 	engineInterceptor     connect.UnaryInterceptorFunc
+}
+
+type featureWriteClient interface {
+	UploadFeatures(context.Context, UploadFeaturesParams) (UploadFeaturesResult, error)
+	DeleteFeatures(context.Context, DeleteFeaturesParams) (DeleteFeaturesResult, error)
+}
+
+type grpcHTTPClientAdapter struct {
+	connect.HTTPClient
+}
+
+func (c grpcHTTPClientAdapter) Get(url string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.Do(req)
+}
+
+func asHTTPClient(client connect.HTTPClient) HTTPClient {
+	if client, ok := client.(HTTPClient); ok {
+		return client
+	}
+	return grpcHTTPClientAdapter{HTTPClient: client}
 }
 
 func newGrpcClient(ctx context.Context, configs ...*GRPCClientConfig) (*grpcClientImpl, error) {
@@ -251,6 +276,18 @@ func newGrpcClient(ctx context.Context, configs ...*GRPCClientConfig) (*grpcClie
 		connect.WithInterceptors(cfg.Interceptors...),
 	)
 
+	featureWriteClient := &clientImpl{
+		config:        configManager,
+		allocator:     cfg.Allocator,
+		Branch:        cfg.Branch,
+		DeploymentTag: cfg.DeploymentTag,
+		resourceGroup: resourceGroup,
+		timeout:       timeout,
+		httpClient:    asHTTPClient(cfg.HTTPClient),
+		logger:        cfg.Logger,
+		tokenManager:  tokenManager,
+	}
+
 	return &grpcClientImpl{
 		deploymentTag:         cfg.DeploymentTag,
 		branch:                cfg.Branch,
@@ -258,6 +295,7 @@ func newGrpcClient(ctx context.Context, configs ...*GRPCClientConfig) (*grpcClie
 		logger:                cfg.Logger,
 		config:                configManager,
 		tokenManager:          tokenManager,
+		featureWriteClient:    featureWriteClient,
 		queryClient:           queryClient,
 		branchQueryClient:     branchQueryClient,
 		graphClient:           graphClient,
@@ -455,6 +493,20 @@ func (c *grpcClientImpl) getQueryClient(hasBranch bool) enginev1connect.QuerySer
 		return c.branchQueryClient
 	}
 	return c.queryClient
+}
+
+func (c *grpcClientImpl) UploadFeatures(
+	ctx context.Context,
+	params UploadFeaturesParams,
+) (UploadFeaturesResult, error) {
+	return c.featureWriteClient.UploadFeatures(ctx, params)
+}
+
+func (c *grpcClientImpl) DeleteFeatures(
+	ctx context.Context,
+	params DeleteFeaturesParams,
+) (DeleteFeaturesResult, error) {
+	return c.featureWriteClient.DeleteFeatures(ctx, params)
 }
 
 func (c *grpcClientImpl) OnlineQueryBulk(ctx context.Context, args OnlineQueryParamsComplete) (*GRPCOnlineQueryBulkResult, error) {


### PR DESCRIPTION
## Summary

Expose UploadFeatures and DeleteFeatures on chalk-go GRPCClient while preserving their existing HTTP transports.

This lets callers keep one GRPCClient-facing gateway abstraction without requiring new protobufs or backend RPCs. Both methods delegate to a narrow internal clientImpl that shares the parent gRPC client resolved configuration, token manager, allocator, timeout, routing options, and HTTP transport, so no second authentication or configuration stack is created.

## Routing

- UploadFeatures delegates to the existing HTTP upload implementation.
- DeleteFeatures delegates to the existing HTTP deletion implementation.
- Existing branch behavior and response types are preserved.
- Custom Connect HTTP clients that only implement Do are adapted for the regular client interface.

## Tests

- Pins method delegation and result/error propagation.
- Verifies the HTTP delegate shares authentication and configuration state with GRPCClient.
- Verifies the actual HTTP methods, endpoints, authorization header, and environment header for both operations.
- go test ./...
- go vet ./...
- go build ./...
- staticcheck ./...

All pass locally.