### PR TITLE
Add HostPoolService handler to testserver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.1
 require (
 	connectrpc.com/connect v1.19.0
 	github.com/apache/arrow/go/v16 v16.1.0
-	github.com/chalk-ai/chalk-go/gen v1.2.279
+	github.com/chalk-ai/chalk-go/gen v1.2.289
 	github.com/cockroachdb/errors v1.12.0
 	github.com/fxamacker/cbor/v2 v2.9.0
 	github.com/iancoleman/strcase v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/chalk-ai/chalk-go/gen v1.2.267 h1:xzr3iA9zl9BFSpprl8ojk3Z4h2O3BZjUleo
 github.com/chalk-ai/chalk-go/gen v1.2.267/go.mod h1:Cd47/VOgt1NJD9LOeSGxiypc8hLOGZ4y8NTO13uVnzc=
 github.com/chalk-ai/chalk-go/gen v1.2.279 h1:hezM9RgjntaHGY9Ug7vQNAXvGAV4LizVv5wfKF1XPx8=
 github.com/chalk-ai/chalk-go/gen v1.2.279/go.mod h1:Cd47/VOgt1NJD9LOeSGxiypc8hLOGZ4y8NTO13uVnzc=
+github.com/chalk-ai/chalk-go/gen v1.2.289 h1:ronaW60hPnlyiIFYvG/Bfs/UItxfrtHTR/HRGfokTZE=
+github.com/chalk-ai/chalk-go/gen v1.2.289/go.mod h1:Cd47/VOgt1NJD9LOeSGxiypc8hLOGZ4y8NTO13uVnzc=
 github.com/cockroachdb/errors v1.12.0 h1:d7oCs6vuIMUQRVbi6jWWWEJZahLCfJpnJSVobd1/sUo=
 github.com/cockroachdb/errors v1.12.0/go.mod h1:SvzfYNNBshAVbZ8wzNc/UPK3w1vf0dKDUP41ucAIf7g=
 github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506 h1:ASDL+UJcILMqgNeV5jiqR4j+sTuvQNHdf2chuKj1M5k=

--- a/testserver/host_pool.go
+++ b/testserver/host_pool.go
@@ -1,0 +1,199 @@
+package testserver
+
+import (
+	"context"
+	"errors"
+
+	"connectrpc.com/connect"
+	serverv1 "github.com/chalk-ai/chalk-go/gen/chalk/server/v1"
+	"github.com/chalk-ai/chalk-go/gen/chalk/server/v1/serverv1connect"
+)
+
+// hostPoolServiceHandler implements the HostPoolService RPC handler using a
+// ResponseRegistry to provide configurable mock responses.
+type hostPoolServiceHandler struct {
+	serverv1connect.UnimplementedHostPoolServiceHandler
+	registry *ResponseRegistry
+}
+
+func newHostPoolServiceHandler(registry *ResponseRegistry) *hostPoolServiceHandler {
+	return &hostPoolServiceHandler{registry: registry}
+}
+
+func (h *hostPoolServiceHandler) CreateEnvironmentHostPool(
+	ctx context.Context,
+	req *connect.Request[serverv1.CreateEnvironmentHostPoolRequest],
+) (*connect.Response[serverv1.CreateEnvironmentHostPoolResponse], error) {
+	h.registry.CaptureRequest("CreateEnvironmentHostPool", req.Msg)
+	if behavior := h.registry.GetBehavior("CreateEnvironmentHostPool"); behavior != nil {
+		resp, err := behavior(req.Msg)
+		if err != nil {
+			return nil, err
+		}
+		return connect.NewResponse(resp.(*serverv1.CreateEnvironmentHostPoolResponse)), nil
+	}
+	if err := h.registry.GetError("CreateEnvironmentHostPool"); err != nil {
+		return nil, err
+	}
+	resp := h.registry.GetResponse("CreateEnvironmentHostPool")
+	if resp == nil {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("no mock response configured for CreateEnvironmentHostPool"))
+	}
+	return connect.NewResponse(resp.(*serverv1.CreateEnvironmentHostPoolResponse)), nil
+}
+
+func (h *hostPoolServiceHandler) UpdateEnvironmentHostPool(
+	ctx context.Context,
+	req *connect.Request[serverv1.UpdateEnvironmentHostPoolRequest],
+) (*connect.Response[serverv1.UpdateEnvironmentHostPoolResponse], error) {
+	h.registry.CaptureRequest("UpdateEnvironmentHostPool", req.Msg)
+	if behavior := h.registry.GetBehavior("UpdateEnvironmentHostPool"); behavior != nil {
+		resp, err := behavior(req.Msg)
+		if err != nil {
+			return nil, err
+		}
+		return connect.NewResponse(resp.(*serverv1.UpdateEnvironmentHostPoolResponse)), nil
+	}
+	if err := h.registry.GetError("UpdateEnvironmentHostPool"); err != nil {
+		return nil, err
+	}
+	resp := h.registry.GetResponse("UpdateEnvironmentHostPool")
+	if resp == nil {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("no mock response configured for UpdateEnvironmentHostPool"))
+	}
+	return connect.NewResponse(resp.(*serverv1.UpdateEnvironmentHostPoolResponse)), nil
+}
+
+func (h *hostPoolServiceHandler) DeleteEnvironmentHostPool(
+	ctx context.Context,
+	req *connect.Request[serverv1.DeleteEnvironmentHostPoolRequest],
+) (*connect.Response[serverv1.DeleteEnvironmentHostPoolResponse], error) {
+	h.registry.CaptureRequest("DeleteEnvironmentHostPool", req.Msg)
+	if behavior := h.registry.GetBehavior("DeleteEnvironmentHostPool"); behavior != nil {
+		resp, err := behavior(req.Msg)
+		if err != nil {
+			return nil, err
+		}
+		return connect.NewResponse(resp.(*serverv1.DeleteEnvironmentHostPoolResponse)), nil
+	}
+	if err := h.registry.GetError("DeleteEnvironmentHostPool"); err != nil {
+		return nil, err
+	}
+	resp := h.registry.GetResponse("DeleteEnvironmentHostPool")
+	if resp == nil {
+		// Delete has an empty response; default to success when unconfigured.
+		return connect.NewResponse(&serverv1.DeleteEnvironmentHostPoolResponse{}), nil
+	}
+	return connect.NewResponse(resp.(*serverv1.DeleteEnvironmentHostPoolResponse)), nil
+}
+
+func (h *hostPoolServiceHandler) CreateClusterHostPool(
+	ctx context.Context,
+	req *connect.Request[serverv1.CreateClusterHostPoolRequest],
+) (*connect.Response[serverv1.CreateClusterHostPoolResponse], error) {
+	h.registry.CaptureRequest("CreateClusterHostPool", req.Msg)
+	if behavior := h.registry.GetBehavior("CreateClusterHostPool"); behavior != nil {
+		resp, err := behavior(req.Msg)
+		if err != nil {
+			return nil, err
+		}
+		return connect.NewResponse(resp.(*serverv1.CreateClusterHostPoolResponse)), nil
+	}
+	if err := h.registry.GetError("CreateClusterHostPool"); err != nil {
+		return nil, err
+	}
+	resp := h.registry.GetResponse("CreateClusterHostPool")
+	if resp == nil {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("no mock response configured for CreateClusterHostPool"))
+	}
+	return connect.NewResponse(resp.(*serverv1.CreateClusterHostPoolResponse)), nil
+}
+
+func (h *hostPoolServiceHandler) UpdateClusterHostPool(
+	ctx context.Context,
+	req *connect.Request[serverv1.UpdateClusterHostPoolRequest],
+) (*connect.Response[serverv1.UpdateClusterHostPoolResponse], error) {
+	h.registry.CaptureRequest("UpdateClusterHostPool", req.Msg)
+	if behavior := h.registry.GetBehavior("UpdateClusterHostPool"); behavior != nil {
+		resp, err := behavior(req.Msg)
+		if err != nil {
+			return nil, err
+		}
+		return connect.NewResponse(resp.(*serverv1.UpdateClusterHostPoolResponse)), nil
+	}
+	if err := h.registry.GetError("UpdateClusterHostPool"); err != nil {
+		return nil, err
+	}
+	resp := h.registry.GetResponse("UpdateClusterHostPool")
+	if resp == nil {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("no mock response configured for UpdateClusterHostPool"))
+	}
+	return connect.NewResponse(resp.(*serverv1.UpdateClusterHostPoolResponse)), nil
+}
+
+func (h *hostPoolServiceHandler) DeleteClusterHostPool(
+	ctx context.Context,
+	req *connect.Request[serverv1.DeleteClusterHostPoolRequest],
+) (*connect.Response[serverv1.DeleteClusterHostPoolResponse], error) {
+	h.registry.CaptureRequest("DeleteClusterHostPool", req.Msg)
+	if behavior := h.registry.GetBehavior("DeleteClusterHostPool"); behavior != nil {
+		resp, err := behavior(req.Msg)
+		if err != nil {
+			return nil, err
+		}
+		return connect.NewResponse(resp.(*serverv1.DeleteClusterHostPoolResponse)), nil
+	}
+	if err := h.registry.GetError("DeleteClusterHostPool"); err != nil {
+		return nil, err
+	}
+	resp := h.registry.GetResponse("DeleteClusterHostPool")
+	if resp == nil {
+		// Delete has an empty response; default to success when unconfigured.
+		return connect.NewResponse(&serverv1.DeleteClusterHostPoolResponse{}), nil
+	}
+	return connect.NewResponse(resp.(*serverv1.DeleteClusterHostPoolResponse)), nil
+}
+
+func (h *hostPoolServiceHandler) GetHostPool(
+	ctx context.Context,
+	req *connect.Request[serverv1.GetHostPoolRequest],
+) (*connect.Response[serverv1.GetHostPoolResponse], error) {
+	h.registry.CaptureRequest("GetHostPool", req.Msg)
+	if behavior := h.registry.GetBehavior("GetHostPool"); behavior != nil {
+		resp, err := behavior(req.Msg)
+		if err != nil {
+			return nil, err
+		}
+		return connect.NewResponse(resp.(*serverv1.GetHostPoolResponse)), nil
+	}
+	if err := h.registry.GetError("GetHostPool"); err != nil {
+		return nil, err
+	}
+	resp := h.registry.GetResponse("GetHostPool")
+	if resp == nil {
+		return nil, connect.NewError(connect.CodeNotFound, errors.New("no mock response configured for GetHostPool"))
+	}
+	return connect.NewResponse(resp.(*serverv1.GetHostPoolResponse)), nil
+}
+
+func (h *hostPoolServiceHandler) ListHostPools(
+	ctx context.Context,
+	req *connect.Request[serverv1.ListHostPoolsRequest],
+) (*connect.Response[serverv1.ListHostPoolsResponse], error) {
+	h.registry.CaptureRequest("ListHostPools", req.Msg)
+	if behavior := h.registry.GetBehavior("ListHostPools"); behavior != nil {
+		resp, err := behavior(req.Msg)
+		if err != nil {
+			return nil, err
+		}
+		return connect.NewResponse(resp.(*serverv1.ListHostPoolsResponse)), nil
+	}
+	if err := h.registry.GetError("ListHostPools"); err != nil {
+		return nil, err
+	}
+	resp := h.registry.GetResponse("ListHostPools")
+	if resp == nil {
+		return connect.NewResponse(&serverv1.ListHostPoolsResponse{}), nil
+	}
+	return connect.NewResponse(resp.(*serverv1.ListHostPoolsResponse)), nil
+}

