### PR TITLE
Bring dataset completion and download to chalkpy parity

### DIFF
--- a/client_impl.go
+++ b/client_impl.go
@@ -426,24 +426,102 @@ func (c *clientImpl) GetRunStatus(ctx context.Context, request GetRunStatusParam
 	return response, errors.Wrap(err, "getting run status")
 }
 
-func (c *clientImpl) getDatasetUrls(ctx context.Context, RevisionId string) ([]string, error) {
-	response := GetOfflineQueryJobResponse{}
-	for !response.IsFinished {
-		err := c.sendRequest(
+func (c *clientImpl) getDatasetUrls(ctx context.Context, revisionId string) ([]string, error) {
+	for {
+		// A fresh response each iteration: reusing one lets fields from an
+		// earlier poll survive into the result if a later response omits them.
+		response := GetOfflineQueryJobResponse{}
+		if err := c.sendRequest(
 			ctx,
 			&sendRequestParams{
 				Method:   "GET",
-				URL:      fmt.Sprintf("v2/offline_query/%s", RevisionId),
+				URL:      fmt.Sprintf("v2/offline_query/%s", revisionId),
 				Response: &response,
 			},
-		)
-		if err != nil {
-			return []string{}, errors.Wrap(err, "getting dataset urls")
+		); err != nil {
+			return nil, errors.Wrap(err, "getting dataset urls")
 		}
-		time.Sleep(500 * time.Millisecond)
+
+		if response.IsFinished {
+			// is_finished means the revision reached a terminal status, which
+			// includes ERROR, CANCELLED and EXPIRED as well as SUCCESSFUL. For
+			// those the server returns an empty url list plus an explanatory
+			// error, so returning response.Urls unconditionally would hand the
+			// caller zero urls and a nil error.
+			if len(response.Errors) > 0 {
+				return nil, errors.Wrapf(
+					ServerErrors(response.Errors),
+					"offline query %q did not produce a dataset",
+					revisionId,
+				)
+			}
+			return response.Urls, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(datasetWaitPollInterval):
+		}
+	}
+}
+
+// datasetJobStatusRequest is the body of POST v4/offline_query/status. It
+// mirrors the Python client's DatasetJobStatusRequest.
+type datasetJobStatusRequest struct {
+	JobId            string `json:"job_id"`
+	IgnoreErrors     bool   `json:"ignore_errors"`
+	SkipFailedShards bool   `json:"skip_failed_shards"`
+	QueryInputs      bool   `json:"query_inputs"`
+}
+
+// getOfflineQueryJobStatus reports the revision-level status of an offline
+// query. This is a different signal from the per-shard status reports returned
+// by GetOfflineQueryStatus: it reflects the revision's own QueryStatus, so it
+// can report an error even when every shard report says COMPLETED.
+func (c *clientImpl) getOfflineQueryJobStatus(
+	ctx context.Context,
+	revisionId string,
+) (GetOfflineQueryJobResponse, error) {
+	response := GetOfflineQueryJobResponse{}
+	err := c.sendRequest(
+		ctx,
+		&sendRequestParams{
+			Method:   "POST",
+			URL:      "v4/offline_query/status",
+			Body:     datasetJobStatusRequest{JobId: revisionId},
+			Response: &response,
+		},
+	)
+	return response, errors.Wrap(err, "getting offline query job status")
+}
+
+// getDatasetByRevisionId fetches the dataset a revision belongs to, with the
+// server's current view of every revision on it.
+func (c *clientImpl) getDatasetByRevisionId(ctx context.Context, revisionId string) (Dataset, error) {
+	response := Dataset{}
+	if err := c.sendRequest(
+		ctx,
+		&sendRequestParams{
+			Method:   "GET",
+			URL:      fmt.Sprintf("v4/offline_query/%s", revisionId),
+			Response: &response,
+		},
+	); err != nil {
+		return Dataset{}, errors.Wrap(err, "getting dataset")
+	}
+	if len(response.Errors) > 0 {
+		return Dataset{}, errors.Wrapf(response.Errors, "getting dataset for revision %q", revisionId)
 	}
 
-	return response.Urls, nil
+	response.client = c
+	for idx := range response.Revisions {
+		response.Revisions[idx].client = c
+		if response.Revisions[idx].EnvironmentID == "" {
+			response.Revisions[idx].EnvironmentID = response.EnvironmentID
+		}
+	}
+	return response, nil
 }
 
 func (c *clientImpl) saveUrlToDirectory(URL string, directory string) (err error) {
@@ -748,28 +826,18 @@ func (c *clientImpl) CancelOfflineQuery(ctx context.Context, offlineQueryId stri
 }
 
 func (c *clientImpl) GetDataset(ctx context.Context, revisionId string) (Dataset, error) {
-	// Get the dataset URLs using the existing getDatasetUrls method
-	// This also validates that the dataset exists and is ready
-	_, err := c.getDatasetUrls(ctx, revisionId)
+	// Ask the server for the dataset rather than fabricating one. The previous
+	// implementation synthesized a revision with IsFinished: true and
+	// QueryStatusSuccessful, which made Wait a guaranteed no-op on the result
+	// and left every other revision field zero. The Python client's
+	// get_dataset(job_id=...) reads the same GET v4/offline_query/{id} endpoint.
+	dataset, err := c.getDatasetByRevisionId(ctx, revisionId)
 	if err != nil {
-		return Dataset{}, errors.Wrap(err, "getting dataset urls")
+		return Dataset{}, err
 	}
-
-	// Create a dataset revision with the retrieved information
-	revision := DatasetRevision{
-		RevisionId: revisionId,
-		Status:     QueryStatusSuccessful, // Since we got URLs, the dataset is complete
-		client:     c,
+	if len(dataset.Revisions) == 0 {
+		return Dataset{}, errors.Newf("no revisions found for revision id %q", revisionId)
 	}
-
-	// Create and return the dataset
-	dataset := Dataset{
-		IsFinished: true,
-		Version:    1,
-		Revisions:  []DatasetRevision{revision},
-		client:     c,
-	}
-
 	return dataset, nil
 }
 

--- a/dataset_wait_test.go
+++ b/dataset_wait_test.go
@@ -8,11 +8,18 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
-// mockWaitClient implements just GetOfflineQueryStatus; any other Client
-// method panics via the embedded nil interface.
+// mockWaitClient implements datasetClient. Unset hooks fall back to benign
+// defaults so each test only has to describe the behavior it cares about.
 type mockWaitClient struct {
-	Client
-	getStatus func(ctx context.Context, args GetOfflineQueryStatusParams) (GetOfflineQueryStatusResult, error)
+	getStatus    func(ctx context.Context, args GetOfflineQueryStatusParams) (GetOfflineQueryStatusResult, error)
+	getJobStatus func(ctx context.Context, revisionId string) (GetOfflineQueryJobResponse, error)
+	getDataset   func(ctx context.Context, revisionId string) (Dataset, error)
+	getUrls      func(ctx context.Context, revisionId string) ([]string, error)
+	saveUrl      func(url string, directory string) error
+
+	jobStatusCalls int
+	refreshCalls   int
+	urlCalls       int
 }
 
 func (m *mockWaitClient) GetOfflineQueryStatus(
@@ -22,7 +29,54 @@ func (m *mockWaitClient) GetOfflineQueryStatus(
 	return m.getStatus(ctx, args)
 }
 
-func waitTestDataset(client Client, numPartitions int, numComputers int) Dataset {
+func (m *mockWaitClient) getOfflineQueryJobStatus(
+	ctx context.Context,
+	revisionId string,
+) (GetOfflineQueryJobResponse, error) {
+	m.jobStatusCalls++
+	if m.getJobStatus == nil {
+		return GetOfflineQueryJobResponse{IsFinished: true}, nil
+	}
+	return m.getJobStatus(ctx, revisionId)
+}
+
+func (m *mockWaitClient) getDatasetByRevisionId(ctx context.Context, revisionId string) (Dataset, error) {
+	m.refreshCalls++
+	if m.getDataset == nil {
+		// The minimum a refresh has to return: the same revision, now marked
+		// successful, as the server would once offline_query.status is COMPLETED.
+		return Dataset{
+			IsFinished: true,
+			Revisions: []DatasetRevision{{
+				RevisionId: revisionId,
+				Status:     QueryStatusSuccessful,
+				OutputUris: "s3://bucket/" + revisionId,
+			}},
+		}, nil
+	}
+	return m.getDataset(ctx, revisionId)
+}
+
+func (m *mockWaitClient) getDatasetUrls(ctx context.Context, revisionId string) ([]string, error) {
+	m.urlCalls++
+	if m.getUrls == nil {
+		return []string{"https://example.com/" + revisionId + "/shard_000.parquet"}, nil
+	}
+	return m.getUrls(ctx, revisionId)
+}
+
+func (m *mockWaitClient) saveUrlToDirectory(url string, directory string) error {
+	if m.saveUrl == nil {
+		return nil
+	}
+	return m.saveUrl(url, directory)
+}
+
+func completedStatus(ctx context.Context, args GetOfflineQueryStatusParams) (GetOfflineQueryStatusResult, error) {
+	return GetOfflineQueryStatusResult{Report: BatchReport{Status: "COMPLETED"}}, nil
+}
+
+func waitTestDataset(client datasetClient, numPartitions int, numComputers int) Dataset {
 	return Dataset{
 		client: client,
 		Revisions: []DatasetRevision{
@@ -93,15 +147,22 @@ func TestDatasetWaitShardFailure(t *testing.T) {
 	assert.Contains(t, err.Error(), "upstream failed")
 
 	// Failure is terminal: IsFinished is set, and a repeated Wait reports the
-	// recorded failure without polling the server again.
+	// recorded failure without polling the server again. The memo is recorded on
+	// the revision, so swap the client there too -- otherwise this asserts
+	// nothing, since Dataset.Wait only falls back to its own client when the
+	// revision has none.
 	assert.True(t, dataset.IsFinished)
-	dataset.client = &mockWaitClient{
+	panicking := &mockWaitClient{
 		getStatus: func(ctx context.Context, args GetOfflineQueryStatusParams) (GetOfflineQueryStatusResult, error) {
 			t.Fatal("should not poll again after a terminal failure")
 			return GetOfflineQueryStatusResult{}, nil
 		},
 	}
+	dataset.client = panicking
+	dataset.Revisions[0].client = panicking
 	assert.Equal(t, err, dataset.Wait(context.Background()))
+	assert.Equal(t, 0, panicking.refreshCalls)
+	assert.Equal(t, 0, panicking.jobStatusCalls)
 }
 
 func TestDatasetWaitToleratesTransientPollErrors(t *testing.T) {
@@ -156,18 +217,39 @@ func TestDatasetWaitContextCancellation(t *testing.T) {
 	assert.ErrorIs(t, dataset.Wait(ctx), context.Canceled)
 }
 
-func TestDatasetWaitAlreadyFinished(t *testing.T) {
+func TestDatasetWaitSkipsAlreadySuccessfulRevision(t *testing.T) {
 	t.Parallel()
+	// The Python client seeds DatasetRevision._hydrated from the revision's own
+	// status, so a revision the server already called SUCCESSFUL needs no work.
 	client := &mockWaitClient{
 		getStatus: func(ctx context.Context, args GetOfflineQueryStatusParams) (GetOfflineQueryStatusResult, error) {
-			t.Fatal("should not poll when dataset is already finished")
+			t.Fatal("should not poll a revision the server already reported successful")
 			return GetOfflineQueryStatusResult{}, nil
 		},
 	}
 	dataset := waitTestDataset(client, 1, 0)
-	dataset.IsFinished = true
+	dataset.Revisions[0].Status = QueryStatusSuccessful
 
 	assert.NoError(t, dataset.Wait(context.Background()))
+	assert.Equal(t, 0, client.refreshCalls)
+}
+
+func TestDatasetWaitDoesNotTrustDatasetLevelIsFinished(t *testing.T) {
+	t.Parallel()
+	// is_finished off the wire means "reached a terminal state", which is also
+	// true of a failed or cancelled query, so it cannot decide whether waiting
+	// is still needed. Both fields derive from OfflineQuerySQL.status server
+	// side: COMPLETED yields is_finished=true AND status=SUCCESSFUL, while
+	// FAILED and CANCELED yield is_finished=true with status=ERROR/CANCELLED.
+	// Keying off is_finished reported those as successes.
+	client := &mockWaitClient{getStatus: completedStatus}
+	dataset := waitTestDataset(client, 2, 0)
+	dataset.IsFinished = true
+	dataset.Revisions[0].Status = QueryStatusError
+
+	assert.NoError(t, dataset.Wait(context.Background()))
+	assert.Equal(t, 1, client.refreshCalls)
+	assert.Equal(t, 1, client.jobStatusCalls)
 }
 
 func TestDatasetWaitTimesOutWhenShardNeverReports(t *testing.T) {
@@ -265,4 +347,169 @@ func TestDatasetWaitNullReportBeforeShardStarts(t *testing.T) {
 	assert.NoError(t, dataset.Wait(context.Background()))
 	assert.True(t, dataset.IsFinished)
 	assert.Equal(t, 3, polls)
+}
+
+func TestDatasetWaitFailsOnRevisionLevelJobErrors(t *testing.T) {
+	t.Parallel()
+	// Every shard report can say COMPLETED while the revision-level job status
+	// still carries errors. The Python client checks this at the end of
+	// DatasetRevision.wait(); without it a failed query looks like a success.
+	client := &mockWaitClient{
+		getStatus: completedStatus,
+		getJobStatus: func(ctx context.Context, revisionId string) (GetOfflineQueryJobResponse, error) {
+			return GetOfflineQueryJobResponse{
+				IsFinished: true,
+				Errors:     []ServerError{{Message: "offline job failed"}},
+			}, nil
+		},
+	}
+	dataset := waitTestDataset(client, 2, 0)
+
+	err := dataset.Wait(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "offline query failed")
+	assert.Contains(t, err.Error(), "offline job failed")
+	// Terminal, so it is recorded and replayed like a shard failure.
+	assert.True(t, dataset.IsFinished)
+	assert.Equal(t, err, dataset.Wait(context.Background()))
+	assert.Equal(t, 1, client.jobStatusCalls)
+}
+
+func TestDatasetWaitRefreshesRevisionMetadata(t *testing.T) {
+	t.Parallel()
+	// Until the refresh, every revision field is the submission-time value:
+	// OutputUris is empty and NumBytes is unset.
+	numBytes := 4096
+	client := &mockWaitClient{
+		getStatus: completedStatus,
+		getDataset: func(ctx context.Context, revisionId string) (Dataset, error) {
+			return Dataset{
+				IsFinished: true,
+				Revisions: []DatasetRevision{
+					{RevisionId: "some-other-revision", Status: QueryStatusSuccessful},
+					{
+						RevisionId:    revisionId,
+						Status:        QueryStatusSuccessful,
+						OutputUris:    "s3://bucket/out",
+						NumPartitions: 2,
+						NumBytes:      &numBytes,
+					},
+				},
+			}, nil
+		},
+	}
+	dataset := waitTestDataset(client, 2, 0)
+	assert.Empty(t, dataset.Revisions[0].OutputUris)
+
+	assert.NoError(t, dataset.Wait(context.Background()))
+	assert.Equal(t, "s3://bucket/out", dataset.Revisions[0].OutputUris)
+	assert.Equal(t, QueryStatusSuccessful, dataset.Revisions[0].Status)
+	assert.NotNil(t, dataset.Revisions[0].NumBytes)
+	assert.Equal(t, 4096, *dataset.Revisions[0].NumBytes)
+	// The refresh must not drop the client, or later calls on the revision fail.
+	assert.NotNil(t, dataset.Revisions[0].client)
+}
+
+func TestDatasetWaitErrorsWhenRefreshOmitsRevision(t *testing.T) {
+	t.Parallel()
+	client := &mockWaitClient{
+		getStatus: completedStatus,
+		getDataset: func(ctx context.Context, revisionId string) (Dataset, error) {
+			return Dataset{Revisions: []DatasetRevision{{RevisionId: "a-different-revision"}}}, nil
+		},
+	}
+	dataset := waitTestDataset(client, 1, 0)
+
+	err := dataset.Wait(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "did not return revision")
+	// Not a query failure, so not memoized as terminal.
+	assert.False(t, dataset.IsFinished)
+}
+
+func TestDatasetWaitIsIdempotentAfterSuccess(t *testing.T) {
+	t.Parallel()
+	// The refresh marks the revision successful, so a second Wait short-circuits
+	// on the revision's own status instead of re-polling every shard.
+	polls := 0
+	client := &mockWaitClient{
+		getStatus: func(ctx context.Context, args GetOfflineQueryStatusParams) (GetOfflineQueryStatusResult, error) {
+			polls++
+			return completedStatus(ctx, args)
+		},
+	}
+	dataset := waitTestDataset(client, 2, 0)
+
+	assert.NoError(t, dataset.Wait(context.Background()))
+	assert.Equal(t, 2, polls)
+	assert.NoError(t, dataset.Wait(context.Background()))
+	assert.Equal(t, 2, polls)
+	assert.Equal(t, 1, client.refreshCalls)
+}
+
+func TestDatasetDownloadUrisWaitsForAllShards(t *testing.T) {
+	t.Parallel()
+	// The reported failure mode: a multi-shard query is treated as complete when
+	// the first shard finishes and the download then comes back empty. Every
+	// data-access path has to wait first, as the Python client does by routing
+	// them all through DatasetRevision._hydrate.
+	var polledShards []int
+	client := &mockWaitClient{
+		getStatus: func(ctx context.Context, args GetOfflineQueryStatusParams) (GetOfflineQueryStatusResult, error) {
+			polledShards = append(polledShards, args.ComputerId)
+			return completedStatus(ctx, args)
+		},
+	}
+	dataset := waitTestDataset(client, 3, 0)
+
+	urls, err := dataset.DownloadUris(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"https://example.com/rev-1/shard_000.parquet"}, urls)
+	assert.Equal(t, []int{0, 1, 2}, polledShards)
+	assert.Equal(t, 1, client.urlCalls)
+}
+
+func TestDatasetDownloadUrisFailsWhenAShardFails(t *testing.T) {
+	t.Parallel()
+	client := &mockWaitClient{
+		getStatus: func(ctx context.Context, args GetOfflineQueryStatusParams) (GetOfflineQueryStatusResult, error) {
+			return GetOfflineQueryStatusResult{
+				Report: BatchReport{Status: "FAILED", AllErrors: []ServerError{{Message: "shard died"}}},
+			}, nil
+		},
+	}
+	dataset := waitTestDataset(client, 2, 0)
+
+	_, err := dataset.DownloadUris(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "shard died")
+	// Never asked for urls for a query that failed.
+	assert.Equal(t, 0, client.urlCalls)
+}
+
+func TestDatasetRevisionDownloadDataWaitsForAllShards(t *testing.T) {
+	t.Parallel()
+	var polledShards []int
+	saved := 0
+	client := &mockWaitClient{
+		getStatus: func(ctx context.Context, args GetOfflineQueryStatusParams) (GetOfflineQueryStatusResult, error) {
+			polledShards = append(polledShards, args.ComputerId)
+			return completedStatus(ctx, args)
+		},
+		saveUrl: func(url string, directory string) error {
+			saved++
+			return nil
+		},
+	}
+	revision := DatasetRevision{RevisionId: "rev-1", NumPartitions: 2, client: client}
+
+	assert.NoError(t, revision.DownloadData(context.Background(), t.TempDir()))
+	assert.Equal(t, []int{0, 1}, polledShards)
+	assert.Equal(t, 1, saved)
+}
+
+func TestDatasetRevisionWaitRequiresClient(t *testing.T) {
+	t.Parallel()
+	revision := DatasetRevision{RevisionId: "rev-1"}
+	assert.ErrorContains(t, revision.Wait(context.Background()), "client is not initialized")
 }

--- a/models.go
+++ b/models.go
@@ -781,16 +781,23 @@ type Dataset struct {
 	Revisions     []DatasetRevision `json:"revisions"`
 	Errors        ServerErrors      `json:"errors"`
 
-	// client is used internally for the Wait method
-	client Client `json:"-"`
-
-	// waitErr records the terminal failure observed by Wait so that
-	// subsequent Wait calls report it instead of re-polling.
-	waitErr error `json:"-"`
+	// client is used internally for the Wait and download methods.
+	client datasetClient `json:"-"`
 
 	// waitReportTimeout overrides datasetWaitReportTimeout in Wait. Zero means
 	// use the default. Only set in tests.
 	waitReportTimeout time.Duration `json:"-"`
+}
+
+// datasetClient is the subset of client behavior that Dataset and
+// DatasetRevision methods need. It is an interface rather than *clientImpl so
+// that the wait and download paths can be exercised against a fake.
+type datasetClient interface {
+	GetOfflineQueryStatus(ctx context.Context, args GetOfflineQueryStatusParams) (GetOfflineQueryStatusResult, error)
+	getOfflineQueryJobStatus(ctx context.Context, revisionId string) (GetOfflineQueryJobResponse, error)
+	getDatasetByRevisionId(ctx context.Context, revisionId string) (Dataset, error)
+	getDatasetUrls(ctx context.Context, revisionId string) ([]string, error)
+	saveUrlToDirectory(url string, directory string) error
 }
 
 type DatasetRevision struct {
@@ -851,7 +858,18 @@ type DatasetRevision struct {
 	// Number of computers for the revision.
 	NumComputers int `json:"num_computers"`
 
-	client *clientImpl
+	client datasetClient
+
+	// waitErr records a terminal query failure that this process observed while
+	// waiting, so that a repeated Wait replays it instead of re-polling a query
+	// the server will never report differently.
+	//
+	// This is deliberately separate from Dataset.IsFinished. IsFinished comes
+	// off the wire and means "the query reached a terminal state", which is also
+	// true of a failed or cancelled query; using it to decide whether waiting is
+	// still needed would report a failed query as a success. waitErr is set only
+	// by Wait, in this process, and being non-nil is its own presence flag.
+	waitErr error
 }
 
 const (
@@ -893,20 +911,15 @@ func newDatasetWaitReportTimeoutError(
 	)
 }
 
-// Wait polls the offline query status until the job is complete.
-// It returns an error if the job fails or if there's an error polling the status.
+// Wait polls the offline query status until the job is complete, and returns an
+// error if the job failed or if the status could not be determined.
 //
-// A sharded offline query produces one status report per shard, and the query
-// is only complete once every shard's report reaches a terminal state. Wait
-// polls each shard's report in order, advancing to the next shard when the
-// current one reports COMPLETED, and returns an error as soon as any shard
-// reports FAILED. Use the ctx deadline to bound the overall wait.
+// Wait waits on the dataset's last revision, matching the Python client, where
+// Dataset.wait() delegates to revisions[-1].wait().
 //
-// Behavior difference from the Python client: IsFinished is set to true once
-// the query reaches a terminal state, including failure (in chalkpy a failed
-// revision is never marked finished and a repeated wait() re-polls the
-// server). A subsequent Wait call on a failed Dataset returns the recorded
-// failure without polling again.
+// IsFinished is set once the query reaches a terminal state, including failure.
+// It is a report of what happened, not the signal Wait keys off: see
+// DatasetRevision.waitErr for why.
 func (d *Dataset) Wait(ctx context.Context) error {
 	if d.client == nil {
 		return errors.New("Dataset client is not initialized")
@@ -916,25 +929,106 @@ func (d *Dataset) Wait(ctx context.Context) error {
 		return errors.New("No revisions found in dataset")
 	}
 
-	// Check if already finished
-	if d.IsFinished {
+	// Wait on the last revision, matching Python's behavior: self.revisions[-1].
+	// Index rather than copy, so the refresh and the memo Wait records are
+	// visible to the caller through d.Revisions.
+	revision := &d.Revisions[len(d.Revisions)-1]
+	if revision.client == nil {
+		revision.client = d.client
+	}
+
+	err := revision.wait(ctx, d.waitReportTimeout)
+
+	// A query that failed is finished, just not successfully. Keep IsFinished
+	// meaning "reached a terminal state" for callers that read it, without
+	// letting it decide whether waiting is still needed.
+	if err == nil || revision.waitErr != nil {
+		d.IsFinished = true
+	}
+	return err
+}
+
+// Wait polls the revision's offline query status until the job is complete, and
+// returns an error if the job failed or if the status could not be determined.
+//
+// A sharded offline query produces one status report per shard, and the query is
+// only complete once every shard's report reaches a terminal state. Wait polls
+// each shard's report in turn, advancing to the next shard when the current one
+// reports COMPLETED, and returns an error as soon as a shard it is polling
+// reports FAILED. Because shards are polled in order, a failure in a later shard
+// is not observed until the shards before it complete.
+//
+// Once every shard has completed, Wait refreshes the revision from the server
+// and checks the revision-level job status, so that a revision whose shards all
+// completed but which the server nonetheless considers failed is reported as an
+// error rather than a success.
+//
+// Use the ctx deadline to bound the overall wait.
+func (d *DatasetRevision) Wait(ctx context.Context) error {
+	return d.wait(ctx, 0)
+}
+
+// wait implements Wait with an overridable report timeout. A reportTimeout of
+// zero or less means use datasetWaitReportTimeout.
+func (d *DatasetRevision) wait(ctx context.Context, reportTimeout time.Duration) error {
+	if d.client == nil {
+		return errors.New("DatasetRevision client is not initialized")
+	}
+
+	// Replay a terminal failure already observed here rather than re-polling a
+	// query whose outcome cannot change.
+	if d.waitErr != nil {
 		return d.waitErr
 	}
 
-	// Poll the last revision's status
-	revision := d.Revisions[len(d.Revisions)-1]
+	// A revision the server already considers successful needs no waiting. This
+	// mirrors the Python client, which seeds DatasetRevision._hydrated from
+	// `self.status == QueryStatus.SUCCESSFUL` -- the revision's own status, and
+	// specifically the successful one, not any terminal one.
+	if d.Status == QueryStatusSuccessful {
+		return nil
+	}
 
+	if err := d.pollShardReports(ctx, reportTimeout); err != nil {
+		return err
+	}
+
+	// Refresh the revision now that it is complete. Until this point every field
+	// is the submission-time value: OutputUris is "", NumBytes and TerminatedAt
+	// are nil, and Status is whatever the submit response reported. The Python
+	// client does the same refresh at the end of DatasetRevision._hydrate.
+	if err := d.refresh(ctx); err != nil {
+		return err
+	}
+
+	// Every shard reported COMPLETED, but the revision-level job status is a
+	// separate signal and can still carry errors. The Python client performs
+	// exactly this second check at the end of DatasetRevision.wait().
+	jobStatus, err := d.client.getOfflineQueryJobStatus(ctx, d.RevisionId)
+	if err != nil {
+		return errors.Wrapf(err, "checking job status for offline query %q", d.RevisionId)
+	}
+	if len(jobStatus.Errors) > 0 {
+		d.waitErr = errors.Wrap(ServerErrors(jobStatus.Errors), "offline query failed")
+		return d.waitErr
+	}
+
+	return nil
+}
+
+// pollShardReports polls each shard's status report in turn until all of them
+// report COMPLETED, or one of them reports FAILED.
+func (d *DatasetRevision) pollShardReports(ctx context.Context, reportTimeout time.Duration) error {
 	// Legacy servers report the shard count as num_computers with
 	// num_partitions = 0; newer servers set num_partitions directly.
-	numShards := revision.NumPartitions
+	numShards := d.NumPartitions
 	if numShards == 0 {
-		numShards = revision.NumComputers
+		numShards = d.NumComputers
 	}
 	if numShards < 1 {
 		numShards = 1
 	}
 
-	reportTimeout := d.waitReportTimeout
 	if reportTimeout <= 0 {
 		reportTimeout = datasetWaitReportTimeout
 	}
@@ -944,7 +1038,7 @@ func (d *Dataset) Wait(ctx context.Context) error {
 
 	for shardId := 0; shardId < numShards; {
 		jobStatus, err := d.client.GetOfflineQueryStatus(ctx, GetOfflineQueryStatusParams{
-			JobId:      revision.RevisionId,
+			JobId:      d.RevisionId,
 			ComputerId: shardId,
 		})
 
@@ -962,7 +1056,7 @@ func (d *Dataset) Wait(ctx context.Context) error {
 		if err != nil || !jobStatus.Report.exists() {
 			if time.Now().After(mustReceiveNextReportBy) {
 				return newDatasetWaitReportTimeoutError(
-					lastPollErr, reportTimeout, revision.RevisionId, shardId, numShards,
+					lastPollErr, reportTimeout, d.RevisionId, shardId, numShards,
 				)
 			}
 		} else {
@@ -989,7 +1083,6 @@ func (d *Dataset) Wait(ctx context.Context) error {
 				if len(allErrors) > 0 {
 					failure = errors.Wrap(allErrors, "offline query failed")
 				}
-				d.IsFinished = true
 				d.waitErr = failure
 				return failure
 			default:
@@ -1011,8 +1104,25 @@ func (d *Dataset) Wait(ctx context.Context) error {
 		}
 	}
 
-	d.IsFinished = true
 	return nil
+}
+
+// refresh replaces the revision's metadata with the server's current view of it.
+func (d *DatasetRevision) refresh(ctx context.Context) error {
+	dataset, err := d.client.getDatasetByRevisionId(ctx, d.RevisionId)
+	if err != nil {
+		return errors.Wrapf(err, "refreshing offline query %q", d.RevisionId)
+	}
+	for _, refreshed := range dataset.Revisions {
+		if refreshed.RevisionId != d.RevisionId {
+			continue
+		}
+		client, waitErr := d.client, d.waitErr
+		*d = refreshed
+		d.client, d.waitErr = client, waitErr
+		return nil
+	}
+	return errors.Newf("server did not return revision %q for the dataset it belongs to", d.RevisionId)
 }
 
 // DownloadUris retrieves the download URIs for the dataset using the last revision.
@@ -1040,8 +1150,12 @@ func (d *Dataset) DownloadUris(ctx context.Context) ([]string, error) {
 		return nil, errors.New("no revisions found in dataset")
 	}
 
-	// Use the last revision, matching Python's behavior: self.revisions[-1]
-	lastRevision := d.Revisions[len(d.Revisions)-1]
+	// Use the last revision, matching Python's behavior: self.revisions[-1].
+	// Index rather than copy so the revision keeps any refresh the wait performs.
+	lastRevision := &d.Revisions[len(d.Revisions)-1]
+	if lastRevision.client == nil {
+		lastRevision.client = d.client
+	}
 
 	return lastRevision.DownloadUris(ctx)
 }
@@ -1051,6 +1165,18 @@ func (d *Dataset) DownloadUris(ctx context.Context) ([]string, error) {
 // method, you can download those raw files into a directory for processing
 // with other tools.
 func (d *DatasetRevision) DownloadData(ctx context.Context, directory string) error {
+	if d.client == nil {
+		return errors.New("DatasetRevision client is not initialized")
+	}
+
+	// Wait for the query to finish before asking for its outputs. The Python
+	// client funnels every data-access method through DatasetRevision._hydrate
+	// for exactly this reason, so a partially complete sharded query cannot be
+	// downloaded as though it were done.
+	if err := d.Wait(ctx); err != nil {
+		return errors.Wrap(err, "waiting for offline query to complete")
+	}
+
 	urls, getUrlsErr := d.client.getDatasetUrls(ctx, d.RevisionId)
 	if getUrlsErr != nil {
 		return errors.Wrap(getUrlsErr, "get dataset urls")
@@ -1083,6 +1209,14 @@ func (d *DatasetRevision) DownloadData(ctx context.Context, directory string) er
 func (d *DatasetRevision) DownloadUris(ctx context.Context) ([]string, error) {
 	if d.client == nil {
 		return nil, errors.New("DatasetRevision client is not initialized")
+	}
+
+	// Wait for the query to finish before asking for its outputs. The Python
+	// client funnels every data-access method through DatasetRevision._hydrate
+	// for exactly this reason, so a partially complete sharded query cannot be
+	// downloaded as though it were done.
+	if err := d.Wait(ctx); err != nil {
+		return nil, errors.Wrap(err, "waiting for offline query to complete")
 	}
 
 	urls, err := d.client.getDatasetUrls(ctx, d.RevisionId)


### PR DESCRIPTION
Stacked on #728, rebased onto the merged #730.

Three gaps remained between `Dataset.Wait` and the Python client. Each can turn a failed or incomplete sharded offline query into an apparent success.

## 1. The wait was gated on the wrong signal

The short-circuit was `if d.IsFinished { return d.waitErr }`. Server side, **both** `is_finished` and `revision.status` derive from the same column — `OfflineQuerySQL.status` — but through different predicates (`dataset_info_service.py`: `sql_to_dataset_revision_response` + `convert_offline_query_status_to_client_query_status`):

| `offline_query.status` | `is_finished` | `revision.status` |
|---|---|---|
| QUEUED | false | SUBMITTED |
| WORKING | false | RUNNING |
| COMPLETED | true | SUCCESSFUL |
| **FAILED** | **true** | **ERROR** |
| **CANCELED** | **true** | **CANCELLED** |

So `is_finished` is *strictly weaker* than `status == SUCCESSFUL` — it's also true of a failed or cancelled query. A `Dataset` that arrives already-terminal-and-failed has `IsFinished: true` and `waitErr: nil` (`waitErr` is `json:"-"` and only ever assigned by `Wait` in-process), so **`Wait()` returned `nil` for a query that failed.**

Reachable two ways today:
- `GetDataset(rev)` then `Wait()` — unconditional, since `GetDataset` hardcoded `IsFinished: true`. Combined with `getDatasetUrls` not checking errors, a failed revision gave zero URLs and a nil error from both calls.
- Any `Dataset` round-tripped through JSON: `IsFinished` survives, `waitErr` is dropped by its tag.

`OfflineQuery()` -> `Wait()` was safe throughout — submission returns `is_finished=False` hardcoded (`pre_actor.py:254`). This is a `GetDataset`/rehydration hazard, not a submission one.

chalkpy does **not** have this bug: it stores `is_finished` on `DatasetImpl` (`dataset.py:1619`) but never reads it, gating only on `_hydrated = self.status == QueryStatus.SUCCESSFUL`.

**Fix:** gate on the revision's own `Status == QueryStatusSuccessful`. The terminal-failure memo from #728 is *kept* — it's a genuine improvement over chalkpy, which re-polls a query whose outcome cannot change — but moved to `DatasetRevision.waitErr`, where being non-nil is its own presence flag. `IsFinished` is still set on terminal failure, so it keeps meaning "reached a terminal state" for callers that read it; it just no longer decides whether waiting is needed.

## 2. `Wait` never checked the revision-level job status

Per-shard reports and the revision's own status are separate signals — every shard can report `COMPLETED` while the revision sits in `ERROR`. chalkpy checks this at the end of `DatasetRevision.wait()`:

```python
self._hydrate(...)
status = self._client.get_job_status_v4(...)          # POST /v4/offline_query/status
if status.errors is not None and len(status.errors) > 0:
    raise ChalkBaseException(errors=status.errors)
```

Added `getOfflineQueryJobStatus` and the check.

## 3. The download path never waited

In chalkpy **every** data-access method funnels through `DatasetRevision._hydrate` first — `download_uris` (`dataset.py:1157`), `download_data` (`:1214`), `get_data_as_pandas` (`:1077`), `summary` (`:1170`). In Go, `DownloadUris`/`DownloadData` went straight to `getDatasetUrls`. **This is the reported failure mode**: a multi-shard query looks complete and the download comes back empty. `DatasetRevision` now has a public `Wait`, and both download methods call it first.

## Alongside those

- **`Wait` never refreshed the revision.** chalkpy's `_hydrate` re-reads the dataset and overwrites `output_uris`, `num_partitions`, `num_rows`, `num_bytes`, `terminated_at`, `status` (`dataset.py:1575-1601`). Go only set `IsFinished`, so after a successful `Wait` every revision field was still the submission-time value (`OutputUris: ""`, `NumBytes: nil`). Added `getDatasetByRevisionId` (`GET /v4/offline_query/{id}` — the endpoint chalkpy's `get_anonymous_dataset` uses). This is also what makes a repeated `Wait` cheap: the refresh sets `Status` to `SUCCESSFUL`.

- **The wait moved to `DatasetRevision`**, matching chalkpy, where `_hydrate`/`wait` are revision methods and `Dataset.wait()` delegates to `revisions[-1]`. `Dataset.Wait` is unchanged for callers.

- **`getDatasetUrls` silently dropped server errors.** `is_finished` on `GET v2/offline_query/{id}` covers `CANCELLED`/`ERROR`/`EXPIRED` too, and for those the engine returns an empty url list plus an explanatory error (`local_chalk_actor.get_offline_query_job`). It now surfaces the error, polls with a ctx-aware sleep instead of `time.Sleep`, and doesn't sleep after the final response.

- **`GetDataset` fabricated a revision** with `IsFinished: true` / `QueryStatusSuccessful`. It now reads the real dataset.

## Compatibility

Source-compatible — no exported symbol is removed or changed. `DatasetRevision.Wait` is additive; `Dataset.client`/`DatasetRevision.client` become an unexported `datasetClient` interface, and both fields were already unexported.

Behaviorally there are intentional changes worth release-noting, because a pipeline that was silently producing empty datasets will start failing loudly:
- `Wait` on a failed/cancelled revision now returns an error instead of `nil`.
- `GetDataset` on a failed revision now errors instead of returning a `Dataset` with no URLs, and returns real metadata rather than `Status: SUCCESSFUL` / `Version: 1`.
- `DownloadUris`/`DownloadData` now wait, so they block where they previously returned junk (one extra request when the revision is already successful).

## Known gap, not addressed here

Per `f4e04e32`, cancellation never reaches the shard report — so a query cancelled mid-flight still surfaces as a report timeout rather than a prompt error, because the shard reports simply stop progressing and the job-status check in (2) is only reached after all shards settle. Fixing that means fast-failing on a terminal-but-unsuccessful `revision.Status` before polling, which diverges further from chalkpy and needs confirmation that query-level `FAILED` is never retried back to `WORKING`. Left out deliberately.

## Tests

`TestDatasetWaitDoesNotTrustDatasetLevelIsFinished` is the regression test for (1) — verified to fail when the `IsFinished` gate is restored. Also added: `TestDatasetWaitFailsOnRevisionLevelJobErrors`, `TestDatasetWaitRefreshesRevisionMetadata`, `TestDatasetWaitIsIdempotentAfterSuccess`, `TestDatasetDownloadUrisWaitsForAllShards`, `TestDatasetDownloadUrisFailsWhenAShardFails`, `TestDatasetRevisionDownloadDataWaitsForAllShards`, `TestDatasetWaitSkipsAlreadySuccessfulRevision`, `TestDatasetWaitErrorsWhenRefreshOmitsRevision`.

`TestDatasetWaitShardFailure` (from #728) is kept and strengthened: it now swaps the *revision's* client as well as the dataset's, since the memo moved — without that it asserted nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)