### PR TITLE
Update protos: QueryLogEntry.multi_query_id

### DIFF
--- a/gen/chalk/engine/v2/query_log.pb.go
+++ b/gen/chalk/engine/v2/query_log.pb.go
@@ -361,8 +361,10 @@ type QueryLogEntry struct {
 	QueryPlanId         string                 `protobuf:"bytes,15,opt,name=query_plan_id,json=queryPlanId,proto3" json:"query_plan_id,omitempty"`
 	ValueTables         []string               `protobuf:"bytes,16,rep,name=value_tables,json=valueTables,proto3" json:"value_tables,omitempty"`
 	MetaQueryHash       string                 `protobuf:"bytes,17,opt,name=meta_query_hash,json=metaQueryHash,proto3" json:"meta_query_hash,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// Shared by every sub-query of one multi-query request. Empty for single queries.
+	MultiQueryId  string `protobuf:"bytes,18,opt,name=multi_query_id,json=multiQueryId,proto3" json:"multi_query_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *QueryLogEntry) Reset() {
@@ -514,6 +516,13 @@ func (x *QueryLogEntry) GetMetaQueryHash() string {
 	return ""
 }
 
+func (x *QueryLogEntry) GetMultiQueryId() string {
+	if x != nil {
+		return x.MultiQueryId
+	}
+	return ""
+}
+
 type GetQueryLogEntriesResponse struct {
 	state   protoimpl.MessageState `protogen:"open.v1"`
 	Entries []*QueryLogEntry       `protobuf:"bytes,1,rep,name=entries,proto3" json:"entries,omitempty"`
@@ -602,7 +611,7 @@ const file_chalk_engine_v2_query_log_proto_rawDesc = "" +
 	"\tpage_size\x18\x04 \x01(\x05R\bpageSize\x12\x1d\n" +
 	"\n" +
 	"page_token\x18\x05 \x01(\tR\tpageTokenB(\n" +
-	"&_query_timestamp_upper_bound_exclusive\"\xa3\x06\n" +
+	"&_query_timestamp_upper_bound_exclusive\"\xc9\x06\n" +
 	"\rQueryLogEntry\x12!\n" +
 	"\foperation_id\x18\x01 \x01(\tR\voperationId\x12%\n" +
 	"\x0eenvironment_id\x18\x02 \x01(\tR\renvironmentId\x12#\n" +
@@ -623,7 +632,8 @@ const file_chalk_engine_v2_query_log_proto_rawDesc = "" +
 	"\btrace_id\x18\x0e \x01(\tR\atraceId\x12\"\n" +
 	"\rquery_plan_id\x18\x0f \x01(\tR\vqueryPlanId\x12!\n" +
 	"\fvalue_tables\x18\x10 \x03(\tR\vvalueTables\x12&\n" +
-	"\x0fmeta_query_hash\x18\x11 \x01(\tR\rmetaQueryHash\"~\n" +
+	"\x0fmeta_query_hash\x18\x11 \x01(\tR\rmetaQueryHash\x12$\n" +
+	"\x0emulti_query_id\x18\x12 \x01(\tR\fmultiQueryId\"~\n" +
 	"\x1aGetQueryLogEntriesResponse\x128\n" +
 	"\aentries\x18\x01 \x03(\v2\x1e.chalk.engine.v2.QueryLogEntryR\aentries\x12&\n" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageTokenB\xbd\x01\n" +


### PR DESCRIPTION
Regenerates `chalk/engine/v2/query_log.pb.go` for `QueryLogEntry.multi_query_id`
(proto field 18).

`bigquery-streaming-write-loader` consumes `chalk-go/gen` as a published module with no
`replace` directive, so it cannot compile against that field until this is merged and
tagged.

Scoped to the one generated file on purpose. A full `generate.sh go` also sweeps in drift
that has accumulated since the last regen — including `[deprecated = true]` markers on
`expression.proto` and `datasets.proto` that chalk-go's own code still uses, which fails
the `build` job's staticcheck. That cleanup is real but unrelated to this field, so it is
left for a separate change.

**Do not merge before chalk-private #40699**, which is where the proto change itself lands.
Merging first would put a field in `gen/` that the canonical proto does not yet declare.

After merge this needs a `gen/vX.Y.Z` tag (next after `gen/v1.2.298`) before anything can
depend on it.
