### PR TITLE
Allow a pre-issued JWT to authenticate without client credentials

### DIFF
--- a/auth/token.go
+++ b/auth/token.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"connectrpc.com/connect"
@@ -17,15 +18,41 @@ import (
 )
 
 type Manager struct {
-	mu         *sync.Mutex
-	config     *config.Manager
-	authClient serverv1connect.AuthServiceClient
-	token      *serverv1.GetTokenResponse
+	// mu serializes token refreshes so concurrent requests do not each trigger
+	// one. Reads go through token, which is atomic, so the common case of an
+	// already-valid token takes no lock.
+	mu     *sync.Mutex
+	config *config.Manager
+	// token is read on every request from any number of goroutines and written on
+	// refresh, so it must be accessed atomically rather than directly.
+	token         atomic.Pointer[serverv1.GetTokenResponse]
+	authClient    serverv1connect.AuthServiceClient
+	tokenProvider TokenProvider
 }
 
+// TokenProvider returns a currently-valid Chalk JWT. It is called whenever the
+// cached token goes stale, in place of the client-credentials exchange.
+//
+// Callers holding a rotating credential -- one an external process replaces
+// before it expires -- supply this so the token can be re-read at its source.
+// Without it a pre-issued token is a one-shot snapshot: there are no credentials
+// to exchange with, so the client is stranded the moment the token expires.
+//
+// Implementations must not call back into the client that owns this Manager;
+// they are invoked while its lock is held.
+type TokenProvider func(ctx context.Context) (*serverv1.GetTokenResponse, error)
+
 type Inputs struct {
-	// Token overrides the default token, if provided. It's unlikely you'll want to provide this.
+	// Token is a pre-issued JWT to authenticate with, instead of exchanging client
+	// credentials. Supply it when the caller has already authenticated and has no
+	// client secret -- and set TokenProvider too if the token rotates, since a
+	// Token on its own cannot be renewed once it expires.
 	Token *serverv1.GetTokenResponse
+
+	// TokenProvider supplies a token whenever the cached one goes stale, instead
+	// of running the client-credentials exchange. Sufficient on its own -- the
+	// first token is obtained from it if Token is unset. See TokenProvider.
+	TokenProvider TokenProvider
 
 	// HttpClient is used as the underlying http.client. Connect provides an interface for abstracting over the
 	// standard library version of the auth client
@@ -44,6 +71,28 @@ type Inputs struct {
 	// on the token's engine maps. If true, the query server will not be
 	// automatically resolved from the token.
 	SkipEngineMapping bool
+}
+
+// validatePreIssuedToken rejects a token that cannot authenticate a request at
+// all. Both a caller-supplied Token and a TokenProvider result go through here.
+//
+// Each check otherwise fails far from its cause: a nil token gets dereferenced
+// inside an interceptor, and an empty access token produces a bare "Bearer "
+// header that the server rejects without explaining why.
+//
+// Deliberately does not require ExpiresAt. A token without one reads as the Unix
+// epoch and so is always stale, which is wasteful but survivable when client
+// credentials are also configured -- a combination that predates this change and
+// that callers, including this repo's own tests, do use. The provider path has no
+// such fallback and does require it; see GetJWT.
+func validatePreIssuedToken(token *serverv1.GetTokenResponse) error {
+	if token == nil {
+		return errors.New("token is nil")
+	}
+	if token.GetAccessToken() == "" {
+		return errors.New("token has an empty access token")
+	}
+	return nil
 }
 
 func cleanEnvironmentId(
@@ -134,16 +183,28 @@ func NewManager(ctx context.Context, opts *Inputs) (*Manager, error) {
 				),
 			),
 		),
-		mu:    &sync.Mutex{},
-		token: opts.Token,
+		mu:            &sync.Mutex{},
+		tokenProvider: opts.TokenProvider,
+	}
+	r.token.Store(opts.Token)
+
+	// Reject an unusable pre-issued token here rather than at first request. The
+	// common trap is omitting ExpiresAt, which reads as the Unix epoch and makes
+	// the token permanently stale -- so every request would try to exchange
+	// credentials the caller deliberately does not have.
+	if token := r.token.Load(); token != nil {
+		if err := validatePreIssuedToken(token); err != nil {
+			return nil, errors.Wrap(err, "invalid pre-issued JWT")
+		}
 	}
 
 	var err error
