### PR TITLE
Fix Dataset.Wait hanging when a shard never reports

### DIFF
--- a/dataset_wait_test.go
+++ b/dataset_wait_test.go
@@ -166,3 +166,100 @@ func TestDatasetWaitAlreadyFinished(t *testing.T) {
 
 	assert.NoError(t, dataset.Wait(context.Background()))
 }
+
+func TestDatasetWaitTimesOutWhenShardNeverReports(t *testing.T) {
+	t.Parallel()
+	// The status route answers 200 with a null report for a shard that has not
+	// published one yet, which decodes to a zero-value BatchReport rather than
+	// an error. Wait must not treat that as a received report, or it would
+	// refresh the report deadline on every poll and never terminate.
+	polls := 0
+	client := &mockWaitClient{
+		getStatus: func(ctx context.Context, args GetOfflineQueryStatusParams) (GetOfflineQueryStatusResult, error) {
+			polls++
+			if args.ComputerId == 0 {
+				return GetOfflineQueryStatusResult{Report: BatchReport{Status: "COMPLETED"}}, nil
+			}
+			return GetOfflineQueryStatusResult{}, nil
+		},
+	}
+	dataset := waitTestDataset(client, 2, 0)
+	dataset.waitReportTimeout = 2 * datasetWaitPollInterval
+
+	err := dataset.Wait(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out waiting")
+	assert.Contains(t, err.Error(), "shard 2 of 2")
+	assert.Contains(t, err.Error(), "never reported a status")
+	assert.False(t, dataset.IsFinished)
+	// Bounded, not spinning forever: one poll for shard 0 plus a handful for
+	// shard 1 before the deadline passes.
+	assert.Less(t, polls, 10)
+}
+
+func TestDatasetWaitTimesOutOnPersistentPollError(t *testing.T) {
+	t.Parallel()
+	// A poll error that never clears must surface the underlying cause rather
+	// than being swallowed. errors.Wrapf returns nil for a nil cause, so the
+	// timeout error has to be built without a cause when polling never failed
+	// and with one when it did.
+	client := &mockWaitClient{
+		getStatus: func(ctx context.Context, args GetOfflineQueryStatusParams) (GetOfflineQueryStatusResult, error) {
+			return GetOfflineQueryStatusResult{}, errors.New("connection refused")
+		},
+	}
+	dataset := waitTestDataset(client, 1, 0)
+	dataset.waitReportTimeout = 2 * datasetWaitPollInterval
+
+	err := dataset.Wait(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out waiting")
+	assert.Contains(t, err.Error(), "connection refused")
+	assert.False(t, dataset.IsFinished)
+}
+
+func TestDatasetWaitReportDeadlineResetsOnNonTerminalReports(t *testing.T) {
+	t.Parallel()
+	// The deadline bounds the gap between reports, not the total wait, so a
+	// shard that keeps reporting a non-terminal status must not time out even
+	// though it runs well past the report timeout.
+	polls := 0
+	client := &mockWaitClient{
+		getStatus: func(ctx context.Context, args GetOfflineQueryStatusParams) (GetOfflineQueryStatusResult, error) {
+			polls++
+			if polls < 6 {
+				return GetOfflineQueryStatusResult{Report: BatchReport{Status: "COMPUTE_STARTED"}}, nil
+			}
+			return GetOfflineQueryStatusResult{Report: BatchReport{Status: "COMPLETED"}}, nil
+		},
+	}
+	dataset := waitTestDataset(client, 1, 0)
+	dataset.waitReportTimeout = 2 * datasetWaitPollInterval
+
+	assert.NoError(t, dataset.Wait(context.Background()))
+	assert.True(t, dataset.IsFinished)
+	assert.Equal(t, 6, polls)
+}
+
+func TestDatasetWaitNullReportBeforeShardStarts(t *testing.T) {
+	t.Parallel()
+	// The common healthy case: a shard's report row does not exist for the
+	// first few polls, then appears and completes. Wait should ride through the
+	// null reports without erroring.
+	polls := 0
+	client := &mockWaitClient{
+		getStatus: func(ctx context.Context, args GetOfflineQueryStatusParams) (GetOfflineQueryStatusResult, error) {
+			polls++
+			if polls < 3 {
+				return GetOfflineQueryStatusResult{}, nil
+			}
+			return GetOfflineQueryStatusResult{Report: BatchReport{Status: "COMPLETED"}}, nil
+		},
+	}
+	dataset := waitTestDataset(client, 1, 0)
+	dataset.waitReportTimeout = 10 * datasetWaitPollInterval
+
+	assert.NoError(t, dataset.Wait(context.Background()))
+	assert.True(t, dataset.IsFinished)
+	assert.Equal(t, 3, polls)
+}

--- a/models.go
+++ b/models.go
@@ -787,6 +787,10 @@ type Dataset struct {
 	// waitErr records the terminal failure observed by Wait so that
 	// subsequent Wait calls report it instead of re-polling.
 	waitErr error `json:"-"`
+
+	// waitReportTimeout overrides datasetWaitReportTimeout in Wait. Zero means
+	// use the default. Only set in tests.
+	waitReportTimeout time.Duration `json:"-"`
 }
 
 type DatasetRevision struct {
@@ -857,10 +861,37 @@ const (
 
 	// datasetWaitReportTimeout is how long Wait tolerates not receiving a
 	// status report before giving up, matching the Python client's
-	// default_status_report_timeout. Transient polling errors are tolerated
-	// until this deadline; it resets each time a report is received.
+	// default_status_report_timeout. Transient polling errors and shards that
+	// have not published a report yet are tolerated until this deadline; it
+	// resets each time a report is received.
 	datasetWaitReportTimeout = 10 * time.Minute
 )
+
+// newDatasetWaitReportTimeoutError builds the error Wait returns when a shard
+// stops producing status reports. lastPollErr is the most recent polling
+// failure, if any: it is nil when the server was reachable the whole time and
+// simply never had a report for the shard, so it cannot be handed to
+// errors.Wrapf, which returns nil for a nil cause.
+func newDatasetWaitReportTimeoutError(
+	lastPollErr error,
+	reportTimeout time.Duration,
+	revisionId string,
+	shardId int,
+	numShards int,
+) error {
+	if lastPollErr != nil {
+		return errors.Wrapf(
+			lastPollErr,
+			"timed out waiting %s for a status report for offline query %q (shard %d of %d)",
+			reportTimeout, revisionId, shardId+1, numShards,
+		)
+	}
+	return errors.Newf(
+		"timed out waiting %s for a status report for offline query %q (shard %d of %d): "+
+			"the server never reported a status for this shard",
+		reportTimeout, revisionId, shardId+1, numShards,
+	)
+}
 
 // Wait polls the offline query status until the job is complete.
 // It returns an error if the job fails or if there's an error polling the status.
@@ -903,32 +934,40 @@ func (d *Dataset) Wait(ctx context.Context) error {
 		numShards = 1
 	}
 
+	reportTimeout := d.waitReportTimeout
+	if reportTimeout <= 0 {
+		reportTimeout = datasetWaitReportTimeout
+	}
+
 	var lastPollErr error
-	mustReceiveNextReportBy := time.Now().Add(datasetWaitReportTimeout)
+	mustReceiveNextReportBy := time.Now().Add(reportTimeout)
 
 	for shardId := 0; shardId < numShards; {
 		jobStatus, err := d.client.GetOfflineQueryStatus(ctx, GetOfflineQueryStatusParams{
 			JobId:      revision.RevisionId,
 			ComputerId: shardId,
 		})
+
+		// A shard that has not published a report yet is not an HTTP error: the
+		// status route responds 200 with a null report until the shard's report
+		// row exists, which decodes to a zero-value BatchReport. Both that and a
+		// transient polling failure mean "no report this time around", and both
+		// are tolerated only until the report deadline, so a shard that never
+		// reports surfaces as an error instead of polling forever. This mirrors
+		// the Python client, which skips a `None` report without extending its
+		// deadline and raises TimeoutError once the deadline passes.
 		if err != nil {
-			// A report may not exist yet (e.g. the shard hasn't started), and
-			// polling can fail transiently; keep polling until the report
-			// timeout elapses.
 			lastPollErr = err
+		}
+		if err != nil || !jobStatus.Report.exists() {
 			if time.Now().After(mustReceiveNextReportBy) {
-				return errors.Wrapf(
-					lastPollErr,
-					"timed out waiting %s for a status report for offline query %q (shard %d of %d)",
-					datasetWaitReportTimeout,
-					revision.RevisionId,
-					shardId+1,
-					numShards,
+				return newDatasetWaitReportTimeoutError(
+					lastPollErr, reportTimeout, revision.RevisionId, shardId, numShards,
 				)
 			}
 		} else {
 			lastPollErr = nil
-			mustReceiveNextReportBy = time.Now().Add(datasetWaitReportTimeout)
+			mustReceiveNextReportBy = time.Now().Add(reportTimeout)
 
 			switch jobStatus.Report.Status {
 			case "COMPLETED":
@@ -1200,6 +1239,18 @@ type BatchReport struct {
 	AllErrors         []ServerError      `json:"all_errors,omitempty"`
 	OperationMetadata *map[string]string `json:"operation_metadata,omitempty"`
 	ComputerID        *int               `json:"computer_id,omitempty"`
+}
+
+// exists reports whether the server actually had a status report to return.
+//
+// The offline query status route answers 200 with a null report — not a 404 —
+// for a shard that has not published one yet, and a null report decodes into a
+// zero-value BatchReport. Status is the discriminator: the server always
+// populates it from the stored report row, and no valid status is the empty
+// string, so an empty Status means there was no report rather than a report
+// whose status happens to be unset.
+func (r BatchReport) exists() bool {
+	return r.Status != ""
 }
 
 // GetOfflineQueryStatusResult holds the result of a get offline query status request.


### PR DESCRIPTION
Stacked on #728.

## Problem

The report timeout that #728 added only ever fires on a transport-level polling failure. That is not how the server signals "this shard has not reported yet".

`GET /v4/offline_query/{id}/status[/{computer_id}]` returns **200 with a null report** — not a 404 — when the shard's report row does not exist. In `chalk-private`:

- `server/server/dataset/batch_report.py:18` — `get_batch_report` returns `None` for a missing row
- `server/server/query/router.py:938-944` — the route wraps that in `BatchReportResponse(report=None)`

Because `GetOfflineQueryStatusResult.Report` is a value type, `{"report": null}` decodes into a zero-value `BatchReport` with **no error**. So `Wait` took the success path:

```go
lastPollErr = nil
mustReceiveNextReportBy = time.Now().Add(datasetWaitReportTimeout)  // refreshed every poll
switch jobStatus.Report.Status {                                    // "" - matches neither case
```

A shard whose report row is never written made `Wait` poll every 500ms **forever**, bounded only by the caller's context.

## Parity

chalkpy gets this right, so this was a genuine gap rather than a shared quirk. `ProgressService.poll_report` (`chalk/_reporting/progress.py`):

```python
batch_report = retry_call(lambda: self.client.get_batch_report(...))
if batch_report is not None:            # None == no report row yet
    if timeout is not None:
        must_receive_next_report_by = datetime.now() + timeout   # reset only here
    yield batch_report
```

and the enclosing `while datetime.now() < must_receive_next_report_by` raises `TimeoutError` once the deadline passes.

## Fix

- Treat a null report exactly like a transient poll failure: keep polling, but only until the report deadline.
- Check the deadline on **every** iteration, not just when the request errored. As written, a persistent null report with a stale earlier error was only caught by luck.
- `BatchReport.exists()` uses `Status` as the discriminator. The server always populates it from the stored row, and no valid `BatchOpStatus` is the empty string, so empty means "no report" rather than "report with unset status".
- The timeout error is built by a helper because `errors.Wrapf` returns `nil` for a `nil` cause, and `lastPollErr` is legitimately `nil` when the server was reachable the whole time and simply never had a report. Without the helper this path returned a `nil` error — a silent success.

## Tests

`Wait`'s report timeout is injectable via an unexported field so the timeout paths are testable without a ten-minute test.

- `TestDatasetWaitTimesOutWhenShardNeverReports` — shard 0 completes, shard 1 returns a null report forever. **Without this fix this test hangs until the test deadline**; verified by reverting just the `exists()` check.
- `TestDatasetWaitTimesOutOnPersistentPollError` — asserts the underlying cause survives into the error, covering the `errors.Wrapf(nil, ...)` trap.
- `TestDatasetWaitReportDeadlineResetsOnNonTerminalReports` — the deadline bounds the gap between reports, not the total wait, so a shard reporting `COMPUTE_STARTED` past the timeout must not fail.
- `TestDatasetWaitNullReportBeforeShardStarts` — the healthy case: a few null reports before the row appears, then completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)