### PR TITLE
Fix offline upload Parquet root repetition

### DIFF
--- a/offline_query_upload.go
+++ b/offline_query_upload.go
@@ -271,6 +271,7 @@ func offlineQueryInputPartitionToParquet(
 		&buf,
 		parquet.NewWriterProperties(
 			parquet.WithCompression(compress.Codecs.Snappy),
+			parquet.WithRootRepetition(parquet.Repetitions.Required),
 		),
 		pqarrow.NewArrowWriterProperties(pqarrow.WithStoreSchema()),
 	)

--- a/offline_query_upload_test.go
+++ b/offline_query_upload_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/file"
 	"github.com/apache/arrow-go/v18/parquet/pqarrow"
 	"github.com/chalk-ai/chalk-go/auth"
 	"github.com/chalk-ai/chalk-go/config"
@@ -222,6 +224,11 @@ func TestUploadOfflineQueryInputAsTableRequestsAllPartitionURLs(t *testing.T) {
 
 	firstBytes, err := os.ReadFile(firstPath)
 	assert.NoError(t, err)
+	firstParquetReader, err := file.NewParquetReader(bytes.NewReader(firstBytes))
+	assert.NoError(t, err)
+	rootSchemaElement := firstParquetReader.MetaData().FileMetaData.Schema[0]
+	assert.True(t, rootSchemaElement.IsSetRepetitionType())
+	assert.EqualValues(t, parquet.Repetitions.Required, rootSchemaElement.GetRepetitionType())
 	first := readParquetTable(t, firstBytes)
 	defer first.Release()
 	assert.Equal(t, int64(2), first.NumRows())


### PR DESCRIPTION
## Summary
- write offline-query upload Parquet files with a REQUIRED root repetition
- assert the raw Parquet footer root repetition in the uploader regression test

## Testing
- go test . -count=1