-	if r.token == nil {
-		// If neither a pre-issued JWT nor a complete pair of client credentials
-		// was provided, short-circuit with a clearer error than letting GetToken
-		// fail with "Client ID and secret are invalid" against the api-server.
-		if r.config.ClientId.Value == "" || r.config.ClientSecret.Value == "" {
+	if r.token.Load() == nil {
+		// If none of a pre-issued JWT, a token provider, or a complete pair of
+		// client credentials was given, short-circuit with a clearer error than
+		// letting GetToken fail with "Client ID and secret are invalid" against
+		// the api-server.
+		if r.tokenProvider == nil && (r.config.ClientId.Value == "" || r.config.ClientSecret.Value == "") {
 			credentialsErr := errors.New(
 				"no JWT and no ClientId/ClientSecret provided; pass a pre-issued JWT (e.g. --access-token) or set client credentials",
 			)
@@ -152,7 +213,10 @@ func NewManager(ctx context.Context, opts *Inputs) (*Manager, error) {
 			}
 			return nil, credentialsErr
 		}
-		r.token, err = r.GetJWT(ctx, time.Now())
+		token, err := r.GetJWT(ctx, time.Now())
+		if err == nil {
+			r.token.Store(token)
+		}
 		if err != nil {
 			return nil, errors.Wrap(err, "initializing token refresher")
 		}
@@ -164,19 +228,20 @@ func NewManager(ctx context.Context, opts *Inputs) (*Manager, error) {
 			return nil, errors.New("environment ID is required when SkipEnvironmentNameMapping is enabled")
 		}
 	} else {
-		r.config.EnvironmentId, err = cleanEnvironmentId(r.config.EnvironmentId, r.token)
+		r.config.EnvironmentId, err = cleanEnvironmentId(r.config.EnvironmentId, r.token.Load())
 		if err != nil {
 			return nil, errors.Wrap(err, "initializing environment id")
 		}
 	}
 
 	if !opts.SkipEngineMapping {
-		envName := r.token.EnvironmentIdToName[r.config.EnvironmentId.Value]
-		if e := r.token.Engines[r.config.EnvironmentId.Value]; r.config.GetJSONQueryServer().Kind == config.DefaultSourceKind && e != "" {
+		activeToken := r.token.Load()
+		envName := activeToken.EnvironmentIdToName[r.config.EnvironmentId.Value]
+		if e := activeToken.Engines[r.config.EnvironmentId.Value]; r.config.GetJSONQueryServer().Kind == config.DefaultSourceKind && e != "" {
 			r.config.SetJSONQueryServer(config.NewFromToken(e, fmt.Sprintf("token for environment %q", envName)))
 		}
 
-		if e := r.token.GrpcEngines[r.config.EnvironmentId.Value]; r.config.GetGRPCQueryServer().Kind == config.DefaultSourceKind && e != "" {
+		if e := activeToken.GrpcEngines[r.config.EnvironmentId.Value]; r.config.GetGRPCQueryServer().Kind == config.DefaultSourceKind && e != "" {
 			r.config.SetGRPCQueryServer(config.NewFromToken(e, fmt.Sprintf("token for environment %q", envName)))
 		}
 	}
@@ -188,15 +253,51 @@ func (r *Manager) GetJWT(
 	ctx context.Context,
 	newerThan time.Time,
 ) (*serverv1.GetTokenResponse, error) {
-	to := r.token
-	if to != nil && to.GetExpiresAt().AsTime().After(newerThan) {
+	if to := r.token.Load(); to != nil && to.GetExpiresAt().AsTime().After(newerThan) {
 		return to, nil
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if r.token != nil && r.token.GetExpiresAt().AsTime().After(newerThan) {
-		return r.token, nil
+	if to := r.token.Load(); to != nil && to.GetExpiresAt().AsTime().After(newerThan) {
+		return to, nil
 	}
+
+	// A rotating credential is re-read at its source rather than exchanged. There
+	// are no client credentials to exchange with on that path, so without this
+	// the request below would be sent with two empty strings and rejected --
+	// stranding the client the moment its token expires, even though a fresh one
+	// is already available.
+	if r.tokenProvider != nil {
+		token, err := r.tokenProvider(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "refreshing pre-issued token")
+		}
+		// Validate rather than trust: this is a caller-supplied callback, and a
+		// nil or empty token here would otherwise be cached and only surface much
+		// later as a nil dereference in an interceptor or a bare "Bearer " header.
+		if err := validatePreIssuedToken(token); err != nil {
+			return nil, errors.Wrap(err, "refreshing pre-issued token")
+		}
+		// The provider is expected to return something usable. If it hands back a
+		// token that is already stale, say so rather than stamping it onto a request
+		// and letting the server reject it as an opaque 401. Callers ask for a
+		// minute of headroom, so this also reports a producer that has stopped
+		// rotating instead of silently re-invoking the provider on every request.
+		//
+		// A missing ExpiresAt lands here too, since it reads as the Unix epoch.
+		// Unlike the caller-supplied Token path there is no credential fallback
+		// here, so an unbounded expiry is never usable.
+		if !token.GetExpiresAt().AsTime().After(newerThan) {
+			return nil, errors.Newf(
+				"pre-issued token provider returned a token expiring at %s, which is not valid until %s; the token source may no longer be refreshed",
+				token.GetExpiresAt().AsTime(),
+				newerThan,
+			)
+		}
+		r.token.Store(token)
+		return token, nil
+	}
+
 	req := &serverv1.GetTokenRequest{
 		ClientId:     string(r.config.ClientId.Value),
 		ClientSecret: string(r.config.ClientSecret.Value),
@@ -211,8 +312,8 @@ func (r *Manager) GetJWT(
 	if err != nil {
 		return nil, errors.Wrap(err, "refreshing token")
 	}
-	r.token = t.Msg
-	return r.token, nil
+	r.token.Store(t.Msg)
+	return t.Msg, nil
 }
 
 func (r *Manager) GetConfig() *config.Manager {

--- a/auth/token.go
+++ b/auth/token.go
@@ -186,21 +186,17 @@ func NewManager(ctx context.Context, opts *Inputs) (*Manager, error) {
 		mu:           &sync.Mutex{},
 		authProvider: opts.AuthProvider,
 	}
+	// Validate before storing so nothing invalid is ever observable in r.auth,
+	// matching how GetAuth handles an AuthProvider result.
 	if opts.Token != nil {
+		if err := validatePreIssuedToken(opts.Token); err != nil {
+			return nil, errors.Wrap(err, "invalid pre-issued JWT")
+		}
 		r.auth.Store(&AuthSnapshot{
 			Token:         opts.Token,
 			EnvironmentID: r.config.EnvironmentId.Value,
 		})
-	}
-
-	if snapshot := r.auth.Load(); snapshot != nil {
-		if err := validatePreIssuedToken(snapshot.Token); err != nil {
-			return nil, errors.Wrap(err, "invalid pre-issued JWT")
-		}
-	}
-
-	var err error
-	if r.auth.Load() == nil {
+	} else {
 		// If none of a pre-issued JWT, an auth provider, or a complete pair of
 		// client credentials was given, short-circuit with a clearer error than
 		// letting GetToken fail with "Client ID and secret are invalid" against
@@ -214,8 +210,7 @@ func NewManager(ctx context.Context, opts *Inputs) (*Manager, error) {
 			}
 			return nil, credentialsErr
 		}
-		_, err := r.GetAuth(ctx, time.Now())
-		if err != nil {
+		if _, err := r.GetAuth(ctx, time.Now()); err != nil {
 			return nil, errors.Wrap(err, "initializing token refresher")
 		}
 	}
@@ -230,10 +225,11 @@ func NewManager(ctx context.Context, opts *Inputs) (*Manager, error) {
 			r.config.EnvironmentId = config.NewFromArg(activeAuth.EnvironmentID)
 		}
 	} else {
-		r.config.EnvironmentId, err = cleanEnvironmentId(r.config.EnvironmentId, activeAuth.Token)
+		cleaned, err := cleanEnvironmentId(r.config.EnvironmentId, activeAuth.Token)
 		if err != nil {
 			return nil, errors.Wrap(err, "initializing environment id")
 		}
+		r.config.EnvironmentId = cleaned
 		activeAuth = &AuthSnapshot{
 			Token:         activeAuth.Token,
 			EnvironmentID: r.config.EnvironmentId.Value,

--- a/auth/token.go
+++ b/auth/token.go
@@ -18,28 +18,38 @@ import (
 )
 
 type Manager struct {
-	mu            *sync.Mutex
-	config        *config.Manager
-	token         atomic.Pointer[serverv1.GetTokenResponse]
-	authClient    serverv1connect.AuthServiceClient
-	tokenProvider TokenProvider
+	mu           *sync.Mutex
+	config       *config.Manager
+	auth         atomic.Pointer[AuthSnapshot]
+	authClient   serverv1connect.AuthServiceClient
+	authProvider AuthProvider
 }
 
-// TokenProvider returns a currently-valid Chalk JWT. It is called whenever the
-// cached token goes stale, in place of the client-credentials exchange.
+// AuthSnapshot is the bearer token and effective environment that must be sent
+// together on an authenticated request.
+type AuthSnapshot struct {
+	Token         *serverv1.GetTokenResponse
+	EnvironmentID string
+}
+
+// AuthProvider returns a currently-valid authentication snapshot. It is called
+// whenever the cached token goes stale, in place of the client-credentials
+// exchange. Token and EnvironmentID must be resolved atomically from the same
+// credential state.
 // Implementations must not call back into the client that owns this Manager;
 // they are invoked while its lock is held.
-type TokenProvider func(ctx context.Context) (*serverv1.GetTokenResponse, error)
+type AuthProvider func(ctx context.Context) (*AuthSnapshot, error)
 
 type Inputs struct {
 	// Token is a pre-issued JWT to authenticate with, instead of exchanging client
 	// credentials
 	Token *serverv1.GetTokenResponse
 
-	// TokenProvider supplies a token whenever the cached one goes stale, instead
-	// of running the client-credentials exchange. Sufficient on its own -- the
-	// first token is obtained from it if Token is unset. See TokenProvider.
-	TokenProvider TokenProvider
+	// AuthProvider supplies a token and effective environment whenever the cached
+	// token goes stale, instead of running the client-credentials exchange.
+	// Sufficient on its own -- the first snapshot is obtained from it if Token is
+	// unset. See AuthProvider.
+	AuthProvider AuthProvider
 
 	// HttpClient is used as the underlying http.client. Connect provides an interface for abstracting over the
 	// standard library version of the auth client
@@ -61,13 +71,26 @@ type Inputs struct {
 }
 
 // validatePreIssuedToken rejects a token that cannot authenticate a request at
-// all. Both a caller-supplied Token and a TokenProvider result go through here.
+// all. Both a caller-supplied Token and an AuthProvider result go through here.
 func validatePreIssuedToken(token *serverv1.GetTokenResponse) error {
 	if token == nil {
 		return errors.New("token is nil")
 	}
 	if token.GetAccessToken() == "" {
 		return errors.New("token has an empty access token")
+	}
+	return nil
+}
+
+func validateAuthSnapshot(snapshot *AuthSnapshot) error {
+	if snapshot == nil {
+		return errors.New("auth snapshot is nil")
+	}
+	if err := validatePreIssuedToken(snapshot.Token); err != nil {
+		return err
+	}
+	if snapshot.EnvironmentID == "" {
+		return errors.New("auth snapshot has an empty environment ID")
 	}
 	return nil
 }
@@ -160,24 +183,29 @@ func NewManager(ctx context.Context, opts *Inputs) (*Manager, error) {
 				),
 			),
 		),
-		mu:            &sync.Mutex{},
-		tokenProvider: opts.TokenProvider,
+		mu:           &sync.Mutex{},
+		authProvider: opts.AuthProvider,
 	}
-	r.token.Store(opts.Token)
+	if opts.Token != nil {
+		r.auth.Store(&AuthSnapshot{
+			Token:         opts.Token,
+			EnvironmentID: r.config.EnvironmentId.Value,
+		})
+	}
 
-	if token := r.token.Load(); token != nil {
-		if err := validatePreIssuedToken(token); err != nil {
+	if snapshot := r.auth.Load(); snapshot != nil {
+		if err := validatePreIssuedToken(snapshot.Token); err != nil {
 			return nil, errors.Wrap(err, "invalid pre-issued JWT")
 		}
 	}
 
 	var err error
-	if r.token.Load() == nil {
-		// If none of a pre-issued JWT, a token provider, or a complete pair of
+	if r.auth.Load() == nil {
+		// If none of a pre-issued JWT, an auth provider, or a complete pair of
 		// client credentials was given, short-circuit with a clearer error than
 		// letting GetToken fail with "Client ID and secret are invalid" against
 		// the api-server.
-		if r.tokenProvider == nil && (r.config.ClientId.Value == "" || r.config.ClientSecret.Value == "") {
+		if r.authProvider == nil && (r.config.ClientId.Value == "" || r.config.ClientSecret.Value == "") {
 			credentialsErr := errors.New(
 				"no JWT and no ClientId/ClientSecret provided; pass a pre-issued JWT (e.g. --access-token) or set client credentials",
 			)
@@ -186,29 +214,35 @@ func NewManager(ctx context.Context, opts *Inputs) (*Manager, error) {
 			}
 			return nil, credentialsErr
 		}
-		token, err := r.GetJWT(ctx, time.Now())
-		if err == nil {
-			r.token.Store(token)
-		}
+		_, err := r.GetAuth(ctx, time.Now())
 		if err != nil {
 			return nil, errors.Wrap(err, "initializing token refresher")
 		}
 	}
 
+	activeAuth := r.auth.Load()
 	if opts.SkipEnvironmentNameMapping {
 		// Use environment ID verbatim without validation or mapping
-		if r.config.EnvironmentId.Value == "" {
+		if activeAuth.EnvironmentID == "" {
 			return nil, errors.New("environment ID is required when SkipEnvironmentNameMapping is enabled")
 		}
+		if r.config.EnvironmentId.Value == "" {
+			r.config.EnvironmentId = config.NewFromArg(activeAuth.EnvironmentID)
+		}
 	} else {
-		r.config.EnvironmentId, err = cleanEnvironmentId(r.config.EnvironmentId, r.token.Load())
+		r.config.EnvironmentId, err = cleanEnvironmentId(r.config.EnvironmentId, activeAuth.Token)
 		if err != nil {
 			return nil, errors.Wrap(err, "initializing environment id")
 		}
+		activeAuth = &AuthSnapshot{
+			Token:         activeAuth.Token,
+			EnvironmentID: r.config.EnvironmentId.Value,
+		}
+		r.auth.Store(activeAuth)
 	}
 
 	if !opts.SkipEngineMapping {
-		activeToken := r.token.Load()
+		activeToken := activeAuth.Token
 		envName := activeToken.EnvironmentIdToName[r.config.EnvironmentId.Value]
 		if e := activeToken.Engines[r.config.EnvironmentId.Value]; r.config.GetJSONQueryServer().Kind == config.DefaultSourceKind && e != "" {
 			r.config.SetJSONQueryServer(config.NewFromToken(e, fmt.Sprintf("token for environment %q", envName)))
@@ -222,17 +256,19 @@ func NewManager(ctx context.Context, opts *Inputs) (*Manager, error) {
 	return r, nil
 }
 
-func (r *Manager) GetJWT(
+// GetAuth returns a token and effective environment from the same credential
+// snapshot, refreshing both atomically when the token goes stale.
+func (r *Manager) GetAuth(
 	ctx context.Context,
 	newerThan time.Time,
-) (*serverv1.GetTokenResponse, error) {
-	if to := r.token.Load(); to != nil && to.GetExpiresAt().AsTime().After(newerThan) {
-		return to, nil
+) (*AuthSnapshot, error) {
+	if snapshot := r.auth.Load(); snapshot != nil && snapshot.Token.GetExpiresAt().AsTime().After(newerThan) {
+		return snapshot, nil
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if to := r.token.Load(); to != nil && to.GetExpiresAt().AsTime().After(newerThan) {
-		return to, nil
+	if snapshot := r.auth.Load(); snapshot != nil && snapshot.Token.GetExpiresAt().AsTime().After(newerThan) {
+		return snapshot, nil
 	}
 
 	// A rotating credential is re-read at its source rather than exchanged. There
@@ -240,24 +276,24 @@ func (r *Manager) GetJWT(
 	// the request below would be sent with two empty strings and rejected --
 	// stranding the client the moment its token expires, even though a fresh one
 	// is already available.
-	if r.tokenProvider != nil {
-		token, err := r.tokenProvider(ctx)
+	if r.authProvider != nil {
+		snapshot, err := r.authProvider(ctx)
 		if err != nil {
 			return nil, errors.Wrap(err, "refreshing pre-issued token")
 		}
-		if err := validatePreIssuedToken(token); err != nil {
+		if err := validateAuthSnapshot(snapshot); err != nil {
 			return nil, errors.Wrap(err, "refreshing pre-issued token")
 		}
 
-		if !token.GetExpiresAt().AsTime().After(newerThan) {
+		if !snapshot.Token.GetExpiresAt().AsTime().After(newerThan) {
 			return nil, errors.Newf(
 				"pre-issued token provider returned a token expiring at %s, which is not valid until %s; the token source may no longer be refreshed",
-				token.GetExpiresAt().AsTime(),
+				snapshot.Token.GetExpiresAt().AsTime(),
 				newerThan,
 			)
 		}
-		r.token.Store(token)
-		return token, nil
+		r.auth.Store(snapshot)
+		return snapshot, nil
 	}
 
 	req := &serverv1.GetTokenRequest{
@@ -274,8 +310,25 @@ func (r *Manager) GetJWT(
 	if err != nil {
 		return nil, errors.Wrap(err, "refreshing token")
 	}
-	r.token.Store(t.Msg)
-	return t.Msg, nil
+	snapshot := &AuthSnapshot{
+		Token:         t.Msg,
+		EnvironmentID: r.config.EnvironmentId.Value,
+	}
+	r.auth.Store(snapshot)
+	return snapshot, nil
+}
+
+// GetJWT is a token-only convenience wrapper. Authenticated request paths
+// should use GetAuth so the token cannot be paired with a stale environment.
+func (r *Manager) GetJWT(
+	ctx context.Context,
+	newerThan time.Time,
+) (*serverv1.GetTokenResponse, error) {
+	snapshot, err := r.GetAuth(ctx, newerThan)
+	if err != nil {
+		return nil, err
+	}
+	return snapshot.Token, nil
 }
 
 func (r *Manager) GetConfig() *config.Manager {

--- a/auth/token.go
+++ b/auth/token.go
@@ -18,13 +18,8 @@ import (
 )
 
 type Manager struct {
-	// mu serializes token refreshes so concurrent requests do not each trigger
-	// one. Reads go through token, which is atomic, so the common case of an
-	// already-valid token takes no lock.
-	mu     *sync.Mutex
-	config *config.Manager
-	// token is read on every request from any number of goroutines and written on
-	// refresh, so it must be accessed atomically rather than directly.
+	mu            *sync.Mutex
+	config        *config.Manager
 	token         atomic.Pointer[serverv1.GetTokenResponse]
 	authClient    serverv1connect.AuthServiceClient
 	tokenProvider TokenProvider
@@ -32,21 +27,13 @@ type Manager struct {
 
 // TokenProvider returns a currently-valid Chalk JWT. It is called whenever the
 // cached token goes stale, in place of the client-credentials exchange.
-//
-// Callers holding a rotating credential -- one an external process replaces
-// before it expires -- supply this so the token can be re-read at its source.
-// Without it a pre-issued token is a one-shot snapshot: there are no credentials
-// to exchange with, so the client is stranded the moment the token expires.
-//
 // Implementations must not call back into the client that owns this Manager;
 // they are invoked while its lock is held.
 type TokenProvider func(ctx context.Context) (*serverv1.GetTokenResponse, error)
 
 type Inputs struct {
 	// Token is a pre-issued JWT to authenticate with, instead of exchanging client
-	// credentials. Supply it when the caller has already authenticated and has no
-	// client secret -- and set TokenProvider too if the token rotates, since a
-	// Token on its own cannot be renewed once it expires.
+	// credentials
 	Token *serverv1.GetTokenResponse
 
 	// TokenProvider supplies a token whenever the cached one goes stale, instead
@@ -75,16 +62,6 @@ type Inputs struct {
 
 // validatePreIssuedToken rejects a token that cannot authenticate a request at
 // all. Both a caller-supplied Token and a TokenProvider result go through here.
-//
-// Each check otherwise fails far from its cause: a nil token gets dereferenced
-// inside an interceptor, and an empty access token produces a bare "Bearer "
-// header that the server rejects without explaining why.
-//
-// Deliberately does not require ExpiresAt. A token without one reads as the Unix
-// epoch and so is always stale, which is wasteful but survivable when client
-// credentials are also configured -- a combination that predates this change and
-// that callers, including this repo's own tests, do use. The provider path has no
-// such fallback and does require it; see GetJWT.
 func validatePreIssuedToken(token *serverv1.GetTokenResponse) error {
 	if token == nil {
 		return errors.New("token is nil")
@@ -188,10 +165,6 @@ func NewManager(ctx context.Context, opts *Inputs) (*Manager, error) {
 	}
 	r.token.Store(opts.Token)
 
-	// Reject an unusable pre-issued token here rather than at first request. The
-	// common trap is omitting ExpiresAt, which reads as the Unix epoch and makes
-	// the token permanently stale -- so every request would try to exchange
-	// credentials the caller deliberately does not have.
 	if token := r.token.Load(); token != nil {
 		if err := validatePreIssuedToken(token); err != nil {
 			return nil, errors.Wrap(err, "invalid pre-issued JWT")
@@ -272,21 +245,10 @@ func (r *Manager) GetJWT(
 		if err != nil {
 			return nil, errors.Wrap(err, "refreshing pre-issued token")
 		}
-		// Validate rather than trust: this is a caller-supplied callback, and a
-		// nil or empty token here would otherwise be cached and only surface much
-		// later as a nil dereference in an interceptor or a bare "Bearer " header.
 		if err := validatePreIssuedToken(token); err != nil {
 			return nil, errors.Wrap(err, "refreshing pre-issued token")
 		}
-		// The provider is expected to return something usable. If it hands back a
-		// token that is already stale, say so rather than stamping it onto a request
-		// and letting the server reject it as an opaque 401. Callers ask for a
-		// minute of headroom, so this also reports a producer that has stopped
-		// rotating instead of silently re-invoking the provider on every request.
-		//
-		// A missing ExpiresAt lands here too, since it reads as the Unix epoch.
-		// Unlike the caller-supplied Token path there is no credential fallback
-		// here, so an unbounded expiry is never usable.
+
 		if !token.GetExpiresAt().AsTime().After(newerThan) {
 			return nil, errors.Newf(
 				"pre-issued token provider returned a token expiring at %s, which is not valid until %s; the token source may no longer be refreshed",

--- a/auth/token.go
+++ b/auth/token.go
@@ -140,13 +140,17 @@ func NewManager(ctx context.Context, opts *Inputs) (*Manager, error) {
 
 	var err error
 	if r.token == nil {
-		// If neither a pre-issued JWT nor client credentials were provided,
-		// short-circuit with a clearer error than letting GetToken fail with
-		// "Client ID and secret are invalid" against the api-server.
-		if r.config.ClientId.Value == "" && r.config.ClientSecret.Value == "" {
-			return nil, errors.New(
+		// If neither a pre-issued JWT nor a complete pair of client credentials
+		// was provided, short-circuit with a clearer error than letting GetToken
+		// fail with "Client ID and secret are invalid" against the api-server.
+		if r.config.ClientId.Value == "" || r.config.ClientSecret.Value == "" {
+			credentialsErr := errors.New(
 				"no JWT and no ClientId/ClientSecret provided; pass a pre-issued JWT (e.g. --access-token) or set client credentials",
 			)
+			if configErr := r.config.ProjectConfigErr(); configErr != nil {
+				return nil, errors.Wrap(configErr, credentialsErr.Error())
+			}
+			return nil, credentialsErr
 		}
 		r.token, err = r.GetJWT(ctx, time.Now())
 		if err != nil {

--- a/auth/token_provider_test.go
+++ b/auth/token_provider_test.go
@@ -13,7 +13,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// These exercise the TokenProvider path without a network. A provider replaces
+// These exercise the AuthProvider path without a network. A provider replaces
 // the client-credentials exchange entirely, so every assertion here would
 // otherwise require a live api-server to disprove.
 
@@ -22,6 +22,10 @@ func tokenValidFor(d time.Duration) *serverv1.GetTokenResponse {
 		AccessToken: "header.payload.signature",
 		ExpiresAt:   timestamppb.New(time.Now().Add(d)),
 	}
+}
+
+func authValidFor(environmentID string, d time.Duration) *AuthSnapshot {
+	return &AuthSnapshot{Token: tokenValidFor(d), EnvironmentID: environmentID}
 }
 
 // managerWithoutCredentials builds a config.Manager with no credentials from any
@@ -48,26 +52,27 @@ func newManagerForTest(t *testing.T, in *Inputs) (*Manager, error) {
 	return NewManager(t.Context(), in)
 }
 
-func TestTokenProviderSuppliesFirstToken(t *testing.T) {
+func TestAuthProviderSuppliesFirstSnapshot(t *testing.T) {
 	t.Parallel()
 
 	calls := 0
 	m, err := newManagerForTest(t, &Inputs{
-		TokenProvider: func(context.Context) (*serverv1.GetTokenResponse, error) {
+		AuthProvider: func(context.Context) (*AuthSnapshot, error) {
 			calls++
-			return tokenValidFor(time.Hour), nil
+			return authValidFor("env-provider", time.Hour), nil
 		},
 	})
 
 	// A provider alone is sufficient: no Token and no credentials.
 	require.NoError(t, err)
 	assert.Equal(t, 1, calls)
-	token, err := m.GetJWT(t.Context(), time.Now())
+	authSnapshot, err := m.GetAuth(t.Context(), time.Now())
 	assert.NoError(t, err)
-	assert.Equal(t, "header.payload.signature", token.AccessToken)
+	assert.Equal(t, "header.payload.signature", authSnapshot.Token.AccessToken)
+	assert.Equal(t, "env-provider", authSnapshot.EnvironmentID)
 }
 
-func TestTokenProviderRefreshesWhenCachedTokenGoesStale(t *testing.T) {
+func TestAuthProviderRefreshesTokenAndEnvironmentTogether(t *testing.T) {
 	t.Parallel()
 
 	calls := 0
@@ -75,31 +80,32 @@ func TestTokenProviderRefreshesWhenCachedTokenGoesStale(t *testing.T) {
 	// ask for, so the next GetJWT must go back to the provider.
 	m, err := newManagerForTest(t, &Inputs{
 		Token: tokenValidFor(30 * time.Second),
-		TokenProvider: func(context.Context) (*serverv1.GetTokenResponse, error) {
+		AuthProvider: func(context.Context) (*AuthSnapshot, error) {
 			calls++
-			return tokenValidFor(time.Hour), nil
+			return authValidFor("env-rotated", time.Hour), nil
 		},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 0, calls, "the supplied token should be used as-is at construction")
 
-	_, err = m.GetJWT(t.Context(), time.Now().Add(time.Minute))
+	authSnapshot, err := m.GetAuth(t.Context(), time.Now().Add(time.Minute))
 
 	// Without the provider this would attempt a credentials exchange with two
 	// empty strings and fail against the api-server.
 	assert.NoError(t, err)
 	assert.Equal(t, 1, calls)
+	assert.Equal(t, "env-rotated", authSnapshot.EnvironmentID)
 }
 
-func TestTokenProviderNotCalledWhileTokenIsFresh(t *testing.T) {
+func TestAuthProviderNotCalledWhileSnapshotIsFresh(t *testing.T) {
 	t.Parallel()
 
 	calls := 0
 	m, err := newManagerForTest(t, &Inputs{
 		Token: tokenValidFor(time.Hour),
-		TokenProvider: func(context.Context) (*serverv1.GetTokenResponse, error) {
+		AuthProvider: func(context.Context) (*AuthSnapshot, error) {
 			calls++
-			return tokenValidFor(time.Hour), nil
+			return authValidFor("env-provider", time.Hour), nil
 		},
 	})
 	require.NoError(t, err)
@@ -112,11 +118,11 @@ func TestTokenProviderNotCalledWhileTokenIsFresh(t *testing.T) {
 	assert.Equal(t, 0, calls, "a fresh token must be served from cache")
 }
 
-func TestTokenProviderErrorIsPropagated(t *testing.T) {
+func TestAuthProviderErrorIsPropagated(t *testing.T) {
 	t.Parallel()
 
 	_, err := newManagerForTest(t, &Inputs{
-		TokenProvider: func(context.Context) (*serverv1.GetTokenResponse, error) {
+		AuthProvider: func(context.Context) (*AuthSnapshot, error) {
 			return nil, assert.AnError
 		},
 	})
@@ -125,39 +131,44 @@ func TestTokenProviderErrorIsPropagated(t *testing.T) {
 	assert.Contains(t, err.Error(), "refreshing pre-issued token")
 }
 
-// TestTokenProviderResultIsValidated covers a callback misbehaving. These are
+// TestAuthProviderResultIsValidated covers a callback misbehaving. These are
 // caller-supplied functions, and each of these returns would otherwise be cached
 // and fail much later -- as a nil dereference in an interceptor, or a bare
 // "Bearer " header, or an endless retry loop.
-func TestTokenProviderResultIsValidated(t *testing.T) {
+func TestAuthProviderResultIsValidated(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
 		name     string
-		returned *serverv1.GetTokenResponse
+		returned *AuthSnapshot
 		expected string
 	}{
 		{
 			name:     "nil token",
 			returned: nil,
-			expected: "token is nil",
+			expected: "auth snapshot is nil",
 		},
 		{
 			name:     "empty access token",
-			returned: &serverv1.GetTokenResponse{ExpiresAt: timestamppb.New(time.Now().Add(time.Hour))},
+			returned: &AuthSnapshot{Token: &serverv1.GetTokenResponse{ExpiresAt: timestamppb.New(time.Now().Add(time.Hour))}, EnvironmentID: "env-provider"},
 			expected: "empty access token",
 		},
 		{
 			// A missing ExpiresAt reads as the Unix epoch, so it lands in the
 			// staleness check rather than needing its own rule.
 			name:     "no expiry",
-			returned: &serverv1.GetTokenResponse{AccessToken: "a.b.c"},
+			returned: &AuthSnapshot{Token: &serverv1.GetTokenResponse{AccessToken: "a.b.c"}, EnvironmentID: "env-provider"},
 			expected: "may no longer be refreshed",
 		},
 		{
 			name:     "already expired",
-			returned: tokenValidFor(-time.Hour),
+			returned: authValidFor("env-provider", -time.Hour),
 			expected: "may no longer be refreshed",
+		},
+		{
+			name:     "empty environment",
+			returned: authValidFor("", time.Hour),
+			expected: "empty environment ID",
 		},
 	}
 
@@ -165,7 +176,7 @@ func TestTokenProviderResultIsValidated(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := newManagerForTest(t, &Inputs{
-				TokenProvider: func(context.Context) (*serverv1.GetTokenResponse, error) {
+				AuthProvider: func(context.Context) (*AuthSnapshot, error) {
 					return tc.returned, nil
 				},
 			})

--- a/auth/token_provider_test.go
+++ b/auth/token_provider_test.go
@@ -1,0 +1,210 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/chalk-ai/chalk-go/config"
+	"github.com/chalk-ai/chalk-go/envfs"
+	serverv1 "github.com/chalk-ai/chalk-go/gen/chalk/server/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// These exercise the TokenProvider path without a network. A provider replaces
+// the client-credentials exchange entirely, so every assertion here would
+// otherwise require a live api-server to disprove.
+
+func tokenValidFor(d time.Duration) *serverv1.GetTokenResponse {
+	return &serverv1.GetTokenResponse{
+		AccessToken: "header.payload.signature",
+		ExpiresAt:   timestamppb.New(time.Now().Add(d)),
+	}
+}
+
+// managerWithoutCredentials builds a config.Manager with no credentials from any
+// source, so anything that works is working via the token or the provider.
+func managerWithoutCredentials(t *testing.T) *config.Manager {
+	t.Helper()
+	emptyDir := t.TempDir()
+	ctx := envfs.ContextWithEnvironmentGetter(t.Context(), envfs.MapEnvironmentGetter{})
+	manager, err := config.NewManager(ctx, &config.ManagerInputs{
+		APIServer:     "https://api.chalk.ai",
+		EnvironmentId: "env-abc",
+		ConfigDir:     &emptyDir,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "", string(manager.ClientId.Value))
+	return manager
+}
+
+func newManagerForTest(t *testing.T, in *Inputs) (*Manager, error) {
+	t.Helper()
+	in.Config = managerWithoutCredentials(t)
+	in.SkipEnvironmentNameMapping = true
+	in.SkipEngineMapping = true
+	return NewManager(t.Context(), in)
+}
+
+func TestTokenProviderSuppliesFirstToken(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	m, err := newManagerForTest(t, &Inputs{
+		TokenProvider: func(context.Context) (*serverv1.GetTokenResponse, error) {
+			calls++
+			return tokenValidFor(time.Hour), nil
+		},
+	})
+
+	// A provider alone is sufficient: no Token and no credentials.
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+	token, err := m.GetJWT(t.Context(), time.Now())
+	assert.NoError(t, err)
+	assert.Equal(t, "header.payload.signature", token.AccessToken)
+}
+
+func TestTokenProviderRefreshesWhenCachedTokenGoesStale(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	// Valid at construction, but not by enough to satisfy the headroom callers
+	// ask for, so the next GetJWT must go back to the provider.
+	m, err := newManagerForTest(t, &Inputs{
+		Token: tokenValidFor(30 * time.Second),
+		TokenProvider: func(context.Context) (*serverv1.GetTokenResponse, error) {
+			calls++
+			return tokenValidFor(time.Hour), nil
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, calls, "the supplied token should be used as-is at construction")
+
+	_, err = m.GetJWT(t.Context(), time.Now().Add(time.Minute))
+
+	// Without the provider this would attempt a credentials exchange with two
+	// empty strings and fail against the api-server.
+	assert.NoError(t, err)
+	assert.Equal(t, 1, calls)
+}
+
+func TestTokenProviderNotCalledWhileTokenIsFresh(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	m, err := newManagerForTest(t, &Inputs{
+		Token: tokenValidFor(time.Hour),
+		TokenProvider: func(context.Context) (*serverv1.GetTokenResponse, error) {
+			calls++
+			return tokenValidFor(time.Hour), nil
+		},
+	})
+	require.NoError(t, err)
+
+	for range 5 {
+		_, err = m.GetJWT(t.Context(), time.Now().Add(time.Minute))
+		assert.NoError(t, err)
+	}
+
+	assert.Equal(t, 0, calls, "a fresh token must be served from cache")
+}
+
+func TestTokenProviderErrorIsPropagated(t *testing.T) {
+	t.Parallel()
+
+	_, err := newManagerForTest(t, &Inputs{
+		TokenProvider: func(context.Context) (*serverv1.GetTokenResponse, error) {
+			return nil, assert.AnError
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refreshing pre-issued token")
+}
+
+// TestTokenProviderResultIsValidated covers a callback misbehaving. These are
+// caller-supplied functions, and each of these returns would otherwise be cached
+// and fail much later -- as a nil dereference in an interceptor, or a bare
+// "Bearer " header, or an endless retry loop.
+func TestTokenProviderResultIsValidated(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		returned *serverv1.GetTokenResponse
+		expected string
+	}{
+		{
+			name:     "nil token",
+			returned: nil,
+			expected: "token is nil",
+		},
+		{
+			name:     "empty access token",
+			returned: &serverv1.GetTokenResponse{ExpiresAt: timestamppb.New(time.Now().Add(time.Hour))},
+			expected: "empty access token",
+		},
+		{
+			// A missing ExpiresAt reads as the Unix epoch, so it lands in the
+			// staleness check rather than needing its own rule.
+			name:     "no expiry",
+			returned: &serverv1.GetTokenResponse{AccessToken: "a.b.c"},
+			expected: "may no longer be refreshed",
+		},
+		{
+			name:     "already expired",
+			returned: tokenValidFor(-time.Hour),
+			expected: "may no longer be refreshed",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := newManagerForTest(t, &Inputs{
+				TokenProvider: func(context.Context) (*serverv1.GetTokenResponse, error) {
+					return tc.returned, nil
+				},
+			})
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.expected)
+		})
+	}
+}
+
+// TestSuppliedTokenIsValidated pins the checks on a caller-supplied Token.
+//
+// Deliberately narrower than the provider path: a missing ExpiresAt is not
+// rejected here, because a Token can be combined with client credentials that
+// pick up the slack, and this repo's own grpc_client_branch_test.go does exactly
+// that. Rejecting it would be a breaking change for a shipped pattern.
+func TestSuppliedTokenIsValidated(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		token    *serverv1.GetTokenResponse
+		expected string
+	}{
+		{
+			name:     "empty access token",
+			token:    &serverv1.GetTokenResponse{ExpiresAt: timestamppb.New(time.Now().Add(time.Hour))},
+			expected: "empty access token",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := newManagerForTest(t, &Inputs{Token: tc.token})
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid pre-issued JWT")
+			assert.Contains(t, err.Error(), tc.expected)
+		})
+	}
+}

--- a/auth_snapshot_client_test.go
+++ b/auth_snapshot_client_test.go
@@ -1,0 +1,113 @@
+package chalk
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/chalk-ai/chalk-go/auth"
+	serverv1 "github.com/chalk-ai/chalk-go/gen/chalk/server/v1"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type authCaptureTransport struct {
+	request *http.Request
+}
+
+func (t *authCaptureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.request = req
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(bytes.NewBufferString(`{}`)),
+		Request:    req,
+	}, nil
+}
+
+func staleAuthToken() *serverv1.GetTokenResponse {
+	return &serverv1.GetTokenResponse{
+		AccessToken: "token-initial",
+		ExpiresAt:   timestamppb.New(time.Now().Add(30 * time.Second)),
+	}
+}
+
+func rotatedAuthProvider(context.Context) (*auth.AuthSnapshot, error) {
+	return &auth.AuthSnapshot{
+		Token: &serverv1.GetTokenResponse{
+			AccessToken: "token-rotated",
+			ExpiresAt:   timestamppb.New(time.Now().Add(time.Hour)),
+		},
+		EnvironmentID: "env-rotated",
+	}, nil
+}
+
+func TestHTTPClientSendsRotatedAuthSnapshot(t *testing.T) {
+	capture := &authCaptureTransport{}
+	client, err := NewClient(t.Context(), &ClientConfig{
+		ApiServer:                  "https://api.chalk.ai",
+		QueryServer:                "https://engine.chalk.ai",
+		EnvironmentId:              "env-initial",
+		JWT:                        staleAuthToken(),
+		AuthProvider:               rotatedAuthProvider,
+		HTTPClient:                 &http.Client{Transport: capture},
+		SkipEnvironmentNameMapping: true,
+		SkipEngineMapping:          true,
+	})
+	require.NoError(t, err)
+
+	impl := client.(*clientImpl)
+	var response map[string]any
+	require.NoError(t, impl.sendRequest(t.Context(), &sendRequestParams{
+		Method:   http.MethodGet,
+		URL:      "https://api.chalk.ai/test",
+		Response: &response,
+	}))
+	require.Equal(t, "Bearer token-rotated", capture.request.Header.Get("Authorization"))
+	require.Equal(t, "env-rotated", capture.request.Header.Get("X-Chalk-Env-Id"))
+}
+
+func TestGRPCClientSendsRotatedAuthSnapshot(t *testing.T) {
+	client, err := NewGRPCClient(t.Context(), &GRPCClientConfig{
+		ApiServer:                  "https://api.chalk.ai",
+		QueryServer:                "https://engine.chalk.ai",
+		EnvironmentId:              "env-initial",
+		JWT:                        staleAuthToken(),
+		AuthProvider:               rotatedAuthProvider,
+		SkipEnvironmentNameMapping: true,
+		SkipEngineMapping:          true,
+	})
+	require.NoError(t, err)
+
+	var captured http.Header
+	next := func(_ context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		captured = req.Header().Clone()
+		return nil, nil
+	}
+	req := connect.NewRequest(&serverv1.GetGraphRequest{})
+	_, err = client.(*grpcClientImpl).engineInterceptor(next)(t.Context(), req)
+	require.NoError(t, err)
+	require.Equal(t, "Bearer token-rotated", captured.Get("Authorization"))
+	require.Equal(t, "env-rotated", captured.Get("x-chalk-env-id"))
+}
+
+func TestVolumeClientSendsRotatedAuthSnapshot(t *testing.T) {
+	client, err := NewVolumeClient(t.Context(), &VolumeClientConfig{
+		ApiServer:                  "https://api.chalk.ai",
+		EnvironmentId:              "env-initial",
+		JWT:                        staleAuthToken(),
+		AuthProvider:               rotatedAuthProvider,
+		SkipEnvironmentNameMapping: true,
+		SkipEngineMapping:          true,
+	})
+	require.NoError(t, err)
+
+	header := http.Header{}
+	require.NoError(t, client.(*volumeClientImpl).addAuthHeaders(t.Context(), header))
+	require.Equal(t, "Bearer token-rotated", header.Get("Authorization"))
+	require.Equal(t, "env-rotated", header.Get("x-chalk-env-id"))
+}

--- a/client.go
+++ b/client.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/apache/arrow/go/v16/arrow/memory"
+	serverv1 "github.com/chalk-ai/chalk-go/gen/chalk/server/v1"
 	"github.com/cockroachdb/errors"
 )
 
@@ -307,6 +308,21 @@ type ClientConfig struct {
 	// Allocator specifies the allocator to use for creating Arrow objects.
 	// Defaults to `memory.DefaultAllocator`.
 	Allocator memory.Allocator
+
+	// JWT is a valid Chalk JWT that can be used to authenticate requests
+	// uncommon to be used, prefer ClientId and ClientSecret instead.
+	JWT *serverv1.GetTokenResponse
+
+	// SkipEnvironmentNameMapping controls whether the TokenManager should
+	// skip validating and mapping environment names to IDs. If true, the
+	// EnvironmentId will be used verbatim without validation against the
+	// token's EnvironmentIdToName map.
+	SkipEnvironmentNameMapping bool
+
+	// SkipEngineMapping controls whether the TokenManager should skip
+	// setting the query server based on the token's engine maps. If true,
+	// the query server will not be automatically resolved from the token.
+	SkipEngineMapping bool
 }
 
 // NewClient creates a Client with authentication settings configured.

--- a/client.go
+++ b/client.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/apache/arrow/go/v16/arrow/memory"
+	"github.com/chalk-ai/chalk-go/auth"
 	serverv1 "github.com/chalk-ai/chalk-go/gen/chalk/server/v1"
 	"github.com/cockroachdb/errors"
 )
@@ -323,6 +324,11 @@ type ClientConfig struct {
 	// setting the query server based on the token's engine maps. If true,
 	// the query server will not be automatically resolved from the token.
 	SkipEngineMapping bool
+	// TokenProvider supplies a JWT whenever the cached one goes stale, instead of
+	// running the client-credentials exchange. Use it when the credential rotates:
+	// a JWT on its own is a one-shot snapshot, so the client stops working the
+	// moment it expires. Sufficient on its own; JWT need not also be set.
+	TokenProvider auth.TokenProvider
 }
 
 // NewClient creates a Client with authentication settings configured.

--- a/client.go
+++ b/client.go
@@ -324,11 +324,11 @@ type ClientConfig struct {
 	// setting the query server based on the token's engine maps. If true,
 	// the query server will not be automatically resolved from the token.
 	SkipEngineMapping bool
-	// TokenProvider supplies a JWT whenever the cached one goes stale, instead of
-	// running the client-credentials exchange. Use it when the credential rotates:
-	// a JWT on its own is a one-shot snapshot, so the client stops working the
-	// moment it expires. Sufficient on its own; JWT need not also be set.
-	TokenProvider auth.TokenProvider
+	// AuthProvider supplies a JWT and effective environment whenever the cached
+	// credential goes stale. Use it when the credential rotates: a JWT on its own
+	// is a one-shot snapshot, so the client stops working the moment it expires.
+	// Sufficient on its own; JWT need not also be set.
+	AuthProvider auth.AuthProvider
 }
 
 // NewClient creates a Client with authentication settings configured.

--- a/client_impl.go
+++ b/client_impl.go
@@ -401,13 +401,14 @@ func (c *clientImpl) saveUrlToDirectory(URL string, directory string) (err error
 }
 
 func (c *clientImpl) GetToken(ctx context.Context) (*TokenResult, error) {
-	res, err := c.tokenManager.GetJWT(ctx, time.Now().Add(1*time.Minute))
+	authSnapshot, err := c.tokenManager.GetAuth(ctx, time.Now().Add(1*time.Minute))
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	res := authSnapshot.Token
 	return &TokenResult{
 		AccessToken:        res.AccessToken,
-		PrimaryEnvironment: c.config.EnvironmentId.Value,
+		PrimaryEnvironment: authSnapshot.EnvironmentID,
 		ValidUntil:         res.ExpiresAt.AsTime(),
 		Engines:            res.Engines,
 	}, nil
@@ -450,12 +451,13 @@ func (c *clientImpl) sendRequest(ctx context.Context, args *sendRequestParams) e
 	headers := c.getHeaders(args.Branch, args.ResourceGroupOverride)
 	request.Header = headers
 
-	token, err := c.tokenManager.GetJWT(ctx, time.Now().Add(1*time.Minute))
+	authSnapshot, err := c.tokenManager.GetAuth(ctx, time.Now().Add(1*time.Minute))
 	if err != nil {
 		return errors.Wrap(err, "getting JWT for request")
 	}
 
-	request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.AccessToken))
+	request.Header.Set("X-Chalk-Env-Id", authSnapshot.EnvironmentID)
+	request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", authSnapshot.Token.AccessToken))
 	if args.Versioned {
 		request.Header.Set("X-Chalk-Features-Versioned", "true")
 	}
@@ -535,12 +537,13 @@ func (c *clientImpl) retryRequest(
 		return nil, err
 	}
 	newRequest.Header = originalRequest.Header
-	token, err := c.tokenManager.GetJWT(ctx, time.Now().Add(1*time.Minute))
+	authSnapshot, err := c.tokenManager.GetAuth(ctx, time.Now().Add(1*time.Minute))
 	if err != nil {
 		return originalResponse, errors.CombineErrors(originalError, err)
 	}
 
-	newRequest.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.AccessToken))
+	newRequest.Header.Set("X-Chalk-Env-Id", authSnapshot.EnvironmentID)
+	newRequest.Header.Set("Authorization", fmt.Sprintf("Bearer %s", authSnapshot.Token.AccessToken))
 	res, err := c.httpClient.Do(newRequest)
 	if err != nil {
 		return nil, err
@@ -642,14 +645,12 @@ func (c *clientImpl) CancelOfflineQuery(ctx context.Context, offlineQueryId stri
 			return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 				req.Header().Set("x-chalk-server", "go-api")
 				req.Header().Set("User-Agent", internal.UserAgent())
-				if envId := c.tokenManager.GetConfig().EnvironmentId.Value; envId != "" {
-					req.Header().Set("x-chalk-env-id", envId)
-				}
-				token, err := c.tokenManager.GetJWT(ctx, time.Now().Add(time.Minute))
+				authSnapshot, err := c.tokenManager.GetAuth(ctx, time.Now().Add(time.Minute))
 				if err != nil {
 					return nil, errors.Wrap(err, "error refreshing token")
 				}
-				req.Header().Set("Authorization", fmt.Sprintf("Bearer %s", token.AccessToken))
+				req.Header().Set("x-chalk-env-id", authSnapshot.EnvironmentID)
+				req.Header().Set("Authorization", fmt.Sprintf("Bearer %s", authSnapshot.Token.AccessToken))
 				return next(ctx, req)
 			}
 		})),
@@ -743,7 +744,7 @@ func newClientImpl(ctx context.Context, cfg *ClientConfig) (*clientImpl, error) 
 		ctx,
 		&auth.Inputs{
 			Token:                      cfg.JWT,
-			TokenProvider:              cfg.TokenProvider,
+			AuthProvider:               cfg.AuthProvider,
 			HttpClient:                 httpClient,
 			Config:                     manager,
 			Timeout:                    timeout,
@@ -767,14 +768,12 @@ func newClientImpl(ctx context.Context, cfg *ClientConfig) (*clientImpl, error) 
 			}
 			req.Header().Set("x-chalk-server", "go-api")
 			req.Header().Set("User-Agent", internal.UserAgent())
-			if envId := tokenManager.GetConfig().EnvironmentId.Value; envId != "" {
-				req.Header().Set("x-chalk-env-id", envId)
-			}
-			token, err := tokenManager.GetJWT(ctx, time.Now().Add(time.Minute))
+			authSnapshot, err := tokenManager.GetAuth(ctx, time.Now().Add(time.Minute))
 			if err != nil {
 				return nil, errors.Wrap(err, "error refreshing token")
 			}
-			req.Header().Set("Authorization", fmt.Sprintf("Bearer %s", token.AccessToken))
+			req.Header().Set("x-chalk-env-id", authSnapshot.EnvironmentID)
+			req.Header().Set("Authorization", fmt.Sprintf("Bearer %s", authSnapshot.Token.AccessToken))
 			return next(ctx, req)
 		}
 	}

--- a/client_impl.go
+++ b/client_impl.go
@@ -743,6 +743,7 @@ func newClientImpl(ctx context.Context, cfg *ClientConfig) (*clientImpl, error) 
 		ctx,
 		&auth.Inputs{
 			Token:                      cfg.JWT,
+			TokenProvider:              cfg.TokenProvider,
 			HttpClient:                 httpClient,
 			Config:                     manager,
 			Timeout:                    timeout,

--- a/client_impl.go
+++ b/client_impl.go
@@ -742,10 +742,12 @@ func newClientImpl(ctx context.Context, cfg *ClientConfig) (*clientImpl, error) 
 	tokenManager, err := auth.NewManager(
 		ctx,
 		&auth.Inputs{
-			Token:      nil,
-			HttpClient: httpClient,
-			Config:     manager,
-			Timeout:    timeout,
+			Token:                      cfg.JWT,
+			HttpClient:                 httpClient,
+			Config:                     manager,
+			Timeout:                    timeout,
+			SkipEnvironmentNameMapping: cfg.SkipEnvironmentNameMapping,
+			SkipEngineMapping:          cfg.SkipEngineMapping,
 		},
 	)
 	if err != nil {

--- a/config/manager.go
+++ b/config/manager.go
@@ -19,6 +19,11 @@ type Manager struct {
 	projectConfigErr error
 }
 
+// ProjectConfigErr is advisory. A non-nil result does not mean the resolved
+// config is unusable -- credentials may have come from a flag or the
+// environment, or a pre-issued JWT may make them unnecessary. It is meaningful
+// only once authentication has found nothing to authenticate with, as the
+// likely explanation for why.
 func (m *Manager) ProjectConfigErr() error {
 	return m.projectConfigErr
 }

--- a/config/manager.go
+++ b/config/manager.go
@@ -2,8 +2,6 @@ package config
 
 import (
 	"context"
-
-	"github.com/cockroachdb/errors"
 )
 
 type Manager struct {
@@ -14,6 +12,15 @@ type Manager struct {
 	ClientSecret    SourcedConfig[ClientSecret]
 	EnvironmentId   SourcedConfig[string]
 	Scope           SourcedConfig[string]
+
+	// projectConfigErr records why chalk.yml could not be read, if it could not.
+	// Resolution proceeds regardless: credentials may come from a flag or the
+	// environment, or a pre-issued JWT may make them unnecessary.
+	projectConfigErr error
+}
+
+func (m *Manager) ProjectConfigErr() error {
+	return m.projectConfigErr
 }
 
 type ManagerInputs struct {
@@ -49,6 +56,10 @@ func (m *Manager) SetJSONQueryServer(server SourcedConfig[string]) {
 }
 
 func NewManager(ctx context.Context, inputs *ManagerInputs) (*Manager, error) {
+	// A failed read is not fatal: credentials may come from a flag or the
+	// environment, or a pre-issued JWT may make them unnecessary entirely. The
+	// error is retained on the Manager so auth can report it if authentication
+	// then turns out to have nothing to use.
 	chalkYamlConfigOrNil, configPath, chalkYamlErr := GetProjectAuthConfig(ctx, inputs.ConfigDir)
 	chalkYamlConfig := ProjectToken{}
 	if chalkYamlConfigOrNil != nil {
@@ -89,17 +100,8 @@ func NewManager(ctx context.Context, inputs *ManagerInputs) (*Manager, error) {
 			NewFromEnvVar[string](ctx, "_CHALK_ACTIVE_ENVIRONMENT"),
 			NewFromFile(configPath, chalkYamlConfig.ActiveEnvironment),
 		),
-		Scope: GetFirstNonEmpty(NewFromArg(inputs.Scope)),
-	}
-
-	if manager.ClientId.Value == "" || manager.ClientSecret.Value == "" {
-		if chalkYamlErr != nil {
-			return nil, errors.Wrap(
-				chalkYamlErr,
-				"could not read chalk.yml and no client ID and client secret were provided",
-			)
-		}
-		return nil, errors.Newf("could not find values for client id and client secret")
+		Scope:            GetFirstNonEmpty(NewFromArg(inputs.Scope)),
+		projectConfigErr: chalkYamlErr,
 	}
 
 	return manager, nil

--- a/config/manager_credentials_test.go
+++ b/config/manager_credentials_test.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/chalk-ai/chalk-go/envfs"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestManagerDoesNotRequireCredentials pins that config resolution succeeds
+// without client credentials.
+//
+// It used to fail outright, which made a pre-issued JWT unusable on its own:
+// resolution runs before auth.NewManager, so it rejected the caller before
+// anything had looked at the token. Only auth.NewManager sees both, so only it
+// can tell whether the caller has a usable credential.
+func TestManagerDoesNotRequireCredentials(t *testing.T) {
+	t.Parallel()
+
+	// An empty directory, so no chalk.yml can supply credentials by accident --
+	// a stray one in the ambient home directory is what masked this originally.
+	emptyDir := t.TempDir()
+	ctx := envfs.ContextWithEnvironmentGetter(t.Context(), envfs.MapEnvironmentGetter{})
+
+	manager, err := NewManager(ctx, &ManagerInputs{ConfigDir: &emptyDir})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, manager)
+	assert.Equal(t, "", string(manager.ClientId.Value))
+	assert.Equal(t, "", string(manager.ClientSecret.Value))
+
+	// The reason credentials are missing is retained rather than discarded, so
+	// auth.NewManager can name the file it searched if nothing else supplies them.
+	assert.Error(t, manager.ProjectConfigErr())
+}
+
+// TestManagerResolvesCredentialsFromEnvironment confirms the credential sources
+// still work, so the check above is not passing merely because resolution broke.
+func TestManagerResolvesCredentialsFromEnvironment(t *testing.T) {
+	t.Parallel()
+
+	ctx := envfs.ContextWithEnvironmentGetter(t.Context(), envfs.MapEnvironmentGetter{
+		Env: map[string]string{
+			"CHALK_CLIENT_ID":     "token-abc",
+			"CHALK_CLIENT_SECRET": "ts-abc",
+		},
+	})
+	emptyDir := t.TempDir()
+
+	manager, err := NewManager(ctx, &ManagerInputs{ConfigDir: &emptyDir})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "token-abc", string(manager.ClientId.Value))
+	assert.Equal(t, "ts-abc", string(manager.ClientSecret.Value))
+}

--- a/grpc_client.go
+++ b/grpc_client.go
@@ -227,11 +227,11 @@ type GRPCClientConfig struct {
 	// setting the query server based on the token's engine maps. If true,
 	// the query server will not be automatically resolved from the token.
 	SkipEngineMapping bool
-	// TokenProvider supplies a JWT whenever the cached one goes stale, instead of
-	// running the client-credentials exchange. Use it when the credential rotates:
-	// a JWT on its own is a one-shot snapshot, so the client stops working the
-	// moment it expires. Sufficient on its own; JWT need not also be set.
-	TokenProvider auth.TokenProvider
+	// AuthProvider supplies a JWT and effective environment whenever the cached
+	// credential goes stale. Use it when the credential rotates: a JWT on its own
+	// is a one-shot snapshot, so the client stops working the moment it expires.
+	// Sufficient on its own; JWT need not also be set.
+	AuthProvider auth.AuthProvider
 }
 
 // NewGRPCClient creates a GRPCClient with authentication settings configured.

--- a/grpc_client.go
+++ b/grpc_client.go
@@ -6,6 +6,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/apache/arrow/go/v16/arrow/memory"
+	"github.com/chalk-ai/chalk-go/auth"
 	aggregatev1 "github.com/chalk-ai/chalk-go/gen/chalk/aggregate/v1"
 	commonv1 "github.com/chalk-ai/chalk-go/gen/chalk/common/v1"
 	serverv1 "github.com/chalk-ai/chalk-go/gen/chalk/server/v1"
@@ -226,6 +227,11 @@ type GRPCClientConfig struct {
 	// setting the query server based on the token's engine maps. If true,
 	// the query server will not be automatically resolved from the token.
 	SkipEngineMapping bool
+	// TokenProvider supplies a JWT whenever the cached one goes stale, instead of
+	// running the client-credentials exchange. Use it when the credential rotates:
+	// a JWT on its own is a one-shot snapshot, so the client stops working the
+	// moment it expires. Sufficient on its own; JWT need not also be set.
+	TokenProvider auth.TokenProvider
 }
 
 // NewGRPCClient creates a GRPCClient with authentication settings configured.

--- a/grpc_client_impl.go
+++ b/grpc_client_impl.go
@@ -124,6 +124,7 @@ func newGrpcClient(ctx context.Context, configs ...*GRPCClientConfig) (*grpcClie
 		ctx,
 		&auth.Inputs{
 			Token:                      cfg.JWT,
+			TokenProvider:              cfg.TokenProvider,
 			HttpClient:                 cfg.HTTPClient,
 			Config:                     configManager,
 			Timeout:                    timeout,

--- a/grpc_client_impl.go
+++ b/grpc_client_impl.go
@@ -124,7 +124,7 @@ func newGrpcClient(ctx context.Context, configs ...*GRPCClientConfig) (*grpcClie
 		ctx,
 		&auth.Inputs{
 			Token:                      cfg.JWT,
-			TokenProvider:              cfg.TokenProvider,
+			AuthProvider:               cfg.AuthProvider,
 			HttpClient:                 cfg.HTTPClient,
 			Config:                     configManager,
 			Timeout:                    timeout,
@@ -201,14 +201,12 @@ func newGrpcClient(ctx context.Context, configs ...*GRPCClientConfig) (*grpcClie
 					req.Header().Set("x-chalk-deployment-tag", cfg.DeploymentTag)
 				}
 
-				if envId := tokenManager.GetConfig().EnvironmentId.Value; envId != "" {
-					req.Header().Set("x-chalk-env-id", envId)
-				}
-				token, err := tokenManager.GetJWT(ctx, time.Now().Add(time.Minute))
+				authSnapshot, err := tokenManager.GetAuth(ctx, time.Now().Add(time.Minute))
 				if err != nil {
 					return nil, errors.Wrap(err, "error refreshing config")
 				}
-				req.Header().Set("Authorization", fmt.Sprintf("Bearer %s", token.AccessToken))
+				req.Header().Set("x-chalk-env-id", authSnapshot.EnvironmentID)
+				req.Header().Set("Authorization", fmt.Sprintf("Bearer %s", authSnapshot.Token.AccessToken))
 				return next(ctx, req)
 			}
 		}
@@ -251,14 +249,12 @@ func newGrpcClient(ctx context.Context, configs ...*GRPCClientConfig) (*grpcClie
 			}
 			req.Header().Set("x-chalk-server", "go-api")
 			req.Header().Set("User-Agent", internal.UserAgent())
-			if envId := tokenManager.GetConfig().EnvironmentId.Value; envId != "" {
-				req.Header().Set("x-chalk-env-id", envId)
-			}
-			token, err := tokenManager.GetJWT(ctx, time.Now().Add(time.Minute))
+			authSnapshot, err := tokenManager.GetAuth(ctx, time.Now().Add(time.Minute))
 			if err != nil {
 				return nil, errors.Wrap(err, "error refreshing config")
 			}
-			req.Header().Set("Authorization", fmt.Sprintf("Bearer %s", token.AccessToken))
+			req.Header().Set("x-chalk-env-id", authSnapshot.EnvironmentID)
+			req.Header().Set("Authorization", fmt.Sprintf("Bearer %s", authSnapshot.Token.AccessToken))
 			return next(ctx, req)
 		}
 	}
@@ -664,15 +660,16 @@ func (c *grpcClientImpl) PlanAggregateBackfill(
 }
 
 func (c *grpcClientImpl) GetToken(ctx context.Context) (*TokenResult, error) {
-	res, err := c.tokenManager.GetJWT(ctx, time.Now().Add(time.Minute))
+	authSnapshot, err := c.tokenManager.GetAuth(ctx, time.Now().Add(time.Minute))
 	if err != nil {
 		return nil, errors.Wrap(err, "getting JWT token")
 	}
+	res := authSnapshot.Token
 
 	return &TokenResult{
 		AccessToken:        res.AccessToken,
 		ValidUntil:         res.ExpiresAt.AsTime(),
-		PrimaryEnvironment: c.config.EnvironmentId.Value,
+		PrimaryEnvironment: authSnapshot.EnvironmentID,
 		Engines:            res.Engines,
 	}, nil
 }

--- a/preissued_jwt_test.go
+++ b/preissued_jwt_test.go
@@ -10,10 +10,14 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// Every client must be constructible from a pre-issued JWT alone, with no client
-// credentials and no readable chalk.yml. That is the whole point of accepting a
-// JWT: the caller has already authenticated and has deliberately not been given
-// a secret.
+// Every client must be constructible from a pre-issued JWT with no client
+// credentials and no readable chalk.yml. That is the point of accepting a JWT:
+// the caller has already authenticated and deliberately has no secret.
+//
+// Note what else is required. A raw pre-issued JWT carries no EnvironmentIdToName
+// or engine maps, so both Skip flags are needed and EnvironmentId must be given
+// explicitly -- the token cannot supply it. So it is "JWT instead of credentials",
+// not "JWT and nothing else".
 //
 // This used to fail for all three clients, because config.NewManager rejected
 // empty credentials before auth.NewManager ever looked at the token. It only

--- a/preissued_jwt_test.go
+++ b/preissued_jwt_test.go
@@ -1,0 +1,132 @@
+package chalk
+
+import (
+	"testing"
+	"time"
+
+	"github.com/chalk-ai/chalk-go/envfs"
+	serverv1 "github.com/chalk-ai/chalk-go/gen/chalk/server/v1"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// Every client must be constructible from a pre-issued JWT alone, with no client
+// credentials and no readable chalk.yml. That is the whole point of accepting a
+// JWT: the caller has already authenticated and has deliberately not been given
+// a secret.
+//
+// This used to fail for all three clients, because config.NewManager rejected
+// empty credentials before auth.NewManager ever looked at the token. It only
+// appeared to work when a chalk.yml happened to exist, so these tests point
+// ConfigDir at an empty directory and inject an empty environment rather than
+// trusting whatever the ambient machine has.
+
+func preIssuedTestJWT() *serverv1.GetTokenResponse {
+	return &serverv1.GetTokenResponse{
+		AccessToken: "header.payload.signature",
+		ExpiresAt:   timestamppb.New(time.Now().Add(time.Hour)),
+	}
+}
+
+func TestClientsAcceptPreIssuedJWTWithoutCredentials(t *testing.T) {
+	t.Parallel()
+
+	t.Run("json client", func(t *testing.T) {
+		t.Parallel()
+		emptyDir := t.TempDir()
+		ctx := envfs.ContextWithEnvironmentGetter(t.Context(), envfs.MapEnvironmentGetter{})
+
+		client, err := NewClient(ctx, &ClientConfig{
+			ApiServer:                  "https://api.chalk.ai",
+			EnvironmentId:              "env-abc",
+			ConfigDir:                  &emptyDir,
+			JWT:                        preIssuedTestJWT(),
+			SkipEnvironmentNameMapping: true,
+			SkipEngineMapping:          true,
+		})
+
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+	})
+
+	t.Run("grpc client", func(t *testing.T) {
+		t.Parallel()
+		emptyDir := t.TempDir()
+		ctx := envfs.ContextWithEnvironmentGetter(t.Context(), envfs.MapEnvironmentGetter{})
+
+		client, err := NewGRPCClient(ctx, &GRPCClientConfig{
+			ApiServer:                  "https://api.chalk.ai",
+			QueryServer:                "https://engine.chalk.ai",
+			EnvironmentId:              "env-abc",
+			ConfigDir:                  &emptyDir,
+			JWT:                        preIssuedTestJWT(),
+			SkipEnvironmentNameMapping: true,
+			SkipEngineMapping:          true,
+		})
+
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+	})
+
+	t.Run("volume client", func(t *testing.T) {
+		t.Parallel()
+		emptyDir := t.TempDir()
+		ctx := envfs.ContextWithEnvironmentGetter(t.Context(), envfs.MapEnvironmentGetter{})
+
+		client, err := NewVolumeClient(ctx, &VolumeClientConfig{
+			ApiServer:                  "https://api.chalk.ai",
+			EnvironmentId:              "env-abc",
+			ConfigDir:                  &emptyDir,
+			JWT:                        preIssuedTestJWT(),
+			SkipEnvironmentNameMapping: true,
+			SkipEngineMapping:          true,
+		})
+
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+	})
+}
+
+// TestClientRejectsNeitherJWTNorCredentials keeps the invariant that removing the
+// config-level check did not remove it altogether -- auth.NewManager still
+// refuses when the caller has nothing usable, and says so clearly.
+func TestClientRejectsNeitherJWTNorCredentials(t *testing.T) {
+	t.Parallel()
+
+	emptyDir := t.TempDir()
+	ctx := envfs.ContextWithEnvironmentGetter(t.Context(), envfs.MapEnvironmentGetter{})
+
+	_, err := NewClient(ctx, &ClientConfig{
+		ApiServer:     "https://api.chalk.ai",
+		EnvironmentId: "env-abc",
+		ConfigDir:     &emptyDir,
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no JWT and no ClientId/ClientSecret provided")
+	// The unreadable chalk.yml is surfaced as the reason they were missing. That
+	// detail used to come from config, which raised the error itself; moving the
+	// check to auth means it now has to cross the package boundary.
+	assert.Contains(t, err.Error(), "auth config file")
+}
+
+// TestClientRejectsPartialCredentials pins that an id without a secret still
+// fails locally. config.NewManager used to catch this with an || check; moving
+// the invariant into auth.NewManager kept the || rather than loosening it to &&,
+// so this does not become a confusing server-side rejection.
+func TestClientRejectsPartialCredentials(t *testing.T) {
+	t.Parallel()
+
+	emptyDir := t.TempDir()
+	ctx := envfs.ContextWithEnvironmentGetter(t.Context(), envfs.MapEnvironmentGetter{})
+
+	_, err := NewClient(ctx, &ClientConfig{
+		ApiServer:     "https://api.chalk.ai",
+		EnvironmentId: "env-abc",
+		ConfigDir:     &emptyDir,
+		ClientId:      "token-abc",
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no JWT and no ClientId/ClientSecret provided")
+}

--- a/volume_client.go
+++ b/volume_client.go
@@ -64,11 +64,11 @@ type VolumeClientConfig struct {
 	SkipEngineMapping          bool
 	CommitAuthor               string
 
-	// TokenProvider supplies a JWT whenever the cached one goes stale, instead of
-	// running the client-credentials exchange. Use it when the credential rotates:
-	// a JWT on its own is a one-shot snapshot, so the client stops working the
-	// moment it expires. Sufficient on its own; JWT need not also be set.
-	TokenProvider auth.TokenProvider
+	// AuthProvider supplies a JWT and effective environment whenever the cached
+	// credential goes stale. Use it when the credential rotates: a JWT on its own
+	// is a one-shot snapshot, so the client stops working the moment it expires.
+	// Sufficient on its own; JWT need not also be set.
+	AuthProvider auth.AuthProvider
 }
 
 // VolumeRef identifies a volume by name or id.
@@ -175,7 +175,6 @@ type volumeClientImpl struct {
 	httpClient   connect.HTTPClient
 	apiServer    string
 	tokenManager *auth.Manager
-	envID        string
 	timeout      *time.Duration
 	author       string
 	authorOnce   sync.Once
@@ -215,7 +214,7 @@ func NewVolumeClient(ctx context.Context, configs ...*VolumeClientConfig) (Volum
 	}
 	tokenManager, err := auth.NewManager(ctx, &auth.Inputs{
 		Token:                      cfg.JWT,
-		TokenProvider:              cfg.TokenProvider,
+		AuthProvider:               cfg.AuthProvider,
 		HttpClient:                 cfg.HTTPClient,
 		Config:                     manager,
 		Timeout:                    timeout,
@@ -226,13 +225,11 @@ func NewVolumeClient(ctx context.Context, configs ...*VolumeClientConfig) (Volum
 		return nil, errors.Wrap(err, "initializing token manager")
 	}
 
-	envID := manager.EnvironmentId.Value
 	apiServer := manager.GetAPIServer().Value
 	client := &volumeClientImpl{
 		httpClient:   cfg.HTTPClient,
 		apiServer:    apiServer,
 		tokenManager: tokenManager,
-		envID:        envID,
 		timeout:      timeout,
 		author:       cfg.CommitAuthor,
 	}
@@ -266,14 +263,12 @@ func (c *volumeClientImpl) authInterceptor() connect.UnaryInterceptorFunc {
 func (c *volumeClientImpl) addAuthHeaders(ctx context.Context, header http.Header) error {
 	header.Set("x-chalk-server", "go-api")
 	header.Set("User-Agent", internal.UserAgent())
-	if c.envID != "" {
-		header.Set("x-chalk-env-id", c.envID)
-	}
-	token, err := c.tokenManager.GetJWT(ctx, time.Now().Add(time.Minute))
+	authSnapshot, err := c.tokenManager.GetAuth(ctx, time.Now().Add(time.Minute))
 	if err != nil {
 		return err
 	}
-	header.Set("Authorization", fmt.Sprintf("Bearer %s", token.AccessToken))
+	header.Set("x-chalk-env-id", authSnapshot.EnvironmentID)
+	header.Set("Authorization", fmt.Sprintf("Bearer %s", authSnapshot.Token.AccessToken))
 	return nil
 }
 
@@ -770,7 +765,10 @@ func (c *volumeClientImpl) resolveCommitAuthor(ctx context.Context) string {
 		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 			return
 		}
-		envID := c.envID
+		// Use the environment that authenticated this exact who-am-i request.
+		// Resolving auth again here could observe a rotation and pair the response
+		// user with an environment that was not actually sent.
+		envID := req.Header.Get("x-chalk-env-id")
 		if envID == "" {
 			envID = body.EnvironmentID
 		}

--- a/volume_client.go
+++ b/volume_client.go
@@ -62,7 +62,13 @@ type VolumeClientConfig struct {
 	Timeout                    time.Duration
 	SkipEnvironmentNameMapping bool
 	SkipEngineMapping          bool
-	CommitAuthor               string
+
+	// TokenProvider supplies a JWT whenever the cached one goes stale, instead of
+	// running the client-credentials exchange. Use it when the credential rotates:
+	// a JWT on its own is a one-shot snapshot, so the client stops working the
+	// moment it expires. Sufficient on its own; JWT need not also be set.
+	TokenProvider auth.TokenProvider
+	CommitAuthor  string
 }
 
 // VolumeRef identifies a volume by name or id.
@@ -209,6 +215,7 @@ func NewVolumeClient(ctx context.Context, configs ...*VolumeClientConfig) (Volum
 	}
 	tokenManager, err := auth.NewManager(ctx, &auth.Inputs{
 		Token:                      cfg.JWT,
+		TokenProvider:              cfg.TokenProvider,
 		HttpClient:                 cfg.HTTPClient,
 		Config:                     manager,
 		Timeout:                    timeout,

--- a/volume_client.go
+++ b/volume_client.go
@@ -62,13 +62,13 @@ type VolumeClientConfig struct {
 	Timeout                    time.Duration
 	SkipEnvironmentNameMapping bool
 	SkipEngineMapping          bool
+	CommitAuthor               string
 
 	// TokenProvider supplies a JWT whenever the cached one goes stale, instead of
 	// running the client-credentials exchange. Use it when the credential rotates:
 	// a JWT on its own is a one-shot snapshot, so the client stops working the
 	// moment it expires. Sufficient on its own; JWT need not also be set.
 	TokenProvider auth.TokenProvider
-	CommitAuthor  string
 }
 
 // VolumeRef identifies a volume by name or id.

--- a/volume_test.go
+++ b/volume_test.go
@@ -795,18 +795,16 @@ func TestVolumeResolveCommitAuthorInvalidJSON(t *testing.T) {
 	require.Empty(t, client.(*volumeClientImpl).resolveCommitAuthor(context.Background()))
 }
 
-func TestVolumeResolveCommitAuthorUsesBodyEnvID(t *testing.T) {
+func TestVolumeResolveCommitAuthorUsesAuthEnvironment(t *testing.T) {
 	t.Parallel()
 	_, url := testHTTPServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"user":"bob","environment_id":"env-from-body"}`))
 	})
-	// Create a client normally, then clear envID so the body's environment_id is used.
 	client := newClientWithServer(t, url)
 	impl := client.(*volumeClientImpl)
-	impl.envID = ""
 	author := impl.resolveCommitAuthor(context.Background())
-	require.Equal(t, "chalk:env-from-body:agent:bob", author)
+	require.Equal(t, "chalk:env-test:agent:bob", author)
 }
 
 func TestVolumeDownloadGetFileError(t *testing.T) {


### PR DESCRIPTION
## Problem

`config.NewManager` rejects any construction where either the client id or secret is empty. It runs *before* `auth.NewManager`, which is the only place that looks at a pre-issued JWT — so the JWT never gets considered, and a caller holding a perfectly valid token is turned away.

Reproduced from the Chalk CLI with `~/.chalk.yml` hidden, passing a valid JWT and no credentials:

```
Failed to initialize Chalk GRPC Client: getting resolved config:
could not read chalk.yml and no client ID and client secret were provided
```

The `getting resolved config:` prefix is the tell — that is `grpc_client_impl.go` wrapping the *config* error, confirming `auth.NewManager` was never reached.

This affects every client. It only appears to work when a `chalk.yml` with credentials happens to exist, which masked it: the CLI's `--access-token` support has been shipping in this state, silently relying on ambient credentials being present.

## Changes

**Removed the credential check from `config.NewManager`.** It was redundant with the check already in `auth.NewManager`, and wrong in principle: `config` cannot see a JWT, so it cannot judge whether the caller has a usable credential. The invariant now lives solely where both facts are visible.

Two details preserved:

- The surviving check in `auth.NewManager` was tightened from `&&` to `||`, so supplying an id without a secret still fails locally rather than becoming a confusing server-side rejection.
- The "chalk.yml could not be read" diagnostic, which previously named the searched path, now travels via `Manager.ProjectConfigErr()`. Without it the error would no longer say *where* credentials were looked for, which is the actual diagnosis for someone who believes they are logged in.

**Gave `ClientConfig` the same pre-issued token fields the other configs already have** — `JWT`, `SkipEnvironmentNameMapping`, `SkipEngineMapping` — and passed them through in `client_impl.go`, which hardcoded `Token: nil`. All three clients already build the same `auth.Manager` from the same `auth.Inputs`, so the machinery was there; the JSON client simply never wired it.

## Tests

Six new tests. All three clients construct from a JWT alone, with no credentials and no readable `chalk.yml`; the neither-credential and partial-credential cases still fail. They point `ConfigDir` at an empty directory and inject an empty environment, since a stray `~/.chalk.yml` is exactly what hid this.

I verified they detect the bug rather than passing vacuously: with the old check temporarily restored, the gRPC and JSON subtests fail with the credential error.

## Reviewer notes

Removing the config-level check widens behaviour for all consumers, not just the CLI. The failure still occurs, but it now originates in `auth` with different wrapping — anything string-matching `could not find values for client id and client secret` would need updating. Nothing in this repo does; I have not audited chalkpy or the terraform provider.

Separately, and not addressed here: `Manager.GetJWT` re-runs the exchange once a token expires, so a client built with a pre-issued token becomes unusable at expiry rather than re-reading its source. That matters for short-lived rotating tokens and is worth a follow-up.