### PR TITLE
Regen protos: GetWorkflowOrchestratorConnectionDetails

### DIFF
--- a/gen/chalk/server/v1/serverv1connect/workflow_orchestrator.connect.go
+++ b/gen/chalk/server/v1/serverv1connect/workflow_orchestrator.connect.go
@@ -34,6 +34,10 @@ const (
 // reflection-formatted method names, remove the leading slash and convert the remaining slash to a
 // period.
 const (
+	// WorkflowOrchestratorServiceGetWorkflowOrchestratorConnectionDetailsProcedure is the
+	// fully-qualified name of the WorkflowOrchestratorService's
+	// GetWorkflowOrchestratorConnectionDetails RPC.
+	WorkflowOrchestratorServiceGetWorkflowOrchestratorConnectionDetailsProcedure = "/chalk.server.v1.WorkflowOrchestratorService/GetWorkflowOrchestratorConnectionDetails"
 	// WorkflowOrchestratorServiceListWorkflowOrchestratorNamespacesProcedure is the fully-qualified
 	// name of the WorkflowOrchestratorService's ListWorkflowOrchestratorNamespaces RPC.
 	WorkflowOrchestratorServiceListWorkflowOrchestratorNamespacesProcedure = "/chalk.server.v1.WorkflowOrchestratorService/ListWorkflowOrchestratorNamespaces"
@@ -51,6 +55,9 @@ const (
 // WorkflowOrchestratorServiceClient is a client for the chalk.server.v1.WorkflowOrchestratorService
 // service.
 type WorkflowOrchestratorServiceClient interface {
+	// Returns how a client (e.g. chalkpy's chalk.workflows) should reach this
+	// environment's Temporal frontend directly to start and await workflows.
+	GetWorkflowOrchestratorConnectionDetails(context.Context, *connect.Request[v1.GetWorkflowOrchestratorConnectionDetailsRequest]) (*connect.Response[v1.GetWorkflowOrchestratorConnectionDetailsResponse], error)
 	ListWorkflowOrchestratorNamespaces(context.Context, *connect.Request[v1.ListWorkflowOrchestratorNamespacesRequest]) (*connect.Response[v1.ListWorkflowOrchestratorNamespacesResponse], error)
 	ListWorkflowOrchestratorWorkflows(context.Context, *connect.Request[v1.ListWorkflowOrchestratorWorkflowsRequest]) (*connect.Response[v1.ListWorkflowOrchestratorWorkflowsResponse], error)
 	DescribeWorkflowOrchestratorWorkflow(context.Context, *connect.Request[v1.DescribeWorkflowOrchestratorWorkflowRequest]) (*connect.Response[v1.DescribeWorkflowOrchestratorWorkflowResponse], error)
@@ -69,6 +76,12 @@ func NewWorkflowOrchestratorServiceClient(httpClient connect.HTTPClient, baseURL
 	baseURL = strings.TrimRight(baseURL, "/")
 	workflowOrchestratorServiceMethods := v1.File_chalk_server_v1_workflow_orchestrator_proto.Services().ByName("WorkflowOrchestratorService").Methods()
 	return &workflowOrchestratorServiceClient{
+		getWorkflowOrchestratorConnectionDetails: connect.NewClient[v1.GetWorkflowOrchestratorConnectionDetailsRequest, v1.GetWorkflowOrchestratorConnectionDetailsResponse](
+			httpClient,
+			baseURL+WorkflowOrchestratorServiceGetWorkflowOrchestratorConnectionDetailsProcedure,
+			connect.WithSchema(workflowOrchestratorServiceMethods.ByName("GetWorkflowOrchestratorConnectionDetails")),
+			connect.WithClientOptions(opts...),
+		),
 		listWorkflowOrchestratorNamespaces: connect.NewClient[v1.ListWorkflowOrchestratorNamespacesRequest, v1.ListWorkflowOrchestratorNamespacesResponse](
 			httpClient,
 			baseURL+WorkflowOrchestratorServiceListWorkflowOrchestratorNamespacesProcedure,
@@ -98,10 +111,17 @@ func NewWorkflowOrchestratorServiceClient(httpClient connect.HTTPClient, baseURL
 
 // workflowOrchestratorServiceClient implements WorkflowOrchestratorServiceClient.
 type workflowOrchestratorServiceClient struct {
-	listWorkflowOrchestratorNamespaces     *connect.Client[v1.ListWorkflowOrchestratorNamespacesRequest, v1.ListWorkflowOrchestratorNamespacesResponse]
-	listWorkflowOrchestratorWorkflows      *connect.Client[v1.ListWorkflowOrchestratorWorkflowsRequest, v1.ListWorkflowOrchestratorWorkflowsResponse]
-	describeWorkflowOrchestratorWorkflow   *connect.Client[v1.DescribeWorkflowOrchestratorWorkflowRequest, v1.DescribeWorkflowOrchestratorWorkflowResponse]
-	getWorkflowOrchestratorWorkflowHistory *connect.Client[v1.GetWorkflowOrchestratorWorkflowHistoryRequest, v1.GetWorkflowOrchestratorWorkflowHistoryResponse]
+	getWorkflowOrchestratorConnectionDetails *connect.Client[v1.GetWorkflowOrchestratorConnectionDetailsRequest, v1.GetWorkflowOrchestratorConnectionDetailsResponse]
+	listWorkflowOrchestratorNamespaces       *connect.Client[v1.ListWorkflowOrchestratorNamespacesRequest, v1.ListWorkflowOrchestratorNamespacesResponse]
+	listWorkflowOrchestratorWorkflows        *connect.Client[v1.ListWorkflowOrchestratorWorkflowsRequest, v1.ListWorkflowOrchestratorWorkflowsResponse]
+	describeWorkflowOrchestratorWorkflow     *connect.Client[v1.DescribeWorkflowOrchestratorWorkflowRequest, v1.DescribeWorkflowOrchestratorWorkflowResponse]
+	getWorkflowOrchestratorWorkflowHistory   *connect.Client[v1.GetWorkflowOrchestratorWorkflowHistoryRequest, v1.GetWorkflowOrchestratorWorkflowHistoryResponse]
+}
+
+// GetWorkflowOrchestratorConnectionDetails calls
+// chalk.server.v1.WorkflowOrchestratorService.GetWorkflowOrchestratorConnectionDetails.
+func (c *workflowOrchestratorServiceClient) GetWorkflowOrchestratorConnectionDetails(ctx context.Context, req *connect.Request[v1.GetWorkflowOrchestratorConnectionDetailsRequest]) (*connect.Response[v1.GetWorkflowOrchestratorConnectionDetailsResponse], error) {
+	return c.getWorkflowOrchestratorConnectionDetails.CallUnary(ctx, req)
 }
 
 // ListWorkflowOrchestratorNamespaces calls
@@ -131,6 +151,9 @@ func (c *workflowOrchestratorServiceClient) GetWorkflowOrchestratorWorkflowHisto
 // WorkflowOrchestratorServiceHandler is an implementation of the
 // chalk.server.v1.WorkflowOrchestratorService service.
 type WorkflowOrchestratorServiceHandler interface {
+	// Returns how a client (e.g. chalkpy's chalk.workflows) should reach this
+	// environment's Temporal frontend directly to start and await workflows.
+	GetWorkflowOrchestratorConnectionDetails(context.Context, *connect.Request[v1.GetWorkflowOrchestratorConnectionDetailsRequest]) (*connect.Response[v1.GetWorkflowOrchestratorConnectionDetailsResponse], error)
 	ListWorkflowOrchestratorNamespaces(context.Context, *connect.Request[v1.ListWorkflowOrchestratorNamespacesRequest]) (*connect.Response[v1.ListWorkflowOrchestratorNamespacesResponse], error)
 	ListWorkflowOrchestratorWorkflows(context.Context, *connect.Request[v1.ListWorkflowOrchestratorWorkflowsRequest]) (*connect.Response[v1.ListWorkflowOrchestratorWorkflowsResponse], error)
 	DescribeWorkflowOrchestratorWorkflow(context.Context, *connect.Request[v1.DescribeWorkflowOrchestratorWorkflowRequest]) (*connect.Response[v1.DescribeWorkflowOrchestratorWorkflowResponse], error)
@@ -144,6 +167,12 @@ type WorkflowOrchestratorServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewWorkflowOrchestratorServiceHandler(svc WorkflowOrchestratorServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	workflowOrchestratorServiceMethods := v1.File_chalk_server_v1_workflow_orchestrator_proto.Services().ByName("WorkflowOrchestratorService").Methods()
+	workflowOrchestratorServiceGetWorkflowOrchestratorConnectionDetailsHandler := connect.NewUnaryHandler(
+		WorkflowOrchestratorServiceGetWorkflowOrchestratorConnectionDetailsProcedure,
+		svc.GetWorkflowOrchestratorConnectionDetails,
+		connect.WithSchema(workflowOrchestratorServiceMethods.ByName("GetWorkflowOrchestratorConnectionDetails")),
+		connect.WithHandlerOptions(opts...),
+	)
 	workflowOrchestratorServiceListWorkflowOrchestratorNamespacesHandler := connect.NewUnaryHandler(
 		WorkflowOrchestratorServiceListWorkflowOrchestratorNamespacesProcedure,
 		svc.ListWorkflowOrchestratorNamespaces,
@@ -170,6 +199,8 @@ func NewWorkflowOrchestratorServiceHandler(svc WorkflowOrchestratorServiceHandle
 	)
 	return "/chalk.server.v1.WorkflowOrchestratorService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
+		case WorkflowOrchestratorServiceGetWorkflowOrchestratorConnectionDetailsProcedure:
+			workflowOrchestratorServiceGetWorkflowOrchestratorConnectionDetailsHandler.ServeHTTP(w, r)
 		case WorkflowOrchestratorServiceListWorkflowOrchestratorNamespacesProcedure:
 			workflowOrchestratorServiceListWorkflowOrchestratorNamespacesHandler.ServeHTTP(w, r)
 		case WorkflowOrchestratorServiceListWorkflowOrchestratorWorkflowsProcedure:
@@ -186,6 +217,10 @@ func NewWorkflowOrchestratorServiceHandler(svc WorkflowOrchestratorServiceHandle
 
 // UnimplementedWorkflowOrchestratorServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedWorkflowOrchestratorServiceHandler struct{}
+
+func (UnimplementedWorkflowOrchestratorServiceHandler) GetWorkflowOrchestratorConnectionDetails(context.Context, *connect.Request[v1.GetWorkflowOrchestratorConnectionDetailsRequest]) (*connect.Response[v1.GetWorkflowOrchestratorConnectionDetailsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("chalk.server.v1.WorkflowOrchestratorService.GetWorkflowOrchestratorConnectionDetails is not implemented"))
+}
 
 func (UnimplementedWorkflowOrchestratorServiceHandler) ListWorkflowOrchestratorNamespaces(context.Context, *connect.Request[v1.ListWorkflowOrchestratorNamespacesRequest]) (*connect.Response[v1.ListWorkflowOrchestratorNamespacesResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("chalk.server.v1.WorkflowOrchestratorService.ListWorkflowOrchestratorNamespaces is not implemented"))

--- a/gen/chalk/server/v1/workflow_orchestrator.pb.go
+++ b/gen/chalk/server/v1/workflow_orchestrator.pb.go
@@ -1163,6 +1163,109 @@ func (x *GetWorkflowOrchestratorWorkflowHistoryResponse) GetTruncated() bool {
 	return false
 }
 
+type GetWorkflowOrchestratorConnectionDetailsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetWorkflowOrchestratorConnectionDetailsRequest) Reset() {
+	*x = GetWorkflowOrchestratorConnectionDetailsRequest{}
+	mi := &file_chalk_server_v1_workflow_orchestrator_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetWorkflowOrchestratorConnectionDetailsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetWorkflowOrchestratorConnectionDetailsRequest) ProtoMessage() {}
+
+func (x *GetWorkflowOrchestratorConnectionDetailsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_chalk_server_v1_workflow_orchestrator_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetWorkflowOrchestratorConnectionDetailsRequest.ProtoReflect.Descriptor instead.
+func (*GetWorkflowOrchestratorConnectionDetailsRequest) Descriptor() ([]byte, []int) {
+	return file_chalk_server_v1_workflow_orchestrator_proto_rawDescGZIP(), []int{13}
+}
+
+type GetWorkflowOrchestratorConnectionDetailsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// gRPC dial target for the environment's Temporal frontend on the data-plane
+	// Envoy gateway, e.g. `workflow-orchestrator-<k8s-ns>.<gateway-dns>:443`.
+	// Envoy terminates TLS and enforces a Chalk JWT on this route, so clients must
+	// dial with TLS and send their token as `authorization` gRPC metadata.
+	Endpoint string `protobuf:"bytes,1,opt,name=endpoint,proto3" json:"endpoint,omitempty"`
+	// Temporal namespace to run workflows in. This is a Temporal-level namespace
+	// and is unrelated to the Kubernetes namespace the frontend runs in.
+	TemporalNamespace string `protobuf:"bytes,2,opt,name=temporal_namespace,json=temporalNamespace,proto3" json:"temporal_namespace,omitempty"`
+	// Task queue that the environment's deployed workers poll.
+	DefaultTaskQueue string `protobuf:"bytes,3,opt,name=default_task_queue,json=defaultTaskQueue,proto3" json:"default_task_queue,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *GetWorkflowOrchestratorConnectionDetailsResponse) Reset() {
+	*x = GetWorkflowOrchestratorConnectionDetailsResponse{}
+	mi := &file_chalk_server_v1_workflow_orchestrator_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetWorkflowOrchestratorConnectionDetailsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetWorkflowOrchestratorConnectionDetailsResponse) ProtoMessage() {}
+
+func (x *GetWorkflowOrchestratorConnectionDetailsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_chalk_server_v1_workflow_orchestrator_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetWorkflowOrchestratorConnectionDetailsResponse.ProtoReflect.Descriptor instead.
+func (*GetWorkflowOrchestratorConnectionDetailsResponse) Descriptor() ([]byte, []int) {
+	return file_chalk_server_v1_workflow_orchestrator_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *GetWorkflowOrchestratorConnectionDetailsResponse) GetEndpoint() string {
+	if x != nil {
+		return x.Endpoint
+	}
+	return ""
+}
+
+func (x *GetWorkflowOrchestratorConnectionDetailsResponse) GetTemporalNamespace() string {
+	if x != nil {
+		return x.TemporalNamespace
+	}
+	return ""
+}
+
+func (x *GetWorkflowOrchestratorConnectionDetailsResponse) GetDefaultTaskQueue() string {
+	if x != nil {
+		return x.DefaultTaskQueue
+	}
+	return ""
+}
+
 var File_chalk_server_v1_workflow_orchestrator_proto protoreflect.FileDescriptor
 
 const file_chalk_server_v1_workflow_orchestrator_proto_rawDesc = "" +
@@ -1276,7 +1379,12 @@ const file_chalk_server_v1_workflow_orchestrator_proto_rawDesc = "" +
 	".GetWorkflowOrchestratorWorkflowHistoryResponse\x12I\n" +
 	"\x06events\x18\x01 \x03(\v21.chalk.server.v1.WorkflowOrchestratorHistoryEventR\x06events\x12D\n" +
 	"\x05spans\x18\x02 \x03(\v2..chalk.server.v1.WorkflowOrchestratorTraceSpanR\x05spans\x12\x1c\n" +
-	"\ttruncated\x18\x03 \x01(\bR\ttruncated*\xd9\x03\n" +
+	"\ttruncated\x18\x03 \x01(\bR\ttruncated\"1\n" +
+	"/GetWorkflowOrchestratorConnectionDetailsRequest\"\xab\x01\n" +
+	"0GetWorkflowOrchestratorConnectionDetailsResponse\x12\x1a\n" +
+	"\bendpoint\x18\x01 \x01(\tR\bendpoint\x12-\n" +
+	"\x12temporal_namespace\x18\x02 \x01(\tR\x11temporalNamespace\x12,\n" +
+	"\x12default_task_queue\x18\x03 \x01(\tR\x10defaultTaskQueue*\xd9\x03\n" +
 	"#WorkflowOrchestratorExecutionStatus\x126\n" +
 	"2WORKFLOW_ORCHESTRATOR_EXECUTION_STATUS_UNSPECIFIED\x10\x00\x122\n" +
 	".WORKFLOW_ORCHESTRATOR_EXECUTION_STATUS_RUNNING\x10\x01\x124\n" +
@@ -1285,8 +1393,10 @@ const file_chalk_server_v1_workflow_orchestrator_proto_rawDesc = "" +
 	"/WORKFLOW_ORCHESTRATOR_EXECUTION_STATUS_CANCELED\x10\x04\x125\n" +
 	"1WORKFLOW_ORCHESTRATOR_EXECUTION_STATUS_TERMINATED\x10\x05\x12;\n" +
 	"7WORKFLOW_ORCHESTRATOR_EXECUTION_STATUS_CONTINUED_AS_NEW\x10\x06\x124\n" +
-	"0WORKFLOW_ORCHESTRATOR_EXECUTION_STATUS_TIMED_OUT\x10\a2\xc0\x05\n" +
-	"\x1bWorkflowOrchestratorService\x12\xa2\x01\n" +
+	"0WORKFLOW_ORCHESTRATOR_EXECUTION_STATUS_TIMED_OUT\x10\a2\xf7\x06\n" +
+	"\x1bWorkflowOrchestratorService\x12\xb4\x01\n" +
+	"(GetWorkflowOrchestratorConnectionDetails\x12@.chalk.server.v1.GetWorkflowOrchestratorConnectionDetailsRequest\x1aA.chalk.server.v1.GetWorkflowOrchestratorConnectionDetailsResponse\"\x03\x80}\n" +
+	"\x12\xa2\x01\n" +
 	"\"ListWorkflowOrchestratorNamespaces\x12:.chalk.server.v1.ListWorkflowOrchestratorNamespacesRequest\x1a;.chalk.server.v1.ListWorkflowOrchestratorNamespacesResponse\"\x03\x80}\n" +
 	"\x12\x9f\x01\n" +
 	"!ListWorkflowOrchestratorWorkflows\x129.chalk.server.v1.ListWorkflowOrchestratorWorkflowsRequest\x1a:.chalk.server.v1.ListWorkflowOrchestratorWorkflowsResponse\"\x03\x80}\n" +
@@ -1310,55 +1420,59 @@ func file_chalk_server_v1_workflow_orchestrator_proto_rawDescGZIP() []byte {
 }
 
 var file_chalk_server_v1_workflow_orchestrator_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_chalk_server_v1_workflow_orchestrator_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_chalk_server_v1_workflow_orchestrator_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_chalk_server_v1_workflow_orchestrator_proto_goTypes = []any{
-	(WorkflowOrchestratorExecutionStatus)(0),               // 0: chalk.server.v1.WorkflowOrchestratorExecutionStatus
-	(WorkflowOrchestratorTraceSpan_Kind)(0),                // 1: chalk.server.v1.WorkflowOrchestratorTraceSpan.Kind
-	(WorkflowOrchestratorTraceSpan_Status)(0),              // 2: chalk.server.v1.WorkflowOrchestratorTraceSpan.Status
-	(*WorkflowOrchestratorNamespace)(nil),                  // 3: chalk.server.v1.WorkflowOrchestratorNamespace
-	(*WorkflowOrchestratorExecutionSummary)(nil),           // 4: chalk.server.v1.WorkflowOrchestratorExecutionSummary
-	(*WorkflowOrchestratorPendingActivity)(nil),            // 5: chalk.server.v1.WorkflowOrchestratorPendingActivity
-	(*WorkflowOrchestratorHistoryEvent)(nil),               // 6: chalk.server.v1.WorkflowOrchestratorHistoryEvent
-	(*WorkflowOrchestratorTraceSpan)(nil),                  // 7: chalk.server.v1.WorkflowOrchestratorTraceSpan
-	(*ListWorkflowOrchestratorNamespacesRequest)(nil),      // 8: chalk.server.v1.ListWorkflowOrchestratorNamespacesRequest
-	(*ListWorkflowOrchestratorNamespacesResponse)(nil),     // 9: chalk.server.v1.ListWorkflowOrchestratorNamespacesResponse
-	(*ListWorkflowOrchestratorWorkflowsRequest)(nil),       // 10: chalk.server.v1.ListWorkflowOrchestratorWorkflowsRequest
-	(*ListWorkflowOrchestratorWorkflowsResponse)(nil),      // 11: chalk.server.v1.ListWorkflowOrchestratorWorkflowsResponse
-	(*DescribeWorkflowOrchestratorWorkflowRequest)(nil),    // 12: chalk.server.v1.DescribeWorkflowOrchestratorWorkflowRequest
-	(*DescribeWorkflowOrchestratorWorkflowResponse)(nil),   // 13: chalk.server.v1.DescribeWorkflowOrchestratorWorkflowResponse
-	(*GetWorkflowOrchestratorWorkflowHistoryRequest)(nil),  // 14: chalk.server.v1.GetWorkflowOrchestratorWorkflowHistoryRequest
-	(*GetWorkflowOrchestratorWorkflowHistoryResponse)(nil), // 15: chalk.server.v1.GetWorkflowOrchestratorWorkflowHistoryResponse
-	(*timestamppb.Timestamp)(nil),                          // 16: google.protobuf.Timestamp
+	(WorkflowOrchestratorExecutionStatus)(0),                 // 0: chalk.server.v1.WorkflowOrchestratorExecutionStatus
+	(WorkflowOrchestratorTraceSpan_Kind)(0),                  // 1: chalk.server.v1.WorkflowOrchestratorTraceSpan.Kind
+	(WorkflowOrchestratorTraceSpan_Status)(0),                // 2: chalk.server.v1.WorkflowOrchestratorTraceSpan.Status
+	(*WorkflowOrchestratorNamespace)(nil),                    // 3: chalk.server.v1.WorkflowOrchestratorNamespace
+	(*WorkflowOrchestratorExecutionSummary)(nil),             // 4: chalk.server.v1.WorkflowOrchestratorExecutionSummary
+	(*WorkflowOrchestratorPendingActivity)(nil),              // 5: chalk.server.v1.WorkflowOrchestratorPendingActivity
+	(*WorkflowOrchestratorHistoryEvent)(nil),                 // 6: chalk.server.v1.WorkflowOrchestratorHistoryEvent
+	(*WorkflowOrchestratorTraceSpan)(nil),                    // 7: chalk.server.v1.WorkflowOrchestratorTraceSpan
+	(*ListWorkflowOrchestratorNamespacesRequest)(nil),        // 8: chalk.server.v1.ListWorkflowOrchestratorNamespacesRequest
+	(*ListWorkflowOrchestratorNamespacesResponse)(nil),       // 9: chalk.server.v1.ListWorkflowOrchestratorNamespacesResponse
+	(*ListWorkflowOrchestratorWorkflowsRequest)(nil),         // 10: chalk.server.v1.ListWorkflowOrchestratorWorkflowsRequest
+	(*ListWorkflowOrchestratorWorkflowsResponse)(nil),        // 11: chalk.server.v1.ListWorkflowOrchestratorWorkflowsResponse
+	(*DescribeWorkflowOrchestratorWorkflowRequest)(nil),      // 12: chalk.server.v1.DescribeWorkflowOrchestratorWorkflowRequest
+	(*DescribeWorkflowOrchestratorWorkflowResponse)(nil),     // 13: chalk.server.v1.DescribeWorkflowOrchestratorWorkflowResponse
+	(*GetWorkflowOrchestratorWorkflowHistoryRequest)(nil),    // 14: chalk.server.v1.GetWorkflowOrchestratorWorkflowHistoryRequest
+	(*GetWorkflowOrchestratorWorkflowHistoryResponse)(nil),   // 15: chalk.server.v1.GetWorkflowOrchestratorWorkflowHistoryResponse
+	(*GetWorkflowOrchestratorConnectionDetailsRequest)(nil),  // 16: chalk.server.v1.GetWorkflowOrchestratorConnectionDetailsRequest
+	(*GetWorkflowOrchestratorConnectionDetailsResponse)(nil), // 17: chalk.server.v1.GetWorkflowOrchestratorConnectionDetailsResponse
+	(*timestamppb.Timestamp)(nil),                            // 18: google.protobuf.Timestamp
 }
 var file_chalk_server_v1_workflow_orchestrator_proto_depIdxs = []int32{
 	0,  // 0: chalk.server.v1.WorkflowOrchestratorExecutionSummary.status:type_name -> chalk.server.v1.WorkflowOrchestratorExecutionStatus
-	16, // 1: chalk.server.v1.WorkflowOrchestratorExecutionSummary.start_time:type_name -> google.protobuf.Timestamp
-	16, // 2: chalk.server.v1.WorkflowOrchestratorExecutionSummary.close_time:type_name -> google.protobuf.Timestamp
-	16, // 3: chalk.server.v1.WorkflowOrchestratorPendingActivity.scheduled_time:type_name -> google.protobuf.Timestamp
-	16, // 4: chalk.server.v1.WorkflowOrchestratorPendingActivity.last_started_time:type_name -> google.protobuf.Timestamp
-	16, // 5: chalk.server.v1.WorkflowOrchestratorPendingActivity.last_heartbeat_time:type_name -> google.protobuf.Timestamp
-	16, // 6: chalk.server.v1.WorkflowOrchestratorHistoryEvent.event_time:type_name -> google.protobuf.Timestamp
+	18, // 1: chalk.server.v1.WorkflowOrchestratorExecutionSummary.start_time:type_name -> google.protobuf.Timestamp
+	18, // 2: chalk.server.v1.WorkflowOrchestratorExecutionSummary.close_time:type_name -> google.protobuf.Timestamp
+	18, // 3: chalk.server.v1.WorkflowOrchestratorPendingActivity.scheduled_time:type_name -> google.protobuf.Timestamp
+	18, // 4: chalk.server.v1.WorkflowOrchestratorPendingActivity.last_started_time:type_name -> google.protobuf.Timestamp
+	18, // 5: chalk.server.v1.WorkflowOrchestratorPendingActivity.last_heartbeat_time:type_name -> google.protobuf.Timestamp
+	18, // 6: chalk.server.v1.WorkflowOrchestratorHistoryEvent.event_time:type_name -> google.protobuf.Timestamp
 	1,  // 7: chalk.server.v1.WorkflowOrchestratorTraceSpan.kind:type_name -> chalk.server.v1.WorkflowOrchestratorTraceSpan.Kind
 	2,  // 8: chalk.server.v1.WorkflowOrchestratorTraceSpan.status:type_name -> chalk.server.v1.WorkflowOrchestratorTraceSpan.Status
-	16, // 9: chalk.server.v1.WorkflowOrchestratorTraceSpan.scheduled_time:type_name -> google.protobuf.Timestamp
-	16, // 10: chalk.server.v1.WorkflowOrchestratorTraceSpan.started_time:type_name -> google.protobuf.Timestamp
-	16, // 11: chalk.server.v1.WorkflowOrchestratorTraceSpan.end_time:type_name -> google.protobuf.Timestamp
+	18, // 9: chalk.server.v1.WorkflowOrchestratorTraceSpan.scheduled_time:type_name -> google.protobuf.Timestamp
+	18, // 10: chalk.server.v1.WorkflowOrchestratorTraceSpan.started_time:type_name -> google.protobuf.Timestamp
+	18, // 11: chalk.server.v1.WorkflowOrchestratorTraceSpan.end_time:type_name -> google.protobuf.Timestamp
 	3,  // 12: chalk.server.v1.ListWorkflowOrchestratorNamespacesResponse.namespaces:type_name -> chalk.server.v1.WorkflowOrchestratorNamespace
 	4,  // 13: chalk.server.v1.ListWorkflowOrchestratorWorkflowsResponse.workflows:type_name -> chalk.server.v1.WorkflowOrchestratorExecutionSummary
 	4,  // 14: chalk.server.v1.DescribeWorkflowOrchestratorWorkflowResponse.workflow:type_name -> chalk.server.v1.WorkflowOrchestratorExecutionSummary
 	5,  // 15: chalk.server.v1.DescribeWorkflowOrchestratorWorkflowResponse.pending_activities:type_name -> chalk.server.v1.WorkflowOrchestratorPendingActivity
 	6,  // 16: chalk.server.v1.GetWorkflowOrchestratorWorkflowHistoryResponse.events:type_name -> chalk.server.v1.WorkflowOrchestratorHistoryEvent
 	7,  // 17: chalk.server.v1.GetWorkflowOrchestratorWorkflowHistoryResponse.spans:type_name -> chalk.server.v1.WorkflowOrchestratorTraceSpan
-	8,  // 18: chalk.server.v1.WorkflowOrchestratorService.ListWorkflowOrchestratorNamespaces:input_type -> chalk.server.v1.ListWorkflowOrchestratorNamespacesRequest
-	10, // 19: chalk.server.v1.WorkflowOrchestratorService.ListWorkflowOrchestratorWorkflows:input_type -> chalk.server.v1.ListWorkflowOrchestratorWorkflowsRequest
-	12, // 20: chalk.server.v1.WorkflowOrchestratorService.DescribeWorkflowOrchestratorWorkflow:input_type -> chalk.server.v1.DescribeWorkflowOrchestratorWorkflowRequest
-	14, // 21: chalk.server.v1.WorkflowOrchestratorService.GetWorkflowOrchestratorWorkflowHistory:input_type -> chalk.server.v1.GetWorkflowOrchestratorWorkflowHistoryRequest
-	9,  // 22: chalk.server.v1.WorkflowOrchestratorService.ListWorkflowOrchestratorNamespaces:output_type -> chalk.server.v1.ListWorkflowOrchestratorNamespacesResponse
-	11, // 23: chalk.server.v1.WorkflowOrchestratorService.ListWorkflowOrchestratorWorkflows:output_type -> chalk.server.v1.ListWorkflowOrchestratorWorkflowsResponse
-	13, // 24: chalk.server.v1.WorkflowOrchestratorService.DescribeWorkflowOrchestratorWorkflow:output_type -> chalk.server.v1.DescribeWorkflowOrchestratorWorkflowResponse
-	15, // 25: chalk.server.v1.WorkflowOrchestratorService.GetWorkflowOrchestratorWorkflowHistory:output_type -> chalk.server.v1.GetWorkflowOrchestratorWorkflowHistoryResponse
-	22, // [22:26] is the sub-list for method output_type
-	18, // [18:22] is the sub-list for method input_type
+	16, // 18: chalk.server.v1.WorkflowOrchestratorService.GetWorkflowOrchestratorConnectionDetails:input_type -> chalk.server.v1.GetWorkflowOrchestratorConnectionDetailsRequest
+	8,  // 19: chalk.server.v1.WorkflowOrchestratorService.ListWorkflowOrchestratorNamespaces:input_type -> chalk.server.v1.ListWorkflowOrchestratorNamespacesRequest
+	10, // 20: chalk.server.v1.WorkflowOrchestratorService.ListWorkflowOrchestratorWorkflows:input_type -> chalk.server.v1.ListWorkflowOrchestratorWorkflowsRequest
+	12, // 21: chalk.server.v1.WorkflowOrchestratorService.DescribeWorkflowOrchestratorWorkflow:input_type -> chalk.server.v1.DescribeWorkflowOrchestratorWorkflowRequest
+	14, // 22: chalk.server.v1.WorkflowOrchestratorService.GetWorkflowOrchestratorWorkflowHistory:input_type -> chalk.server.v1.GetWorkflowOrchestratorWorkflowHistoryRequest
+	17, // 23: chalk.server.v1.WorkflowOrchestratorService.GetWorkflowOrchestratorConnectionDetails:output_type -> chalk.server.v1.GetWorkflowOrchestratorConnectionDetailsResponse
+	9,  // 24: chalk.server.v1.WorkflowOrchestratorService.ListWorkflowOrchestratorNamespaces:output_type -> chalk.server.v1.ListWorkflowOrchestratorNamespacesResponse
+	11, // 25: chalk.server.v1.WorkflowOrchestratorService.ListWorkflowOrchestratorWorkflows:output_type -> chalk.server.v1.ListWorkflowOrchestratorWorkflowsResponse
+	13, // 26: chalk.server.v1.WorkflowOrchestratorService.DescribeWorkflowOrchestratorWorkflow:output_type -> chalk.server.v1.DescribeWorkflowOrchestratorWorkflowResponse
+	15, // 27: chalk.server.v1.WorkflowOrchestratorService.GetWorkflowOrchestratorWorkflowHistory:output_type -> chalk.server.v1.GetWorkflowOrchestratorWorkflowHistoryResponse
+	23, // [23:28] is the sub-list for method output_type
+	18, // [18:23] is the sub-list for method input_type
 	18, // [18:18] is the sub-list for extension type_name
 	18, // [18:18] is the sub-list for extension extendee
 	0,  // [0:18] is the sub-list for field type_name
@@ -1378,7 +1492,7 @@ func file_chalk_server_v1_workflow_orchestrator_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chalk_server_v1_workflow_orchestrator_proto_rawDesc), len(file_chalk_server_v1_workflow_orchestrator_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   13,
+			NumMessages:   15,
 			NumExtensions: 0,
 			NumServices:   1,
 		},


### PR DESCRIPTION
Generated counterpart to the chalk-private PR adding `WorkflowOrchestratorService.GetWorkflowOrchestratorConnectionDetails`.

chalkpy's `chalk.workflows` ([chalk-ai/chalk#3561](https://github.com/chalk-ai/chalk/pull/3561)) calls that RPC to learn how to reach an environment's Temporal frontend. It was never added, so every call 404s.

Regenerated with `protos/generate.sh go`. Only the two `workflow_orchestrator` files are included — regeneration also reverted `gen/chalk/server/v1/model_registry.pb.go`, because chalk-go's committed `ListModelVersionsFilters` is ahead of `model_registry.proto` on chalk-private main. That revert was dropped from this branch, so someone's in-flight work isn't clobbered; it does mean the two repos remain out of sync on that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAgupCFgoKoWwq2W85524k