--- a/testserver/server.go
+++ b/testserver/server.go
@@ -85,6 +85,11 @@ func NewMockBuilderServer(t testing.TB) *MockServer {
 	scalingGroupPath, scalingGroupRPCHandler := scalinggroupv1connect.NewScalingGroupManagerServiceHandler(scalingGroupHandler)
 	mux.Handle(scalingGroupPath, scalingGroupRPCHandler)
 
+	// Register HostPoolService handler
+	hostPoolHandler := newHostPoolServiceHandler(registry)
+	hostPoolPath, hostPoolRPCHandler := serverv1connect.NewHostPoolServiceHandler(hostPoolHandler)
+	mux.Handle(hostPoolPath, hostPoolRPCHandler)
+
 	// Create httptest server
 	httpServer := httptest.NewServer(mux)
 
@@ -684,6 +689,70 @@ func (s *MockServer) OnListBindingClusterContainerRegistry() *MethodConfigBuilde
 func (s *MockServer) OnDeleteBindingClusterContainerRegistry() *MethodConfigBuilder[*serverv1.DeleteBindingClusterContainerRegistryResponse] {
 	return &MethodConfigBuilder[*serverv1.DeleteBindingClusterContainerRegistryResponse]{
 		methodName: "DeleteBindingClusterContainerRegistry",
+		registry:   s.registry,
+	}
+}
+
+// OnCreateEnvironmentHostPool configures the CreateEnvironmentHostPool RPC method.
+func (s *MockServer) OnCreateEnvironmentHostPool() *MethodConfigBuilder[*serverv1.CreateEnvironmentHostPoolResponse] {
+	return &MethodConfigBuilder[*serverv1.CreateEnvironmentHostPoolResponse]{
+		methodName: "CreateEnvironmentHostPool",
+		registry:   s.registry,
+	}
+}
+
+// OnUpdateEnvironmentHostPool configures the UpdateEnvironmentHostPool RPC method.
+func (s *MockServer) OnUpdateEnvironmentHostPool() *MethodConfigBuilder[*serverv1.UpdateEnvironmentHostPoolResponse] {
+	return &MethodConfigBuilder[*serverv1.UpdateEnvironmentHostPoolResponse]{
+		methodName: "UpdateEnvironmentHostPool",
+		registry:   s.registry,
+	}
+}
+
+// OnDeleteEnvironmentHostPool configures the DeleteEnvironmentHostPool RPC method.
+func (s *MockServer) OnDeleteEnvironmentHostPool() *MethodConfigBuilder[*serverv1.DeleteEnvironmentHostPoolResponse] {
+	return &MethodConfigBuilder[*serverv1.DeleteEnvironmentHostPoolResponse]{
+		methodName: "DeleteEnvironmentHostPool",
+		registry:   s.registry,
+	}
+}
+
+// OnCreateClusterHostPool configures the CreateClusterHostPool RPC method.
+func (s *MockServer) OnCreateClusterHostPool() *MethodConfigBuilder[*serverv1.CreateClusterHostPoolResponse] {
+	return &MethodConfigBuilder[*serverv1.CreateClusterHostPoolResponse]{
+		methodName: "CreateClusterHostPool",
+		registry:   s.registry,
+	}
+}
+
+// OnUpdateClusterHostPool configures the UpdateClusterHostPool RPC method.
+func (s *MockServer) OnUpdateClusterHostPool() *MethodConfigBuilder[*serverv1.UpdateClusterHostPoolResponse] {
+	return &MethodConfigBuilder[*serverv1.UpdateClusterHostPoolResponse]{
+		methodName: "UpdateClusterHostPool",
+		registry:   s.registry,
+	}
+}
+
+// OnDeleteClusterHostPool configures the DeleteClusterHostPool RPC method.
+func (s *MockServer) OnDeleteClusterHostPool() *MethodConfigBuilder[*serverv1.DeleteClusterHostPoolResponse] {
+	return &MethodConfigBuilder[*serverv1.DeleteClusterHostPoolResponse]{
+		methodName: "DeleteClusterHostPool",
+		registry:   s.registry,
+	}
+}
+
+// OnGetHostPool configures the GetHostPool RPC method.
+func (s *MockServer) OnGetHostPool() *MethodConfigBuilder[*serverv1.GetHostPoolResponse] {
+	return &MethodConfigBuilder[*serverv1.GetHostPoolResponse]{
+		methodName: "GetHostPool",
+		registry:   s.registry,
+	}
+}
+
+// OnListHostPools configures the ListHostPools RPC method.
+func (s *MockServer) OnListHostPools() *MethodConfigBuilder[*serverv1.ListHostPoolsResponse] {
+	return &MethodConfigBuilder[*serverv1.ListHostPoolsResponse]{
+		methodName: "ListHostPools",
 		registry:   s.registry,
 	}
 }


### PR DESCRIPTION
Adds a testserver mock handler for the HostPoolService so that client tests can be written against the service.