### PR TITLE
Fix SA1019 findings from staticcheck 2026.2

### DIFF
--- a/examples/redeploy_deployment.go
+++ b/examples/redeploy_deployment.go
@@ -28,7 +28,6 @@ func redeployDeployment() {
 	// Create a redeploy request
 	req := &serverv1.RedeployDeploymentRequest{
 		ExistingDeploymentId: "your-deployment-id", // Replace with actual deployment ID
-		EnableProfiling:      false,
 		DeploymentTags:       []string{"production", "v2"},
 		// Pin the engine platform version (a tag/digest selector applied to the default
 		// engine base image). Mutually exclusive with BaseImageOverride — setting both

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -679,6 +679,7 @@ func (hm *HasManyFeatureBuilder) WithMaxStaleness(d time.Duration) *HasManyFeatu
 func toFilterParsedColumnProto(relation string, name string) *expressionv1.LogicalExprNode {
 	return &expressionv1.LogicalExprNode{
 		ExprType: &expressionv1.LogicalExprNode_Column{
+			//lint:ignore SA1019 FilterParsed is the legacy expr_type oneof by definition; expr/ has the modern path
 			Column: &expressionv1.Column{
 				Name: name,
 				Relation: &expressionv1.ColumnRelation{
@@ -692,6 +693,7 @@ func toFilterParsedColumnProto(relation string, name string) *expressionv1.Logic
 func toFilterParsedBinaryProto(op string, operands []*expressionv1.LogicalExprNode) *expressionv1.LogicalExprNode {
 	return &expressionv1.LogicalExprNode{
 		ExprType: &expressionv1.LogicalExprNode_BinaryExpr{
+			//lint:ignore SA1019 ditto
 			BinaryExpr: &expressionv1.BinaryExprNode{
 				Op:       op,
 				Operands: operands,
@@ -718,6 +720,7 @@ func toFilterParsedProto(expression expr.ExprI, foreignNamespace string) (*expre
 	case *expr.LiteralExpr:
 		return &expressionv1.LogicalExprNode{
 			ExprType: &expressionv1.LogicalExprNode_Literal{
+				//lint:ignore SA1019 ditto
 				Literal: e.ScalarValue,
 			},
 		}, nil

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -679,7 +679,7 @@ func (hm *HasManyFeatureBuilder) WithMaxStaleness(d time.Duration) *HasManyFeatu
 func toFilterParsedColumnProto(relation string, name string) *expressionv1.LogicalExprNode {
 	return &expressionv1.LogicalExprNode{
 		ExprType: &expressionv1.LogicalExprNode_Column{
-			//lint:ignore SA1019 FilterParsed is the legacy expr_type oneof by definition; expr/ has the modern path
+			//lint:ignore SA1019 toFilterParsedProto deliberately emits the legacy expr_type oneof; expr/ holds the modern expr_form path
 			Column: &expressionv1.Column{
 				Name: name,
 				Relation: &expressionv1.ColumnRelation{
@@ -693,7 +693,7 @@ func toFilterParsedColumnProto(relation string, name string) *expressionv1.Logic
 func toFilterParsedBinaryProto(op string, operands []*expressionv1.LogicalExprNode) *expressionv1.LogicalExprNode {
 	return &expressionv1.LogicalExprNode{
 		ExprType: &expressionv1.LogicalExprNode_BinaryExpr{
-			//lint:ignore SA1019 ditto
+			//lint:ignore SA1019 legacy expr_type; the has-one join parser above reads this same BinaryExpr form back
 			BinaryExpr: &expressionv1.BinaryExprNode{
 				Op:       op,
 				Operands: operands,
@@ -720,7 +720,7 @@ func toFilterParsedProto(expression expr.ExprI, foreignNamespace string) (*expre
 	case *expr.LiteralExpr:
 		return &expressionv1.LogicalExprNode{
 			ExprType: &expressionv1.LogicalExprNode_Literal{
-				//lint:ignore SA1019 ditto
+				//lint:ignore SA1019 legacy expr_type, to match the Column and BinaryExpr nodes it is combined with
 				Literal: e.ScalarValue,
 			},
 		}, nil

--- a/graph/windowed.go
+++ b/graph/windowed.go
@@ -333,6 +333,7 @@ func (w *WindowedFeatureBuilder) appendFeatures(features []*graphv1.FeatureType,
 			Aggregation: &graphv1.WindowAggregation{
 				Namespace:   parsedAgg.foreignNamespace,
 				Aggregation: aggPtr.Function,
+				//lint:ignore SA1019 aggregate_on_features supersedes this, but deployed engines still read aggregate_on
 				AggregateOn: parsedAgg.aggregateOn,
 				Filters:     parsedAgg.filters,
 				ArrowType:   scalarPtr.proto.ArrowType,

--- a/serializers.go
+++ b/serializers.go
@@ -572,7 +572,8 @@ func convertOnlineQueryParamsToProto(params *OnlineQueryParams, allocator memory
 		Staleness: staleness,
 		Now:       now,
 		Context: &commonv1.OnlineQueryContext{
-			Tags:                 params.Tags,
+			Tags: params.Tags,
+			//lint:ignore SA1019 the x-chalk-branch-id header is authoritative; kept for servers that still read the context field
 			BranchId:             params.BranchId,
 			CorrelationId:        ptr.OrNil(params.CorrelationId),
 			QueryName:            ptr.OrNil(params.QueryName),


### PR DESCRIPTION
staticcheck 2026.2 (released 2026-08-20) extended SA1019 to cover deprecated fields used
in **struct initializers**. Six pre-existing call sites hit the new case, which fails the
`build` job on every open PR — `#722` and `#723` are both blocked on it. The workflow pins
`version: "latest"`, so no commit was involved; main's last `build` ran the day before the
release and is stale, not green on merit.

Five of the six are deliberate use of the legacy proto representation and take
`//lint:ignore`, matching the convention already used five times in `graph.go`:

- `graph/graph.go` (x3) — `toFilterParsedProto` exists to emit the legacy `expr_type` oneof;
  `expr/` holds the modern `expr_form` path. chalk-go also reads this form back, so migrating
  would change the wire contract on both sides.
- `graph/windowed.go` — `aggregate_on_features` supersedes `aggregate_on`, but deployed
  engines still read the latter.
- `serializers.go` — the `x-chalk-branch-id` header is authoritative and set independently;
  the context field is kept for servers that still read it.

The sixth, `examples/redeploy_deployment.go`, set a deprecated field to its zero value, so
it is removed outright.

Verified locally with staticcheck 2026.2: clean on the root and `gen` modules, `go build`
clean, unit tests pass. Integration tests not run — they need a live environment, and are
red on main independently.
